### PR TITLE
fix: unset PYAUTO_SMALL_DATASETS for howtolens and guides

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -30,6 +30,15 @@ overrides:
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "multi/start_here"
     unset: [PYAUTO_SMALL_DATASETS]
+  # Non-simulator scripts that load committed FITS data need full-size
+  # datasets to avoid shape mismatch with pre-existing 100x100 data.
+  # Simulators run first and regenerate data at the capped size, but
+  # scripts using the old `if not dataset_path.exists()` pattern skip
+  # re-simulation when data already exists.
+  - pattern: "howtolens/"
+    unset: [PYAUTO_SMALL_DATASETS]
+  - pattern: "guides/"
+    unset: [PYAUTO_SMALL_DATASETS]
   # guides/results/start_here.py must produce real samples so the example
   # scripts that read from `output/results_folder` afterwards
   # (data_fitting, queries, models, samples_via_aggregator) find a


### PR DESCRIPTION
## Summary

Unset `PYAUTO_SMALL_DATASETS` for `howtolens/` and `guides/` script paths in `config/build/env_vars.yaml`. These scripts load committed FITS data at full resolution (100x100) but the env var caps masks to 15x15, causing shape mismatch errors in the release build.

This is a temporary workaround — the proper fix is migrating all 111 scripts from the old `if not dataset_path.exists()` pattern to `aa.util.dataset.should_simulate()`, which deletes stale data and re-simulates at the correct resolution.

Relates to Jammy2211/PyAutoArray#269.

## API Changes
None — build configuration only.

## Test Plan
- [ ] Re-trigger release build after merging all PRs in this task

🤖 Generated with [Claude Code](https://claude.com/claude-code)