### PR TITLE
refactor: drop PYAUTO_DISABLE_CRITICAL_CAUSTICS env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,15 +30,14 @@ python scripts/imaging/modeling/start_here.py
 PYAUTOFIT_TEST_MODE=1 python scripts/imaging/modeling/start_here.py
 ```
 
-**Fast smoke tests**: For maximum speed, combine test mode with small datasets and disabled critical curves:
+**Fast smoke tests**: For maximum speed, combine test mode with small datasets and fast plots:
 
 ```bash
-PYAUTOFIT_TEST_MODE=2 PYAUTO_WORKSPACE_SMALL_DATASETS=1 PYAUTO_DISABLE_CRITICAL_CAUSTICS=1 PYAUTO_FAST_PLOTS=1 python scripts/imaging/modeling.py
+PYAUTOFIT_TEST_MODE=2 PYAUTO_WORKSPACE_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python scripts/imaging/modeling.py
 ```
 
 - `PYAUTO_WORKSPACE_SMALL_DATASETS=1` — caps all grids/masks to 15x15 pixels at 0.6"/px, making simulators and all downstream computations dramatically faster. Delete `dataset/` when toggling this variable.
-- `PYAUTO_DISABLE_CRITICAL_CAUSTICS=1` — skips critical curve and caustic overlay computation in plots.
-- `PYAUTO_FAST_PLOTS=1` — skips `plt.tight_layout()` in subplot functions, avoiding expensive matplotlib font/text metrics computation.
+- `PYAUTO_FAST_PLOTS=1` — skips `plt.tight_layout()` and critical curve/caustic overlay computation in subplot functions.
 
 **Codex / sandboxed runs**: when running from Codex or any restricted environment, set writable cache directories so `numba` and `matplotlib` do not fail on unwritable home or source-tree paths:
 

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -11,9 +11,8 @@
 defaults:
   PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
   PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
-  PYAUTO_DISABLE_CRITICAL_CAUSTICS: "1" # Skip critical curve/caustic overlays in plots
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
-  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() in subplots
+  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib


### PR DESCRIPTION
## Summary
Remove the retired `PYAUTO_DISABLE_CRITICAL_CAUSTICS` env var from workspace configs and docs. `PYAUTO_FAST_PLOTS=1` now handles both tight_layout skipping and critical curve/caustic overlay skipping.

## Scripts Changed
- `config/build/env_vars.yaml` — removed `PYAUTO_DISABLE_CRITICAL_CAUSTICS` entry, updated `PYAUTO_FAST_PLOTS` comment
- `CLAUDE.md` — removed env var from command example and doc bullet, updated description

## Upstream PR
- https://github.com/PyAutoLabs/PyAutoGalaxy/pull/340
- https://github.com/PyAutoLabs/PyAutoBuild/pull/43

## Test Plan
- [x] Smoke tests pass (25/27, 2 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)