### PR TITLE
refactor: rename env vars to PYAUTO_* prefix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ You are working on the **autolens_workspace**, a tutorial/example repository for
 
 ## Testing
 
-`run_all_scripts.sh` sets `PYAUTOFIT_TEST_MODE=1` automatically. Every script should pass in this mode. A script that fails in test mode indicates a real problem (broken import, wrong function name, etc.).
+`run_all_scripts.sh` sets `PYAUTO_TEST_MODE=1` automatically. Every script should pass in this mode. A script that fails in test mode indicates a real problem (broken import, wrong function name, etc.).
 
 ## Notebook Generation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ python scripts/imaging/modeling/start_here.py
 
 ## Testing
 
-Set `PYAUTOFIT_TEST_MODE=1` so non-linear searches skip actual sampling (fast test run).
+Set `PYAUTO_TEST_MODE=1` so non-linear searches skip actual sampling (fast test run).
 
 Run all scripts:
 
@@ -28,7 +28,7 @@ Run all scripts:
 bash run_all_scripts.sh
 ```
 
-This sets `PYAUTOFIT_TEST_MODE=1` automatically, runs every script in `scripts/`, and reports pass/fail/skipped counts. Failure logs are written to `failed/<relative_path>.log`.
+This sets `PYAUTO_TEST_MODE=1` automatically, runs every script in `scripts/`, and reports pass/fail/skipped counts. Failure logs are written to `failed/<relative_path>.log`.
 
 ### Script ordering
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,19 +24,19 @@ Scripts are run from the repository root so relative paths to `dataset/` and `ou
 python scripts/imaging/modeling/start_here.py
 ```
 
-**Integration testing / fast mode**: Set `PYAUTOFIT_TEST_MODE=1` to skip non-linear search sampling:
+**Integration testing / fast mode**: Set `PYAUTO_TEST_MODE=1` to skip non-linear search sampling:
 
 ```bash
-PYAUTOFIT_TEST_MODE=1 python scripts/imaging/modeling/start_here.py
+PYAUTO_TEST_MODE=1 python scripts/imaging/modeling/start_here.py
 ```
 
-**Fast smoke tests**: For maximum speed, combine test mode with small datasets and fast plots:
+**Fast smoke tests**: For maximum speed, combine test mode with all skip flags and small datasets:
 
 ```bash
-PYAUTOFIT_TEST_MODE=2 PYAUTO_WORKSPACE_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python scripts/imaging/modeling.py
+PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python scripts/imaging/modeling.py
 ```
 
-- `PYAUTO_WORKSPACE_SMALL_DATASETS=1` — caps all grids/masks to 15x15 pixels at 0.6"/px, making simulators and all downstream computations dramatically faster. Delete `dataset/` when toggling this variable.
+- `PYAUTO_SMALL_DATASETS=1` — caps all grids/masks to 15x15 pixels at 0.6"/px, making simulators and all downstream computations dramatically faster. Delete `dataset/` when toggling this variable.
 - `PYAUTO_FAST_PLOTS=1` — skips `plt.tight_layout()` and critical curve/caustic overlay computation in subplot functions.
 
 **Codex / sandboxed runs**: when running from Codex or any restricted environment, set writable cache directories so `numba` and `matplotlib` do not fail on unwritable home or source-tree paths:

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -9,8 +9,11 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
-  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_TEST_MODE: "2"                 # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SKIP_FIT_OUTPUT: "1"           # Skip pre/post-fit I/O, VRAM profiling, result text
+  PYAUTO_SKIP_VISUALIZATION: "1"        # Skip fit visualization and plotting
+  PYAUTO_SKIP_CHECKS: "1"              # Skip mesh validation, position checks, weight thresholds
+  PYAUTO_SMALL_DATASETS: "1"           # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
   PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
@@ -20,16 +23,16 @@ defaults:
 overrides:
   # start_here scripts load real FITS data that breaks with small datasets
   - pattern: "imaging/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "interferometer/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "group/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "multi/start_here"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   # guides/results/start_here.py must produce real samples so the example
   # scripts that read from `output/results_folder` afterwards
   # (data_fitting, queries, models, samples_via_aggregator) find a
   # non-empty aggregator. Covers all scripts under guides/results/.
   - pattern: "guides/results/"
-    unset: [PYAUTOFIT_TEST_MODE]
+    unset: [PYAUTO_TEST_MODE, PYAUTO_SKIP_FIT_OUTPUT]

--- a/scripts/group/simulator.py
+++ b/scripts/group/simulator.py
@@ -297,7 +297,7 @@ modeling scripts (e.g. SLaM pipeline) to help the non-linear search converge.
 """
 import os
 
-small_datasets = os.environ.pop("PYAUTO_WORKSPACE_SMALL_DATASETS", None)
+small_datasets = os.environ.pop("PYAUTO_SMALL_DATASETS", None)
 
 solver = al.PointSolver.for_grid(
     grid=al.Grid2D.uniform(shape_native=(500, 500), pixel_scales=0.1),
@@ -310,7 +310,7 @@ positions = solver.solve(
 )
 
 if small_datasets is not None:
-    os.environ["PYAUTO_WORKSPACE_SMALL_DATASETS"] = small_datasets
+    os.environ["PYAUTO_SMALL_DATASETS"] = small_datasets
 
 al.output_to_json(
     obj=positions,

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -1,13 +1,13 @@
-# imaging/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_WORKSPACE_SMALL_DATASETS=1
+# imaging/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_SMALL_DATASETS=1
 imaging/modeling.py
 imaging/fit.py
 # imaging/data_preparation/start_here.py  # disabled: no auto-simulation, depends on imaging/modeling.py dataset (race condition in parallel)
-# interferometer/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_WORKSPACE_SMALL_DATASETS=1
+# interferometer/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_SMALL_DATASETS=1
 interferometer/modeling.py
 # point_source/start_here.py  # disabled: bypass mode tuple-path KeyError on point source models (rhayes777/PyAutoFit#1179)
-# group/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_WORKSPACE_SMALL_DATASETS=1
+# group/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_SMALL_DATASETS=1
 group/modeling.py
-# multi/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_WORKSPACE_SMALL_DATASETS=1
+# multi/start_here.py  # disabled: uses checked-in real data incompatible with PYAUTO_SMALL_DATASETS=1
 multi/modeling.py
 guides/galaxies.py
 # guides/results/start_here.py  # disabled: depends on prior search output in output/ dir (not generated during smoke tests)


### PR DESCRIPTION
## Summary
Update env_vars.yaml, Python scripts, and documentation to use the new unified `PYAUTO_*` environment variable names.

## Scripts Changed
- `config/build/env_vars.yaml` — renamed vars, added skip flags
- `scripts/group/simulator.py` — `PYAUTO_WORKSPACE_SMALL_DATASETS` → `PYAUTO_SMALL_DATASETS`
- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `smoke_tests.txt` — updated docs

## Upstream PRs
- https://github.com/PyAutoLabs/PyAutoConf/pull/86
- https://github.com/PyAutoLabs/PyAutoArray/pull/265
- https://github.com/PyAutoLabs/PyAutoLens/pull/432

## Test Plan
- [x] All 7 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)