### PR TITLE
Skip 3 scripts that exceed 60s timeout

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -3,8 +3,17 @@
 #   - Entries with '/' do a substring match against the file path
 #   - Entries without '/' match the file stem exactly
 # Add an inline # comment to document the reason for skipping.
+#
+# SLOW-skip convention:
+#   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
+#   skipped because they exceed the 60s per-script timeout cap. These are
+#   NOT permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Fix the performance issue and remove the SLOW marker.
 
 - tutorial_searches
+- guides/results/examples/samples # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
+- guides/results/examples/samples_via_aggregator # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
+- howtolens/chapter_4_pixelizations/tutorial_10_brightness_adaption # SLOW 2026-04-10 - pixelization tutorial exceeds 60s test timeout
 - tutorial_5_borders # Cant get right masks, need proper update.
 - tutorial_6_model_fit # InversionException due to test mode
 - gui/extra_galaxies_centres # GUI scripts cannot be run


### PR DESCRIPTION
## Summary

- `guides/results/examples/samples.py` and `samples_via_aggregator.py` unset `PYAUTOFIT_TEST_MODE` via `config/build/env_vars.yaml` so they can produce real samples for downstream aggregator examples
- `howtolens/chapter_4_pixelizations/tutorial_10_brightness_adaption.py` is a genuinely slow pixelization tutorial
- All three reliably exceed the 60s per-script timeout cap
- Skipped with the new `SLOW <YYYY-MM-DD>` marker so PyAutoBuild surfaces them in a warning banner every mega-run until the performance issue is fixed

Paired with PyAutoBuild PR #40 which adds the SLOW convention and warning banner.

## Test plan

- [x] Pattern matches verified locally
- [ ] Next mega-run shows 0 timeouts from this workspace and warning banner lists all 3 entries