### PR TITLE
fix: auto-run results/start_here.py for aggregator example scripts

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -28,3 +28,9 @@ overrides:
     unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
   - pattern: "multi/start_here"
     unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+  # guides/results/start_here.py must produce real samples so the example
+  # scripts that read from `output/results_folder` afterwards
+  # (data_fitting, queries, models, samples_via_aggregator) find a
+  # non-empty aggregator. Covers all scripts under guides/results/.
+  - pattern: "guides/results/"
+    unset: [PYAUTOFIT_TEST_MODE]

--- a/scripts/guides/results/examples/data_fitting.py
+++ b/scripts/guides/results/examples/data_fitting.py
@@ -52,6 +52,16 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/start_here.py"],
+        check=True,
+    )
+
 agg = Aggregator.from_directory(
     directory=Path("output") / "results_folder",
 )

--- a/scripts/guides/results/examples/models.py
+++ b/scripts/guides/results/examples/models.py
@@ -39,6 +39,16 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/start_here.py"],
+        check=True,
+    )
+
 agg = Aggregator.from_directory(
     directory=Path("output") / "results_folder",
 )

--- a/scripts/guides/results/examples/queries.py
+++ b/scripts/guides/results/examples/queries.py
@@ -39,6 +39,16 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/start_here.py"],
+        check=True,
+    )
+
 agg = Aggregator.from_directory(
     directory=Path("output") / "results_folder",
 )

--- a/scripts/guides/results/examples/samples_via_aggregator.py
+++ b/scripts/guides/results/examples/samples_via_aggregator.py
@@ -95,6 +95,16 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/start_here.py"],
+        check=True,
+    )
+
 agg = Aggregator.from_directory(
     directory=Path("output") / "results_folder",
 )


### PR DESCRIPTION
## Summary
Four example scripts under `guides/results/examples/` load results via `Aggregator.from_directory("output/results_folder")`, requiring `guides/results/start_here.py` to have been run first. When executed directly at the workspace level (not via PyAutoBuild's ordered runner), the aggregator is empty and downstream calls fail. Also, the workspace default `PYAUTOFIT_TEST_MODE=2` bypasses the sampler so even CI's ordered runner produces empty results.

Fix: add a subprocess auto-run block that invokes `start_here.py` when the results folder is missing, matching the dataset auto-simulation pattern already used elsewhere. Add a `guides/results/` env_vars.yaml override so CI doesn't bypass the sampler.

## Scripts Changed
- `scripts/guides/results/examples/data_fitting.py` — auto-run `start_here.py` if `output/results_folder` missing
- `scripts/guides/results/examples/queries.py` — same
- `scripts/guides/results/examples/models.py` — same
- `scripts/guides/results/examples/samples_via_aggregator.py` — same
- `config/build/env_vars.yaml` — add `guides/results/` override unsetting `PYAUTOFIT_TEST_MODE`

## Test Plan
- [ ] `guides/results/examples/*.py` scripts run standalone from a clean workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)