### PR TITLE
Update all scripts for new flat plot function API

### DIFF
--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -588,8 +588,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result_list[0].samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result_list[0].samples)
 
 """
 This script gives a concise overview of the basic cluster modeling API, fitting one the simplest lens models possible.

--- a/scripts/group/modeling.py
+++ b/scripts/group/modeling.py
@@ -677,8 +677,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 This script gives a concise overview of the basic modeling API, fitting one the simplest lens models possible.

--- a/scripts/guides/advanced/custom_analysis.py
+++ b/scripts/guides/advanced/custom_analysis.py
@@ -555,8 +555,7 @@ It also contains information on the posterior as estimated by the non-linear sea
 
 Below, we make a corner plot of the "Probability Density Function" of every parameter in the model-fit.
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -160,8 +160,7 @@ def fit():
 
     aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-    plotter = aplt.NestPlotter(samples=result.samples)
-    plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=result.samples)
 
 
 """

--- a/scripts/guides/plot/examples/README.rst
+++ b/scripts/guides/plot/examples/README.rst
@@ -10,5 +10,5 @@ Files
 
 - ``mat_plot``: Objects which wrap Matplotlib functions which customize a figure's appearance.
 - ``plotters``: Plot specific **PyAutoLens** objects (e.g. ``Tracer``).
-- ``searches``: Visualization tools for the results of a non-linear search (e.g. ``NestPlotter``).
+- ``searches``: Visualization tools for the results of a non-linear search (e.g. ``corner_anesthetic``).
 - ``visuals``: Include visuals on a plot (e.g. a critical curve on an image).

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -12,10 +12,10 @@ behaviour of plotting visuals.
 __Contents__
 
 - **Setup:** Sets up a dataset and model which we will perform quick model-fits to for illustration.
-- **DynestyPlotter:**: Plots results of the nested sampling method Dynesty.
-- **MCMCPlotter:**: Plots results of an Emcee fit (e.g. cornerplot).
-- **PySwarmsPlotter:**: Plots results of a PySwarms fit (e.g. contour).
-- **ZeusPlotter:**: Plots results of a Zeus fit (e.g. cornerplot).
+- **Nested Sampling Plots:**: Plots results of the nested sampling method Dynesty.
+- **MCMC Plots (Emcee):**: Plots results of an Emcee fit (e.g. cornerplot).
+- **MLE Plots (PySwarms):**: Plots results of a PySwarms fit (e.g. contour).
+- **MCMC Plots (Zeus):**: Plots results of a Zeus fit (e.g. cornerplot).
 - **GetDist:**: Plot results of any MCMC / nested sampler non-linear search using the library GetDist.
 
 __Setup__
@@ -129,17 +129,16 @@ we:
 There are other `_kwargs` inputs we pass as None, you should check out the Dynesty docs if you need to customize your
 figure.
 """
-plotter = aplt.NestPlotter(samples=result.samples)
+"""
+The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.
+"""
+aplt.corner_anesthetic(samples=result.samples)
 
 """
-The `corner_anesthetic` method produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.
+The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter using the library `corner.py`.
 """
-plotter.corner_anesthetic()
-
-"""
-The `corner_cornerpy` method produces a triangle of 1D and 2D PDF's of every parameter using the library `corner.py`.
-"""
-plotter.corner_cornerpy(
+aplt.corner_cornerpy(
+    samples=result.samples,
     dims=None,
     span=None,
     quantiles=[0.025, 0.5, 0.975],
@@ -381,27 +380,25 @@ except (AttributeError, TypeError):
 """
 __EmceePlotter__
 
-We now pass the samples to a `MCMCPlotter` which will allow us to use emcee's in-built plotting libraries to 
-make figures.
+We now use the MCMC plotting functions to visualize emcee's results.
 
-The emcee readthedocs describes fully all of the methods used below 
+The emcee readthedocs describes fully all of the methods used below
 
  - https://emcee.readthedocs.io/en/stable/user/sampler/
- 
- The plotter wraps the `corner` method of the library `corner.py` to make corner plots of the PDF:
+
+ The `corner_cornerpy` function wraps the library `corner.py` to make corner plots of the PDF:
 
 - https://corner.readthedocs.io/en/latest/index.html
- 
-In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are 
+
+In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are
 described in the API docs.
 """
-plotter = aplt.MCMCPlotter(samples=result.samples)
-
 
 """
-The `corner` method produces a triangle of 1D and 2D PDF's of every parameter in the model fit.
+The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter in the model fit.
 """
-plotter.corner_cornerpy(
+aplt.corner_cornerpy(
+    samples=result.samples,
     bins=20,
     range=None,
     color="k",
@@ -504,27 +501,26 @@ except AttributeError:
 """
 __ZeusPlotter__
 
-We now pass the samples to a `ZeusPlotter` which will allow us to use Nautilus's in-built plotting libraries to 
-make figures.
+We now use the MCMC plotting functions to visualize Zeus's results.
 
