### PR TITLE
chore: skip all subhalo sensitivity scripts in no_run.yaml

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -27,7 +27,6 @@
 - mass_stellar_dark/slam # Requires CSE to be JAX enabled.
 - shapelets/modeling # Issue with JAX, claude remind me about this when you next look at build.
 - detect/database # Unsure but not a feature actively used currently.
-- sensitivity/slam_source_parametric # Need to update when visuaization refactored.
-- sensitivity/slam_source_pixelized # Need to update, when visuaization refactored.
+- imaging/features/advanced/subhalo/sensitivity/ # All sensitivity scripts need updating when visualization refactored.
 - plot/visuals # Bugged, but visuals being refactored soon.
 - point_source/features/double_einstein_cross/simulator # PointSolver finds 0 positions on small grid


### PR DESCRIPTION
## Summary
Add `start_here.py` to the skip list by consolidating the existing two sensitivity exclusions (`slam_source_parametric`, `slam_source_pixelized`) into a single folder-level pattern covering every script under `scripts/imaging/features/advanced/subhalo/sensitivity/`.

## Scripts Changed
- `config/build/no_run.yaml` — replace two specific sensitivity entries with one folder-level pattern

## Test Plan
- [ ] CI skips all three sensitivity scripts (`start_here.py`, `slam_source_parametric.py`, `slam_source_pixelized.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)