### PR TITLE
Added schematic image instead of crude drawing in Planes tutorial 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/
 /Users/Jammy/Code/PyAuto/autolens_workspace/howtolens/config
+.ipynb_checkpoints

--- a/howtolens/chapter_1_introduction/tutorial_4_planes.ipynb
+++ b/howtolens/chapter_1_introduction/tutorial_4_planes.ipynb
@@ -1,468 +1,463 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Tutorial 4: Planes\n",
-        "==================\n",
-        "\n",
-        "We've learnt how to make galaxy objects out of `LightProfile`'s and `MassProfile`'s. Now, we'll use these galaxies to\n",
-        "make a strong-gravitational lens.\n",
-        "\n",
-        "For newcomers to lensing, a strong gravitational lens is a system where two (or more) galaxies align perfectly down our\n",
-        "line of sight, such that the foreground `Galaxy`'s mass (represented as `MassProfile`'s) deflects the light (represented\n",
-        "as `LightProfile`'s) of the background source galaxy(s).\n",
-        "\n",
-        "When the alignment is just right and the lens is just massive enough, the background source galaxy appears multiple\n",
-        "times. The schematic below shows a crude drawing of such a system, where two light-rays from the source are bending\n",
-        "around the lens galaxy and into the observer (light should bend `smoothly`, but drawing this on a keyboard wasn`t\n",
-        "possible - so just pretend the diagonal lines coming from the observer and source are less jagged)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Observer                  Image-Plane               Source-Plane\n",
-        "\n",
-        "(z=0, Earth)               (z = 0.5)                (z = 1.0)\n",
-        "\n",
-        "         ----------------------------------------------\n",
-        "        /                                              \\ <---- This is one of the source's light-rays\n",
-        "       /                      --                        \\\n",
-        "  p   /                      /  \\                      __\n",
-        "  |  /                      /   \\                     /  \\\n",
-        " /\\  \\                      \\   /                     \\__/\n",
-        "      \\                     \\__/                 Source Galaxy (s)\n",
-        "       \\                Lens Galaxy(s)                /\n",
-        "         \\                                           / <----- And this is its other light-ray\n",
-        "          ------------------------------------------/"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "As an observer, we don't see the source's true appearance (e.g. a round blob of light). Instead, we only observe its \n",
-        "light after it is deflected and lensed by the foreground `Galaxy`'s mass. In this exercise, we'll make a source galaxy \n",
-        "image whose light has been deflected by a lens galaxy.\n",
-        "\n",
-        "In the schematic above, we used the terms `Image-Plane` and `Source-Plane`. In lensing speak, a `plane` is a \n",
-        "collection of galaxies at the same redshift (that is, parallel to one another down our line-of-sight). Therefore:\n",
-        "\n",
-        "- If two or more lens galaxies are at the same redshift in the image-plane, they deflect light in the same way. \n",
-        "This means we can sum the convergences, potentials and deflection angles of their `MassProfile`'s.\n",
-        "\n",
-        "- If two or more source galaxies are at the same redshift in the source-plane, their light is ray-traced in the same \n",
-        "way. Therefore, when determining their lensed images, we can sum the lensed images of each `Galaxy`'s `LightProfile`'s.\n",
-        "\n",
-        "So, lets do it - lets use the `plane` module in AutoLens to create a strong lensing system like the one pictured above. \n",
-        "For simplicity, we'll assume 1 lens galaxy and 1 source galaxy."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "%matplotlib inline\n",
-        "\n",
-        "from pyprojroot import here\n",
-        "\n",
-        "workspace_path = str(here())\n",
-        "%cd $workspace_path\n",
-        "print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
-        "import autolens as al\n",
-        "import autolens.plot as aplt"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "As always, we need a `Grid`, where our `Grid` is the coordinates we `trace` from the image-plane to the source-plane in \n",
-        "the lensing configuration above. Our `Grid` is therefore no longer just a `grid`, but an image-plane `Grid` representing \n",
-        "our image-plane coordinates. Thus, lets name as such."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "image_plane_grid = al.Grid.uniform(shape_2d=(100, 100), pixel_scales=0.05, sub_size=1)"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Whereas before we called our `Galaxy`'s things like `galaxy_with_light_profile`, lets now refer to them by their role \n",
-        "in lensing, e.g. `lens_galaxy` and `source_galaxy`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "mass_profile = al.mp.SphericalIsothermal(centre=(0.0, 0.0), einstein_radius=1.6)\n",
-        "\n",
-        "lens_galaxy = al.Galaxy(redshift=0.5, mass=mass_profile)\n",
-        "\n",
-        "light_profile = al.lp.SphericalSersic(\n",
-        "    centre=(0.0, 0.0), intensity=1.0, effective_radius=1.0, sersic_index=1.0\n",
-        ")\n",
-        "\n",
-        "source_galaxy = al.Galaxy(redshift=1.0, bulge=light_profile)"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Lets setup our image-plane using a `Plane` object. This `Plane` takes the lens galaxy we made above."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "image_plane = al.Plane(galaxies=[lens_galaxy])"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Just like we did with `Galaxy`'s we can compute quantities from the `Plane` by passing it a `Grid`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "deflections = image_plane.deflections_from_grid(grid=image_plane_grid)\n",
-        "\n",
-        "print(\"deflection-angles of `Plane`'s `Grid` pixel 0:\")\n",
-        "print(deflections.in_2d[0, 0, 0])\n",
-        "print(deflections.in_2d[0, 0, 0])\n",
-        "\n",
-        "print(\"deflection-angles of `Plane`'s `Grid` pixel 1:\")\n",
-        "print(deflections.in_2d[0, 1, 1])\n",
-        "print(deflections.in_2d[0, 1, 1])"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "_Plane_ plotters exist, which work analogously to `Profile` plotters and `Galaxy` plotters."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.deflections_y(plane=image_plane, grid=image_plane_grid)\n",
-        "aplt.Plane.deflections_x(plane=image_plane, grid=image_plane_grid)"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Throughout this chapter, we plotted lots of deflection angles. However, if you are not familiar with strong lensing, \n",
-        "you probably weren`t entirely sure what they are actually used for. \n",
-        "\n",
-        "The deflection angles tell us how light is `lensed` by a lens galaxy. By taking the image-plane coordinates and \n",
-        "deflection angles, we can subtract the two to determine the source-plane`s lensed coordinates, e.g.\n",
-        "\n",
-        "source_plane_coordinates = image_plane_coordinates - image_plane_deflection_angles\n",
-        "\n",
-        "Therefore, we can use our image_plane to `trace` its `Grid` to the source-plane..."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "source_plane_grid = image_plane.traced_grid_from_grid(grid=image_plane_grid)\n",
-        "print(\"Traced source-plane coordinates of `Grid` pixel 0:\")\n",
-        "print(source_plane_grid.in_2d[0, 0, :])\n",
-        "print(\"Traced source-plane coordinates of `Grid` pixel 1:\")\n",
-        "print(source_plane_grid.in_2d[0, 1, :])"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "... and use this `Grid` to setup the source-plane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "source_plane = al.Plane(galaxies=[source_galaxy])"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Lets inspect our `Grid`'s - I bet our source-plane isn't the boring uniform `Grid` we plotted in the first tutorial!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.plane_grid(\n",
-        "    plane=image_plane,\n",
-        "    grid=image_plane_grid,\n",
-        "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Image-plane Grid\")),\n",
-        ")\n",
-        "\n",
-        "aplt.Plane.plane_grid(\n",
-        "    plane=source_plane,\n",
-        "    grid=source_plane_grid,\n",
-        "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Source-plane Grid\")),\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can zoom in on the `centre` of the source-plane (remembering the lens galaxy was centred at (0.1\", 0.1\"))."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.plane_grid(\n",
-        "    plane=source_plane,\n",
-        "    grid=source_plane_grid,\n",
-        "    axis_limits=[-0.1, 0.1, -0.1, 0.1],\n",
-        "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Source-plane Grid\")),\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can also plot both `Plane`'s next to one another, and highlight specific points. This means we can see how different \n",
-        "image pixels map to the source-plane (and visa versa).\n",
-        "\n",
-        "(We are inputting the indexes of the `Grid` into `indexes` - the first set of indexes go from 0 -> 50, which is the top \n",
-        "row of the image-grid running from the left - as we said it would!)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.image_and_source_plane_subplot(\n",
-        "    image_plane=image_plane,\n",
-        "    source_plane=source_plane,\n",
-        "    grid=image_plane_grid,\n",
-        "    indexes=[\n",
-        "        range(0, 50),\n",
-        "        range(500, 550),\n",
-        "        [1350, 1450, 1550, 1650, 1750, 1850, 1950, 2050, 2150, 2250],\n",
-        "        [6250, 8550, 8450, 8350, 8250, 8150, 8050, 7950, 7850, 7750],\n",
-        "    ],\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Clearly, the source-plane`s `Grid` is very different to the image-planes! It's not uniform and its certranly not boring!\n",
-        "\n",
-        "We can now ask the question - `what does our source-galaxy look like in the image-plane`? That is, to us, the observer \n",
-        "on Earth, how does the source-galaxy appear after lensing?. To do this, we simple trace the source `Galaxy`'s light \n",
-        "back from the source-plane grid."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.image(plane=source_plane, grid=source_plane_grid)"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "It's a rather spectacular ring of light, but why is it a ring? Well:\n",
-        "\n",
-        "- Our lens galaxy was centred at (0.0\", 0.0\").\n",
-        "- Our source-galaxy was centred at (0.0\", 0.0\").\n",
-        "- Our lens galaxy had a spherical `MassProfile`.\n",
-        "- Our source-galaxy a spherical `LightProfile`.\n",
-        "\n",
-        "Given the perfect symmetry of the system, every path the source's light takes around the lens galaxy is radially \n",
-        "identical. Thus, nothing else but a ring of light can form!\n",
-        "\n",
-        "This is called an 'Einstein Ring' and its radius is called the 'Einstein Radius', which are both named after the man \n",
-        "who famously used gravitational lensing to prove his theory of general relativity.\n",
-        "\n",
-        "Finally, because we know our source-`Galaxy`'s `LightProfile`, we can also plot its `plane-image`. This image is how the \n",
-        "source intrinsically appears in the source-plane (e.g. without lensing). This is a useful thing to know, because the \n",
-        "source-s light is highly magnified, meaning astronomers can study it in a lot more detail than would otherwise be \n",
-        "possible!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.plane_image(\n",
-        "    plane=source_plane, grid=source_plane_grid, include=aplt.Include(grid=True)\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Plotting the `Grid` over the plane image obscures its appearance, which isn't ideal. We can of course tell **PyAutoLens** \n",
-        "not to plot the grid."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.plane_image(\n",
-        "    plane=source_plane, grid=source_plane_grid, include=aplt.Include(grid=False)\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "For `MassProfile`'s, you can also plot their 'critical curve' and 'caustics', which for those unfamiliar with lensing \n",
-        "are defined as follows:\n",
-        "\n",
-        "__Critical Curve__: Lines of infinite magnification where the `MassProfile` perfectly `focuses` light rays. Source light near a \n",
-        " critical curve appears much brighter than its true luminosity!\n",
-        "\n",
-        "__Caustic__: Given the deflection angles of the `MassProfile` at the critical curves, the caustic is where the \n",
-        " critical curve `maps` too.\n",
-        "        \n",
-        "You may be surprised that the inner critical curve does not appear symmetric, but instead is a non-circular jagged \n",
-        "shape. As a result of this, the corresponding caustic in the source plane also appears jaggedy. \n",
-        " \n",
-        "This is a numerical issue with the way that **PyAutoLens** computes the critical curves and caustics - without this issue\n",
-        "both would appear perfect symmetric and smooth! Implementing a more robust calculation of these quantities is on the\n",
-        "**PyAutoLens** featre list, but for now you'll just have to accept this aspect of the visualization is sub-optimal!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.Plane.image_and_source_plane_subplot(\n",
-        "    image_plane=image_plane,\n",
-        "    source_plane=source_plane,\n",
-        "    grid=image_plane_grid,\n",
-        "    include=aplt.Include(critical_curves=True, caustics=True),\n",
-        ")\n",
-        "\n",
-        "aplt.Plane.image_and_source_plane_subplot(\n",
-        "    image_plane=image_plane,\n",
-        "    source_plane=source_plane,\n",
-        "    grid=image_plane_grid,\n",
-        "    include=aplt.Include(critical_curves=False, caustics=False),\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "And, we're done. This is the first tutorial covering strong-lensing and I highly recommend you take a moment to really \n",
-        "mess about with the code above to see what sort of lensed images you can form. Pay attention to the source-plane `Grid` - \n",
-        "its appearance can change a lot!\n",
-        "\n",
-        "In particular, try:\n",
-        "\n",
-        " 1) Changing the lens `Galaxy`'s einstein radius - what happens to the source-plane`s image?\n",
-        "\n",
-        " 2) Change the SphericalIsothermal `MassProfile` to an `EllipticalIsothermal` `MassProfile`.and set its axis_ratio to 0.8. \n",
-        " What happens to the number of source images?\n",
-        "\n",
-        " 3) As discussed at the beginning, `Plane`'s can be composed of multiple galaxies. Make an the image-plane with two \n",
-        " galaxies and see how multi-galaxy lensing leads to crazy source images. Also try making a source-plane with two \n",
-        " galaxies!\n",
-        "\n",
-        "Finally, if you are a newcomer to strong lensing, it might be worth reading briefly about some strong lensing theory. \n",
-        "Don't worry about maths, and equations, and anything scary, but you should at least go to Wikipedia to figure out:\n",
-        "\n",
-        " - What a critical line is.\n",
-        " - What a caustic is.\n",
-        " - What determines the image multiplicity of the lensed source."
-      ]
-    }
-  ],
-  "metadata": {
-    "anaconda-cloud": {},
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.1"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tutorial 4: Planes\n",
+    "==================\n",
+    "\n",
+    "We've learnt how to make galaxy objects out of `LightProfile`'s and `MassProfile`'s. Now, we'll use these galaxies to\n",
+    "make a strong-gravitational lens.\n",
+    "\n",
+    "For newcomers to lensing, a strong gravitational lens is a system where two (or more) galaxies align perfectly down our\n",
+    "line of sight, such that the foreground `Galaxy`'s mass (represented as `MassProfile`'s) deflects the light (represented\n",
+    "as `LightProfile`'s) of the background source galaxy(s).\n",
+    "\n",
+    "When the alignment is just right and the lens is just massive enough, the background source galaxy appears multiple\n",
+    "times. The schematic below shows such a system, where two light-rays from the source are bending\n",
+    "around the lens galaxy and into the observer (light should bend smoothly)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Schematic of Gravitational Lensing](https://i.imgur.com/zB6tIdI.jpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an observer, we don't see the source's true appearance (e.g. a round blob of light). Instead, we only observe its \n",
+    "light after it is deflected and lensed by the foreground `Galaxy`'s mass. In this exercise, we'll make a source galaxy \n",
+    "image whose light has been deflected by a lens galaxy.\n",
+    "\n",
+    "In the schematic above, we used the terms `Image-Plane` and `Source-Plane`. In lensing speak, a `plane` is a \n",
+    "collection of galaxies at the same redshift (that is, parallel to one another down our line-of-sight). Therefore:\n",
+    "\n",
+    "- If two or more lens galaxies are at the same redshift in the image-plane, they deflect light in the same way. \n",
+    "This means we can sum the convergences, potentials and deflection angles of their `MassProfile`'s.\n",
+    "\n",
+    "- If two or more source galaxies are at the same redshift in the source-plane, their light is ray-traced in the same \n",
+    "way. Therefore, when determining their lensed images, we can sum the lensed images of each `Galaxy`'s `LightProfile`'s.\n",
+    "\n",
+    "So, lets do it - lets use the `plane` module in AutoLens to create a strong lensing system like the one pictured above. \n",
+    "For simplicity, we'll assume 1 lens galaxy and 1 source galaxy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/rka/0repos/astro/autolens_workspace\n",
+      "Working Directory has been set to `/home/rka/0repos/astro/autolens_workspace`\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "from pyprojroot import here\n",
+    "\n",
+    "workspace_path = str(here())\n",
+    "%cd $workspace_path\n",
+    "print(f\"Working Directory has been set to `{workspace_path}`\")\n",
+    "\n",
+    "import autolens as al\n",
+    "import autolens.plot as aplt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As always, we need a `Grid`, where our `Grid` is the coordinates we `trace` from the image-plane to the source-plane in \n",
+    "the lensing configuration above. Our `Grid` is therefore no longer just a `grid`, but an image-plane `Grid` representing \n",
+    "our image-plane coordinates. Thus, lets name as such."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_plane_grid = al.Grid.uniform(shape_2d=(100, 100), pixel_scales=0.05, sub_size=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Whereas before we called our `Galaxy`'s things like `galaxy_with_light_profile`, lets now refer to them by their role \n",
+    "in lensing, e.g. `lens_galaxy` and `source_galaxy`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mass_profile = al.mp.SphericalIsothermal(centre=(0.0, 0.0), einstein_radius=1.6)\n",
+    "\n",
+    "lens_galaxy = al.Galaxy(redshift=0.5, mass=mass_profile)\n",
+    "\n",
+    "light_profile = al.lp.SphericalSersic(\n",
+    "    centre=(0.0, 0.0), intensity=1.0, effective_radius=1.0, sersic_index=1.0\n",
+    ")\n",
+    "\n",
+    "source_galaxy = al.Galaxy(redshift=1.0, bulge=light_profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets setup our image-plane using a `Plane` object. This `Plane` takes the lens galaxy we made above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_plane = al.Plane(galaxies=[lens_galaxy])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like we did with `Galaxy`'s we can compute quantities from the `Plane` by passing it a `Grid`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deflections = image_plane.deflections_from_grid(grid=image_plane_grid)\n",
+    "\n",
+    "print(\"deflection-angles of `Plane`'s `Grid` pixel 0:\")\n",
+    "print(deflections.in_2d[0, 0, 0])\n",
+    "print(deflections.in_2d[0, 0, 0])\n",
+    "\n",
+    "print(\"deflection-angles of `Plane`'s `Grid` pixel 1:\")\n",
+    "print(deflections.in_2d[0, 1, 1])\n",
+    "print(deflections.in_2d[0, 1, 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_Plane_ plotters exist, which work analogously to `Profile` plotters and `Galaxy` plotters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.deflections_y(plane=image_plane, grid=image_plane_grid)\n",
+    "aplt.Plane.deflections_x(plane=image_plane, grid=image_plane_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Throughout this chapter, we plotted lots of deflection angles. However, if you are not familiar with strong lensing, \n",
+    "you probably weren`t entirely sure what they are actually used for. \n",
+    "\n",
+    "The deflection angles tell us how light is `lensed` by a lens galaxy. By taking the image-plane coordinates and \n",
+    "deflection angles, we can subtract the two to determine the source-plane`s lensed coordinates, e.g.\n",
+    "\n",
+    "source_plane_coordinates = image_plane_coordinates - image_plane_deflection_angles\n",
+    "\n",
+    "Therefore, we can use our image_plane to `trace` its `Grid` to the source-plane..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_plane_grid = image_plane.traced_grid_from_grid(grid=image_plane_grid)\n",
+    "print(\"Traced source-plane coordinates of `Grid` pixel 0:\")\n",
+    "print(source_plane_grid.in_2d[0, 0, :])\n",
+    "print(\"Traced source-plane coordinates of `Grid` pixel 1:\")\n",
+    "print(source_plane_grid.in_2d[0, 1, :])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... and use this `Grid` to setup the source-plane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_plane = al.Plane(galaxies=[source_galaxy])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets inspect our `Grid`'s - I bet our source-plane isn't the boring uniform `Grid` we plotted in the first tutorial!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.plane_grid(\n",
+    "    plane=image_plane,\n",
+    "    grid=image_plane_grid,\n",
+    "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Image-plane Grid\")),\n",
+    ")\n",
+    "\n",
+    "aplt.Plane.plane_grid(\n",
+    "    plane=source_plane,\n",
+    "    grid=source_plane_grid,\n",
+    "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Source-plane Grid\")),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can zoom in on the `centre` of the source-plane (remembering the lens galaxy was centred at (0.1\", 0.1\"))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.plane_grid(\n",
+    "    plane=source_plane,\n",
+    "    grid=source_plane_grid,\n",
+    "    axis_limits=[-0.1, 0.1, -0.1, 0.1],\n",
+    "    plotter=aplt.Plotter(labels=aplt.Labels(title=\"Source-plane Grid\")),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also plot both `Plane`'s next to one another, and highlight specific points. This means we can see how different \n",
+    "image pixels map to the source-plane (and visa versa).\n",
+    "\n",
+    "(We are inputting the indexes of the `Grid` into `indexes` - the first set of indexes go from 0 -> 50, which is the top \n",
+    "row of the image-grid running from the left - as we said it would!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.image_and_source_plane_subplot(\n",
+    "    image_plane=image_plane,\n",
+    "    source_plane=source_plane,\n",
+    "    grid=image_plane_grid,\n",
+    "    indexes=[\n",
+    "        range(0, 50),\n",
+    "        range(500, 550),\n",
+    "        [1350, 1450, 1550, 1650, 1750, 1850, 1950, 2050, 2150, 2250],\n",
+    "        [6250, 8550, 8450, 8350, 8250, 8150, 8050, 7950, 7850, 7750],\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clearly, the source-plane`s `Grid` is very different to the image-planes! It's not uniform and its certranly not boring!\n",
+    "\n",
+    "We can now ask the question - `what does our source-galaxy look like in the image-plane`? That is, to us, the observer \n",
+    "on Earth, how does the source-galaxy appear after lensing?. To do this, we simple trace the source `Galaxy`'s light \n",
+    "back from the source-plane grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.image(plane=source_plane, grid=source_plane_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's a rather spectacular ring of light, but why is it a ring? Well:\n",
+    "\n",
+    "- Our lens galaxy was centred at (0.0\", 0.0\").\n",
+    "- Our source-galaxy was centred at (0.0\", 0.0\").\n",
+    "- Our lens galaxy had a spherical `MassProfile`.\n",
+    "- Our source-galaxy a spherical `LightProfile`.\n",
+    "\n",
+    "Given the perfect symmetry of the system, every path the source's light takes around the lens galaxy is radially \n",
+    "identical. Thus, nothing else but a ring of light can form!\n",
+    "\n",
+    "This is called an 'Einstein Ring' and its radius is called the 'Einstein Radius', which are both named after the man \n",
+    "who famously used gravitational lensing to prove his theory of general relativity.\n",
+    "\n",
+    "Finally, because we know our source-`Galaxy`'s `LightProfile`, we can also plot its `plane-image`. This image is how the \n",
+    "source intrinsically appears in the source-plane (e.g. without lensing). This is a useful thing to know, because the \n",
+    "source-s light is highly magnified, meaning astronomers can study it in a lot more detail than would otherwise be \n",
+    "possible!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.plane_image(\n",
+    "    plane=source_plane, grid=source_plane_grid, include=aplt.Include(grid=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting the `Grid` over the plane image obscures its appearance, which isn't ideal. We can of course tell **PyAutoLens** \n",
+    "not to plot the grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.plane_image(\n",
+    "    plane=source_plane, grid=source_plane_grid, include=aplt.Include(grid=False)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For `MassProfile`'s, you can also plot their 'critical curve' and 'caustics', which for those unfamiliar with lensing \n",
+    "are defined as follows:\n",
+    "\n",
+    "__Critical Curve__: Lines of infinite magnification where the `MassProfile` perfectly `focuses` light rays. Source light near a \n",
+    " critical curve appears much brighter than its true luminosity!\n",
+    "\n",
+    "__Caustic__: Given the deflection angles of the `MassProfile` at the critical curves, the caustic is where the \n",
+    " critical curve `maps` too.\n",
+    "        \n",
+    "You may be surprised that the inner critical curve does not appear symmetric, but instead is a non-circular jagged \n",
+    "shape. As a result of this, the corresponding caustic in the source plane also appears jaggedy. \n",
+    " \n",
+    "This is a numerical issue with the way that **PyAutoLens** computes the critical curves and caustics - without this issue\n",
+    "both would appear perfect symmetric and smooth! Implementing a more robust calculation of these quantities is on the\n",
+    "**PyAutoLens** featre list, but for now you'll just have to accept this aspect of the visualization is sub-optimal!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aplt.Plane.image_and_source_plane_subplot(\n",
+    "    image_plane=image_plane,\n",
+    "    source_plane=source_plane,\n",
+    "    grid=image_plane_grid,\n",
+    "    include=aplt.Include(critical_curves=True, caustics=True),\n",
+    ")\n",
+    "\n",
+    "aplt.Plane.image_and_source_plane_subplot(\n",
+    "    image_plane=image_plane,\n",
+    "    source_plane=source_plane,\n",
+    "    grid=image_plane_grid,\n",
+    "    include=aplt.Include(critical_curves=False, caustics=False),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And, we're done. This is the first tutorial covering strong-lensing and I highly recommend you take a moment to really \n",
+    "mess about with the code above to see what sort of lensed images you can form. Pay attention to the source-plane `Grid` - \n",
+    "its appearance can change a lot!\n",
+    "\n",
+    "In particular, try:\n",
+    "\n",
+    " 1) Changing the lens `Galaxy`'s einstein radius - what happens to the source-plane`s image?\n",
+    "\n",
+    " 2) Change the SphericalIsothermal `MassProfile` to an `EllipticalIsothermal` `MassProfile`.and set its axis_ratio to 0.8. \n",
+    " What happens to the number of source images?\n",
+    "\n",
+    " 3) As discussed at the beginning, `Plane`'s can be composed of multiple galaxies. Make an the image-plane with two \n",
+    " galaxies and see how multi-galaxy lensing leads to crazy source images. Also try making a source-plane with two \n",
+    " galaxies!\n",
+    "\n",
+    "Finally, if you are a newcomer to strong lensing, it might be worth reading briefly about some strong lensing theory. \n",
+    "Don't worry about maths, and equations, and anything scary, but you should at least go to Wikipedia to figure out:\n",
+    "\n",
+    " - What a critical line is.\n",
+    " - What a caustic is.\n",
+    " - What determines the image multiplicity of the lensed source."
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In chapter 1, planes tutorial
There was a schematic diagram of Gravitational lensing drawn using ASCII characters, which is actually like this
![Screenshot from 2020-12-24 15-23-53](https://user-images.githubusercontent.com/44907757/103081605-4ebdbf80-45fe-11eb-843c-b9274bd8b093.png)

But when it is run, it looks like this(different from original and difficult to understand)
![Screenshot from 2020-12-24 15-24-00](https://user-images.githubusercontent.com/44907757/103081642-5e3d0880-45fe-11eb-9747-684b2bac5abe.png)

So, I thought it would be better if there was an actual image, which would be clear. Added [this](https://lh3.googleusercontent.com/proxy/P8sLJaVKAQIxJPzl5UD_rLKW2_aXg8TTLREDU-DnpB8A9PQ2ICvft9hy4PtGQhx7oZXL-7G_ROpG_xAPIL4LCPxB1_zI6JfPpphDqtfvbLZd04MKtwdax_ei-Sw6568) image in the tutorial and changed the text above it to match.
Currently it looks like this...
![image](https://user-images.githubusercontent.com/44907757/103083273-03a5ab80-4602-11eb-9dda-567211ee271a.png)



I also added `.ipynb_checkpoints` in `.gitignore`, so that they are not tracked accidentally in someone's future PRs or commits. 
P.S The tutorials are great, really well written! Thanks for them! 