-The zeus readthedocs describes fully all of the methods used below 
+The zeus readthedocs describes fully all of the methods used below
 
  - https://zeus-mcmc.readthedocs.io/en/latest/api/plotting.html#cornerplot
  - https://zeus-mcmc.readthedocs.io/en/latest/notebooks/normal_distribution.html
- 
- The plotter wraps the `corner` method of the library `corner.py` to make corner plots of the PDF:
+
+ The `corner_cornerpy` function wraps the library `corner.py` to make corner plots of the PDF:
 
 - https://corner.readthedocs.io/en/latest/index.html
- 
-In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are 
+
+In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are
 described in the API docs.
 """
-plotter = aplt.MCMCPlotter(samples=result.samples)
 
 """
-The `corner` method produces a triangle of 1D and 2D PDF's of every parameter in the model fit.
+The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter in the model fit.
 """
-plotter.corner_cornerpy(
+aplt.corner_cornerpy(
+    samples=result.samples,
     weight_list=None,
     levels=None,
     span=None,
@@ -611,17 +607,15 @@ except AttributeError:
 """
 __PySwarmsPlotter__
 
-We now pass the samples to a `MLEPlotter` which will allow us to use pyswarms's in-built plotting libraries to 
-make figures.
+We now use the MLE plotting functions to visualize pyswarms's results.
 
-The pyswarms readthedocs describes fully all of the methods used below 
+The pyswarms readthedocs describes fully all of the methods used below
 
  - https://pyswarms.readthedocs.io/en/latest/api/pyswarms.utils.plotters.html
- 
-In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are 
+
+In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are
 described in the API docs.
 """
-plotter = aplt.MLEPlotter(samples=result.samples)
 
 """
 __Search Specific Visualization__

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -203,6 +203,6 @@ fit = al.FitImaging(dataset=dataset, tracer=tracer)
 aplt.subplot_fit_imaging(fit=fit)
 
 """
-The search plotters (`aplt.NestPlotter`, `aplt.MCMCPlotter`, `aplt.MLEPlotter`) still exist
-and are unchanged — see `scripts/guides/plot/examples/searches.py`.
+The search plotting functions (`aplt.corner_anesthetic`, `aplt.corner_cornerpy`, etc.) provide
+visualization of non-linear search results -- see `scripts/guides/plot/examples/searches.py`.
 """

--- a/scripts/guides/results/examples/samples.py
+++ b/scripts/guides/results/examples/samples.py
@@ -271,14 +271,13 @@ __Search Plots__
 The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search in-built 
 visualization tools.
 
-This fit used `Nautilus` therefore we use the `NestPlotter` for visualization, which wraps in-built
+This fit used `Nautilus` therefore we use the nested sampling visualization functions, which wrap in-built
 visualization tools.
 
 The `autofit_workspace/*/plots` folder illustrates other packages that can be used to make these plots using
 the standard output results formats (e.g. `GetDist.py`).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Maximum Likelihood__

--- a/scripts/guides/results/examples/samples_via_aggregator.py
+++ b/scripts/guides/results/examples/samples_via_aggregator.py
@@ -317,15 +317,14 @@ __Search Plots__
 The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search in-built 
 visualization tools.
 
-This fit used `Nautilus` therefore we use the `NestPlotter` for visualization, which wraps `Nautilus`'s in-built
-visualization tools.
+This fit used `Nautilus` therefore we use the nested sampling visualization functions, which wrap `Nautilus`'s
+in-built visualization tools.
 
 The `autofit_workspace/*/plots` folder illustrates other packages that can be used to make these plots using
 the standard output results formats (e.g. `GetDist.py`).
 """
 for samples in agg.values("samples"):
-    plotter = aplt.NestPlotter(samples=samples)
-#  plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=samples)
 
 """
 __Maximum Likelihood__

--- a/scripts/howtolens/chapter_2_lens_modeling/tutorial_2_practicalities.py
+++ b/scripts/howtolens/chapter_2_lens_modeling/tutorial_2_practicalities.py
@@ -362,7 +362,7 @@ aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
 """
 The Probability Density Functions (PDF's) of the results can be plotted using an in-built visualization 
-library, which is wrapped via the `NestPlotter` object.
+library, which is wrapped via the `corner_anesthetic` function.
 
 The PDF shows the 1D and 2D probabilities estimated for every parameter after the model-fit. The two dimensional 
 figures can show the degeneracies between different parameters, for example how increasing the intensity $I$ of the
@@ -376,8 +376,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Other Practicalities__

--- a/scripts/imaging/features/advanced/double_einstein_ring/modeling.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/modeling.py
@@ -277,8 +277,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
@@ -242,8 +242,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/imaging/features/advanced/operated_light_profile/modeling.py
+++ b/scripts/imaging/features/advanced/operated_light_profile/modeling.py
@@ -253,8 +253,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/imaging/features/advanced/shapelets/modeling.py
+++ b/scripts/imaging/features/advanced/shapelets/modeling.py
@@ -373,8 +373,7 @@ aplt.subplot_galaxies_images(tracer=result.max_log_likelihood_tracer, grid=datas
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Shapelet Cartesian__

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -268,8 +268,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Intensities__

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -331,8 +331,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Source MGE__

--- a/scripts/imaging/features/no_lens_light/modeling.py
+++ b/scripts/imaging/features/no_lens_light/modeling.py
@@ -256,8 +256,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -397,8 +397,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 The example `pixelization/fit` provides a full description of the different calculations that can be performed

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -501,8 +501,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Source Science (Magnification, Flux and More)__

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -426,8 +426,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_interferometer(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 The example `pixelization/fit` provides a full description of the different calculations that can be performed

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -446,8 +446,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Source Science (Magnification, Flux and More)__

--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -260,8 +260,7 @@ The `Samples` object still has the dimensions of the overall non-linear search (
 Therefore, the samples is identical in every result object.
 """
 for result in result_list:
