### PR TITLE
fix: remove stale Galaxy.point reference in multi/slam/independent.py

### DIFF
--- a/notebooks/multi/features/slam/independent.ipynb
+++ b/notebooks/multi/features/slam/independent.ipynb
@@ -494,7 +494,6 @@
         "                redshift=redshift_lens,\n",
         "                bulge=light_result.instance.galaxies.lens.bulge,\n",
         "                disk=None,\n",
-        "                point=light_result.instance.galaxies.lens.point,\n",
         "                mass=mass_result.instance.galaxies.lens.mass,\n",
         "                shear=mass_result.instance.galaxies.lens.shear,\n",
         "            ),\n",

--- a/scripts/multi/features/slam/independent.py
+++ b/scripts/multi/features/slam/independent.py
@@ -420,7 +420,6 @@ def source_lp_secondary(
                 redshift=redshift_lens,
                 bulge=light_result.instance.galaxies.lens.bulge,
                 disk=None,
-                point=light_result.instance.galaxies.lens.point,
                 mass=mass_result.instance.galaxies.lens.mass,
                 shear=mass_result.instance.galaxies.lens.shear,
             ),


### PR DESCRIPTION
## Summary
- Category F fix: the `point` attribute was removed from Galaxy models. Line 423 in `source_lp_secondary` tried to propagate a non-existent `light_result.instance.galaxies.lens.point`.
- No `point` component is used anywhere else in this pipeline, so the kwarg is simply dropped.

## Test plan
- [x] `python scripts/multi/features/slam/independent.py` with TEST_MODE=2 now runs the full 5 primary + 3 secondary pipeline stages to completion (EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)