-    plotter = aplt.NestPlotter(samples=result.samples)
-    plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/multi/features/imaging_and_interferometer/modeling.py
+++ b/scripts/multi/features/imaging_and_interferometer/modeling.py
@@ -227,8 +227,7 @@ aplt.subplot_fit_imaging(fit=result_list[0].max_log_likelihood_fit)
 aplt.subplot_fit_interferometer(fit=result_list[1].max_log_likelihood_fit)
 aplt.subplot_fit_dirty_images(fit=result_list[1].max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result_list.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result_list.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/multi/features/pixelization/modeling.py
+++ b/scripts/multi/features/pixelization/modeling.py
@@ -208,8 +208,7 @@ The `Samples` object still has the dimensions of the overall non-linear search (
 Therefore, the samples is identical in every result object.
 """
 for result in result_list:
-    plotter = aplt.NestPlotter(samples=result.samples)
-    plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/multi/features/same_wavelength/modeling.py
+++ b/scripts/multi/features/same_wavelength/modeling.py
@@ -204,8 +204,7 @@ The `Samples` object still has the dimensions of the overall non-linear search (
 
 Therefore, the samples is identical in every result object.
 """
-plotter = aplt.NestPlotter(samples=result_list.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result_list.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -255,8 +255,7 @@ The `Samples` object still has the dimensions of the overall non-linear search (
 Therefore, the samples is identical in every result object.
 """
 for result in result_list:
-    plotter = aplt.NestPlotter(samples=result.samples)
-    plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/multi/modeling.py
+++ b/scripts/multi/modeling.py
@@ -325,8 +325,7 @@ The `Samples` object still has the dimensions of the overall non-linear search (
 Therefore, the samples is identical in every result object.
 """
 for result in result_list:
-    plotter = aplt.NestPlotter(samples=result.samples)
-    plotter.corner_anesthetic()
+    aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Wrap Up__

--- a/scripts/point_source/features/deblending/modeling.py
+++ b/scripts/point_source/features/deblending/modeling.py
@@ -315,8 +315,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Point Source__

--- a/scripts/point_source/modeling.py
+++ b/scripts/point_source/modeling.py
@@ -440,8 +440,7 @@ parameter `n`). These mappings ate specified in the `config/notation.yaml` file 
 The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
 mass its name `mass` defined when making the `Model` above is used).
 """
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_anesthetic()
+aplt.corner_anesthetic(samples=result.samples)
 
 """
 __Results__


### PR DESCRIPTION
## Summary
Update ~30 workspace scripts to use the new flat plot function API from PyAutoFit/PyAutoLens. Replaces all `aplt.NestPlotter`/`MCMCPlotter`/`MLEPlotter` class instantiations with direct function calls like `aplt.corner_anesthetic(samples=s)`.

## API Changes
Consuming upstream API change only — no new APIs introduced. All plotter class instantiations replaced with direct function calls across modeling scripts, guides, tutorials, and feature examples.
See full details below.

## Test Plan
- [x] All modified scripts pass `py_compile` syntax check
- [ ] Run scripts against PyAutoLens `feature/plot_refactor` branch

<details>
<summary>📋 Full API Changes (for automation & release notes)</summary>

### Changed (consuming new upstream API)
- 27 modeling scripts: `aplt.NestPlotter(samples).corner_anesthetic()` → `aplt.corner_anesthetic(samples=samples)`
- 2 sites: `aplt.MCMCPlotter(samples).corner_cornerpy(...)` → `aplt.corner_cornerpy(samples=samples, ...)`
- 1 site: `aplt.MLEPlotter(samples)` removed (had no method calls)
- 6 guide/tutorial files: updated docstring references

### Migration
- Before: `plotter = aplt.NestPlotter(samples=result.samples); plotter.corner_anesthetic()`
- After: `aplt.corner_anesthetic(samples=result.samples)`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)