### PR TITLE
docs: draft end-to-end CASA → PyAutoLens data-prep script

### DIFF
--- a/scripts/interferometer/casa_reduction.py
+++ b/scripts/interferometer/casa_reduction.py
@@ -1,239 +1,468 @@
 """
-THIS SCRIPT IS INCOMPLETE AND IN DEVELOPMENT BUT IT HOPEFULLY IS INFORMATIVE ENOUGH TO HELP YOU GET STARTED.
+Interferometer: CASA Reduction
+==============================
 
-If not contact us on SLACK!
+This script is a practical walkthrough of how to reduce an ALMA / JVLA interferometer
+observation with **CASA** and export it into the three FITS files that **PyAutoLens**
+expects for lens modeling:
+
+- `data.fits`         — complex visibilities, shape `(n_vis,)`
+- `noise_map.fits`    — complex per-visibility RMS (sigma), shape `(n_vis,)`
+- `uv_wavelengths.fits` — `(u, v)` baselines in units of *wavelengths*, shape `(n_vis, 2)`
+
+The script is deliberately a hybrid: the sections that must run **inside the CASA
+environment** (`split`, `statwt`, `uvcontsub`, `tb.open`, etc.) are shown as CASA
+snippets you copy into a CASA session. The plain Python helpers at the bottom use
+`numpy` and `astropy` to convert CASA-exported columns into the shapes PyAutoLens
+requires, and can be run either inside CASA (which has a Python interpreter) or
+in a normal Python environment once the FITS files have been produced.
+
+The script is **a starting point**, not a finished tool. Every real dataset has
+quirks (single-field vs. mosaic, spectral line vs. continuum, different numbers
+of spectral windows, flagged antennas, polarisation products, ...). You will
+almost certainly need to tweak it. If you get stuck, please contact us on the
+PyAutoLens **SLACK** — interferometry support is actively evolving, and your
+feedback directly shapes these examples.
 
 __Contents__
 
-**CASA to PyAutoLens:** The interferometer object in AutoLens takes as arguments the visibilities, uv_wavelengths and.
+**PyAutoLens Requirements:** What the `al.Interferometer` object expects as input.
+**CASA in Five Steps:** The canonical CASA reduction pipeline for PyAutoLens.
+**Step 1 — Split by Field / SPW:** Isolate the lens target and each spectral window.
+**Step 2 — Channel Averaging:** Reduce visibility count by averaging channels.
+**Step 3 — Continuum Subtraction:** Optional `uvcontsub` for line observations.
+**Step 4 — Rescale Sigmas:** `statwt` makes the SIGMA column reflect real scatter.
+**Step 5 — Export to FITS:** Python helpers to read the .ms and write .fits.
+**Combining Spectral Windows:** Concatenate per-SPW arrays into a single dataset.
+**Polarisations:** Averaging XX/YY (or RR/LL) into a single complex visibility.
+**Building the Interferometer Object:** Load the FITS files into `al.Interferometer`.
+**Troubleshooting:** Common pitfalls and what to check.
+**SLACK:** Where to ask for help.
 
-__CASA to PyAutoLens__
+__PyAutoLens Requirements__
 
-The interferometer object in AutoLens takes as arguments the visibilities, uv_wavelengths and noise_map (i.e. the
-SIGMA associated with the visibilities). The uv_wavelengths should have a shape (n_vis, 2) where n_vis is the total
-number of visibilities and the two different columns correspond to the u, v components of the uv_wavenelengths.
+`al.Interferometer.from_fits(...)` loads three FITS files. **On disk**, they are
+stored as plain real-valued arrays with a single `n_vis` axis, after polarisations
+and channels have been collapsed into one long visibility list:
 
-The visibilities and noise map are complex arrays of shape (n_vis, ) where the real and imag of the array are the real
-and imag parts of the visibilities and SIGMA.
+- `data.fits`           : real array, shape `(n_vis, 2)` — col 0 real, col 1 imag
+- `noise_map.fits`      : real array, shape `(n_vis, 2)` — col 0 sigma_real, col 1 sigma_imag
+- `uv_wavelengths.fits` : real array, shape `(n_vis, 2)` — cols are (u, v) in wavelengths
 
-- Exporting visibilities and uv_wavelengths with CASA.
+PyAutoLens converts the first two into complex arrays internally when the
+`Interferometer` object is built.
 
-ALMA data are stored in .ms data structure. The shape of the visibilities in this structure has a shape
-of (2, n_spw, n_c, n_v, 2) where n_spw in the number of spectral windows, n_c is the number of channels, n_v is the
-number of visibilities. The first two rows of this array correspond to the 2 different polarisations.
+Critically:
+
+- The `uv` coordinates must be in **wavelengths**, not metres. The CASA `UVW`
+  column stores metres, so you must multiply by `frequency / c` per channel.
+- You must flatten *all* polarisation and channel axes into the single `n_vis`
+  axis before writing the FITS. The standard order is:
+  **(1) average polarisations → (2) reshape channels into n_vis → (3) concatenate SPWs**.
+  If you skip step (1), the polarisations end up interleaved with the channels
+  and the noise-map will be wrong.
+
+__CASA in Five Steps__
+
+A typical ALMA calibrated Measurement Set `my_obs.ms.split.cal` becomes PyAutoLens
+input via this pipeline:
+
+    1. split out the field and (optionally) per-SPW   → field/spw isolated .ms
+    2. channel-average to reduce n_vis                 → chanaveraged .ms
+    3. (line only) uvcontsub to remove continuum       → .ms.contsub
+    4. statwt to rescale SIGMA                         → .ms.statwt
+    5. export DATA / UVW / CHAN_FREQ / SIGMA to FITS   → data/noise/uv .fits
+
+The rest of this script walks through each of these steps in order. All `split(...)`,
+`statwt(...)`, `uvcontsub(...)`, `tb.open(...)` calls must be executed from within
+a running CASA session (either interactively or via `casa -c my_script.py`).
+
+__Step 1 — Split by Field / SPW__
+
+ALMA `.ms` datasets typically contain multiple fields (calibrators + science
+target) and multiple spectral windows (SPWs). Start by splitting out just the
+science field. You can also split per-SPW at this stage, which makes later
+channel-averaging simpler because different SPWs can have different numbers
+of channels.
 """
 
-import numpy as np
-import os
-
-import autolens as al
-
-"""
-You can use the CASA task "split" to create 4 new different .ms directories, each corresponding to a different spw.
-"""
-
+# CASA:
 # split(
-#     vis="name.ms",
-#     outputvis="name_spw_0.ms",
+#     vis="my_obs.ms.split.cal",
+#     outputvis="my_obs_field_SPT-0418_spw0.ms",
 #     keepmms=True,
 #     field="SPT-0418",
 #     spw="0",
-#     datacolumn="data",
-#     keepflags=True
+#     datacolumn="data",     # use "corrected" if CORRECTED_DATA exists
+#     keepflags=False,
 # )
 
 """
-Now each "name_spw.ms" will have the visibilities stored in an array shaped (2, n_c, n_v, 2). In order to reduce the 
-size of the visibilities we often average visibilities corresponding to different channels. 
+Repeat the `split` for each SPW you want to include (e.g. spw="1", "2", "3").
+If your `.ms` only has a single field and you want *all* SPWs in one file, you
+can omit the `spw` argument.
 
-We can use the CASA task "split", setting the argument width=<number of channels> (e.g. width=128), again for this 
-step (note, however, that different spws can have different number of channels)
+__Step 2 — Channel Averaging__
+
+ALMA observations often have thousands of channels per SPW, producing far more
+visibilities than PyAutoLens can comfortably model (the light-profile path tops
+out around ~10,000 visibilities; the pixelized source path scales to millions
+but is more advanced). For continuum-style lens modeling you typically average
+all channels in an SPW down to one (or a handful) by setting `width`.
+
+Note that `width` must not exceed the number of channels in the SPW — check with
+the `get_num_chan` helper below if unsure.
 """
 
+# CASA:
 # split(
-#     vis="name_spw_0.ms",
-#     outputvis="name_spw_0_chanaveraged.ms",
+#     vis="my_obs_field_SPT-0418_spw0.ms",
+#     outputvis="my_obs_field_SPT-0418_spw0_chanavg.ms",
 #     keepmms=True,
-#     field="SPT-0418",
-#     width=128,
+#     width=128,             # average 128 channels together
 #     datacolumn="data",
-#     keepflags=True
+#     keepflags=False,
 # )
 
 """
-To return the visibilities and uv_wavelengths (in units of wavelengths, NOT meters - which is the way they are 
-stored in the .ms) from each .ms directory that you created in the previous step use the following scripts (save 
-them in a .fits format):
-"""
-#
-# def getcol_wrapper(ms, table, colname):
-#
-#     if os.path.isdir(ms):
-#         tb.open(
-#             "{}/{}".format(ms, table)
-#         )
-#
-#         col = np.squeeze(
-#             tb.getcol(colname)
-#         )
-#
-#         tb.close()
-#     else:
-#         raise IOError(
-#             "{} does not exist".format(ms)
-#         )
-#
-#     return col
-#
-# def get_visibilities(ms):
-#
-#     if os.path.isdir(ms):
-#         data = getcol_wrapper(
-#             ms=ms,
-#             table="",
-#             colname="DATA"
-#         )
-#     else:
-#         raise IOError(
-#             "{} does not exisxt".format(ms)
-#         )
-#
-#     visibilities = np.stack(
-#         arrays=(data.real, data.imag),
-#         axis=-1
-#     )
-#
-#     return visibilities
-#
-#
-# def get_uv_wavelengths(ms):
-#
-#     def convert_array_to_wavelengths(array, frequency):
-#
-#         if astropy_is_imported:
-#             array_converted = (
-#                 (array * units.m) * (frequency * units.Hz) / constants.c
-#             ).decompose()
-#
-#             array_converted = array_converted.value
-#         else:
-#             factor = 3.3356409519815204e-09
-#             array_converted = array * frequency * factor
-#
-#         return array_converted
-#
-#     if os.path.isdir(ms):
-#         uvw = getcol_wrapper(
-#             ms=ms,
-#             table="",
-#             colname="UVW"
-#         )
-#     else:
-#         raise IOError(
-#             "{} does not exist".format(ms)
-#         )
-#
-#     chan_freq = getcol_wrapper(
-#         ms=ms,
-#         table="SPECTRAL_WINDOW",
-#         colname="CHAN_FREQ"
-#     )
-#
-#     chan_freq_shape = np.shape(chan_freq)
-#
-#     if np.shape(chan_freq):
-#
-#         u_wavelengths, v_wavelengths = np.zeros(
-#             shape=(
-#                 2,
-#                 chan_freq_shape[0],
-#                 uvw.shape[1]
-#             )
-#         )
-#
-#         for i in range(chan_freq_shape[0]):
-#             u_wavelengths[i, :] = convert_array_to_wavelengths(array=uvw[0, :], frequency=chan_freq[i])
-#             v_wavelengths[i, :] = convert_array_to_wavelengths(array=uvw[1, :], frequency=chan_freq[i])
-#
-#     else:
-#
-#         u_wavelengths = convert_array_to_wavelengths(array=uvw[0, :], frequency=chan_freq)
-#         v_wavelengths = convert_array_to_wavelengths(array=uvw[1, :], frequency=chan_freq)
-#
-#
-#     uv_wavelengths = np.stack(
-#         arrays=(u_wavelengths, v_wavelengths),
-#         axis=-1
-#     )
-#
-#     return uv_wavelengths
+__Step 3 — Continuum Subtraction (line observations only)__
 
+If you're modeling a **spectral line** (e.g. CO(9-8) from a high-z lensed galaxy),
+you want to remove the underlying continuum first using `uvcontsub`. Specify
+the line-free channel ranges via `fitspw` and the channels to keep via `spw`.
+Skip this step for pure continuum lens modeling.
 """
-Now we have the visibilities and uv_wavelengths arrays with shapes, (2, n_v, 2) and (n_v, 2), respectively. Note that 
-the same point in uv-space has 2 visibilities associated with it, corresponding to the two different polarisations. 
-You can further average the visibilities for the two polarisations "np.average(visibilities, axis=0)".
 
-Now back to where we started ... AutoLens requires you to create the object "interferometer":
-"""
-#
-# dataset = al.Interferometer(
-#     visibilities=,
-#     noise_map=,
-#     uv_wavelengths=,
-#     real_space_mask=,
-#     settings=al.SettingsInterferometer(
-#         transformer_class=al.TransformerNUFFT,
-#     ),
+# CASA:
+# uvcontsub(
+#     vis="my_obs_field_SPT-0418_spw0.ms",
+#     outputvis="my_obs_field_SPT-0418_spw0.ms.contsub",
+#     fitspw="0:10~200;800~1000",    # line-free channel ranges for the fit
+#     spw="0",                       # channels to keep in the output
+#     fitorder=1,
 # )
 
 """
-Assuming you have averaged the polarisations you can simply use:
+If you ran `uvcontsub`, use the resulting `.ms.contsub` file as input to Step 4
+and Step 5 instead of the original.
+
+__Step 4 — Rescale Sigmas with statwt__
+
+The `SIGMA` / `WEIGHT` columns that come out of ALMA calibration are often
+set to nominal values rather than reflecting the true scatter in the visibilities.
+`statwt` measures the scatter per-baseline and rescales SIGMA accordingly. This
+is **strongly recommended** before exporting the noise-map — without it, your
+per-visibility error bars will be wrong and the likelihood will be biased.
+
+`statwt` modifies the `.ms` in place, so copy it first if you want to keep the
+original SIGMAs for comparison.
 """
 
-# visibilities=al.Visibilities(visibilities[:, 0] + 1j * visibilities[:, 1])
-# uv_wavelengths=uv_wavelengths
-
-"""
-If not, and visibilities still have a shape (2, n_v, 2) then add the following lines before initialising the 
-interferometer object:
-"""
-
-# visibilities = visibilities.reshape(int(visibilities.shape[0] * visibilities.shape[1]), 2)
-# uv_wavelengths = np.concatenate((uv_wavelengths, uv_wavelengths), axis=0)
-# uv_wavelengths = uv_wavelengths.reshape(int(uv_wavelengths.shape[0] * uv_wavelengths.shape[1]), 2)
-
-"""
-**NOTE: You have visibilities from 4 spectral windows. Concatenate them in one single array**
-
-- Exporting SIGMA with CASA.
-
-The procedure to export the SIGMA using CASA is the same as the visibilities with ones extra step. By default the 
-SIGMA are computed in a relative way and they do not reflect the real scatter in the visibility data. 
-
-We can use the CASA task "statwt" to rescale the visibilities according to their scatter. Execute the following 
-command after you performed the first "split"
-"""
-#
+# CASA (from the shell / inside a CASA session):
+# import os
+# os.system("cp -r my_obs_field_SPT-0418_spw0_chanavg.ms "
+#           "my_obs_field_SPT-0418_spw0_chanavg.ms.statwt")
 # statwt(
-#     vis="name_spw_0.ms",
-#     datacolumn="data"
+#     vis="my_obs_field_SPT-0418_spw0_chanavg.ms.statwt",
+#     datacolumn="data",
 # )
 
 """
-Repeat the steps above, but use the following script to return the SIGMA
+__Step 5 — Export DATA / UVW / CHAN_FREQ / SIGMA to FITS__
+
+With the reduced `.ms` in hand we now read the relevant columns out with the
+CASA `tb` tool and save them as FITS files. The helpers below can be saved
+as a separate `.py` file and executed inside CASA via
+
+    casa -c export_to_fits.py
+
+or pasted directly into an interactive CASA session. They use the global `tb`
+object CASA injects, together with numpy and astropy.
 """
 
-# def get_sigma(ms):
-#
-#     sigma = getcol_wrapper(
-#         ms=ms,
-#         table="",
-#         colname="SIGMA"
-#     )
-#
-#     return sigma
+import os
+import numpy as np
+
+try:
+    from astropy import units, constants
+    from astropy.io import fits
+    astropy_is_imported = True
+except ImportError:
+    astropy_is_imported = False
+
+
+def getcol_wrapper(ms, table, colname):
+    """
+    Open a CASA Measurement Set sub-table and return a squeezed column.
+
+    Parameters
+    ----------
+    ms : str
+        Path to the .ms directory.
+    table : str
+        Sub-table name (e.g. "SPECTRAL_WINDOW", "DATA_DESCRIPTION"). Empty
+        string for the main table.
+    colname : str
+        Column name (e.g. "DATA", "UVW", "CHAN_FREQ", "SIGMA", "NUM_CHAN").
+
+    Returns
+    -------
+    np.ndarray
+        The requested column, with trivial dimensions removed.
+    """
+    if not os.path.isdir(ms):
+        raise IOError(f"{ms} does not exist")
+
+    tb.open(f"{ms}/{table}" if table else ms)  # noqa: F821 — `tb` is the CASA tool
+    col = np.squeeze(tb.getcol(colname))        # noqa: F821
+    tb.close()                                  # noqa: F821
+    return col
+
+
+def get_num_chan(ms):
+    """Number of channels per SPW (shape `(n_spw,)` or scalar)."""
+    return getcol_wrapper(ms=ms, table="SPECTRAL_WINDOW", colname="NUM_CHAN")
+
+
+def get_spw_ids(ms):
+    """SPW ids present in the main table (shape `(n_spw,)` or scalar)."""
+    return getcol_wrapper(ms=ms, table="DATA_DESCRIPTION", colname="SPECTRAL_WINDOW_ID")
+
+
+def get_frequencies(ms):
+    """Channel frequencies in Hz (shape `(n_chan,)` or `(n_chan, n_spw)`)."""
+    return getcol_wrapper(ms=ms, table="SPECTRAL_WINDOW", colname="CHAN_FREQ")
+
+
+def _write_array(filename, data):
+    """Write a numpy array as FITS if astropy is available, else `.npy`."""
+    if astropy_is_imported:
+        fits.writeto(filename=filename + ".fits", data=data, overwrite=True)
+    else:
+        with open(filename + ".numpy", "wb") as f:
+            np.save(f, data)
+
 
 """
-CASA assigns the same error to both the real and imag components of the visibilities, so the sigma array will 
-have a shape (2, n_v, ). Use, "sigma=np.stack(arrays=(sigma, sigma),axis=-1)".
+__Visibilities__
+
+The `DATA` column has complex dtype and shape `(n_pol, n_chan, n_vis)` for a
+single-SPW split. We stack the real and imaginary parts along a new trailing
+axis so downstream code can load them as a real-valued FITS image and
+recombine into a complex array via `vis[..., 0] + 1j * vis[..., 1]`.
 """
+
+
+def get_visibilities(ms):
+    data = getcol_wrapper(ms=ms, table="", colname="DATA")
+    return np.stack(arrays=(data.real, data.imag), axis=-1)
+
+
+def export_visibilities(ms, filename):
+    if os.path.isfile(filename + ".fits") or os.path.isfile(filename + ".numpy"):
+        print(f"{filename} already exists — skipping")
+        return
+    visibilities = get_visibilities(ms=ms)
+    print("shape (visibilities):", visibilities.shape)
+    _write_array(filename=filename, data=visibilities)
+
+
+"""
+__UV Wavelengths__
+
+`UVW` in CASA is stored in **metres**, with shape `(3, n_vis)`. PyAutoLens
+needs `(u, v)` in **wavelengths**, so we multiply by `frequency / c` for each
+channel. This produces a `(2, n_chan, n_vis)` array of u, v wavelengths, which
+is later reshaped to `(n_vis_total, 2)` once you flatten over channels.
+"""
+
+
+def convert_array_to_wavelengths(array, frequency):
+    if astropy_is_imported:
+        return (
+            (array * units.m) * (frequency * units.Hz) / constants.c
+        ).decompose().value
+    return array * frequency / 299792458.0
+
+
+def get_uv_wavelengths(ms):
+    uvw = getcol_wrapper(ms=ms, table="", colname="UVW")
+    chan_freq = get_frequencies(ms=ms)
+
+    if np.shape(chan_freq):
+        n_chan = np.shape(chan_freq)[0]
+        u_wavelengths = np.zeros((n_chan, uvw.shape[1]))
+        v_wavelengths = np.zeros((n_chan, uvw.shape[1]))
+        for i in range(n_chan):
+            u_wavelengths[i] = convert_array_to_wavelengths(uvw[0], chan_freq[i])
+            v_wavelengths[i] = convert_array_to_wavelengths(uvw[1], chan_freq[i])
+    else:
+        u_wavelengths = convert_array_to_wavelengths(uvw[0], chan_freq)
+        v_wavelengths = convert_array_to_wavelengths(uvw[1], chan_freq)
+
+    return np.stack(arrays=(u_wavelengths, v_wavelengths), axis=-1)
+
+
+def export_uv_wavelengths(ms, filename):
+    if os.path.isfile(filename + ".fits") or os.path.isfile(filename + ".numpy"):
+        print(f"{filename} already exists — skipping")
+        return
+    uv_wavelengths = get_uv_wavelengths(ms=ms)
+    print("shape (uv_wavelengths):", uv_wavelengths.shape)
+    _write_array(filename=filename, data=uv_wavelengths)
+
+
+"""
+__Sigma (Noise Map)__
+
+The `SIGMA` column in CASA has shape `(n_pol, n_vis)` — one value per polarisation
+per visibility — and CASA assigns the *same* sigma to the real and imaginary
+components. We broadcast it across the channel axis and duplicate the last
+axis so the final shape matches the visibilities: `(n_pol, n_chan, n_vis, 2)`.
+
+For this to be meaningful you **must** have run `statwt` first, otherwise the
+sigmas are nominal placeholders rather than real scatter estimates.
+"""
+
+
+def get_sigma(ms):
+    sigma = getcol_wrapper(ms=ms, table="", colname="SIGMA")
+    chan_freq = np.atleast_1d(get_frequencies(ms=ms))
+    n_chan = chan_freq.shape[0]
+
+    # Re-introduce the polarisation axis if np.squeeze removed it (n_pol == 1).
+    if sigma.ndim == 1:
+        sigma = sigma[np.newaxis, :]
+
+    sigma = np.tile(sigma[:, np.newaxis, :], (1, n_chan, 1))
+    return np.stack(arrays=(sigma, sigma), axis=-1)
+
+
+def export_sigma(ms, filename):
+    if os.path.isfile(filename + ".fits") or os.path.isfile(filename + ".numpy"):
+        print(f"{filename} already exists — skipping")
+        return
+    sigma = get_sigma(ms=ms)
+    print("shape (sigma):", sigma.shape)
+    _write_array(filename=filename, data=sigma)
+
+
+"""
+__Polarisations (do this FIRST)__
+
+Raw ALMA data has two polarisations (XX, YY) on axis 0 of `DATA` and `SIGMA`.
+For lens modeling the standard approach is to average the two into a single
+complex visibility with combined sigma, since the source emission is not
+polarised for the vast majority of lensed galaxies. **Do this before
+flattening channels or concatenating SPWs**, otherwise the polarisations end
+up interleaved with the channel axis and the noise-map no longer corresponds
+to the visibility it was measured from.
+
+    # vis: (n_pol, n_chan, n_vis, 2) — real/imag on last axis
+    vis_avg = 0.5 * (vis[0] + vis[1])                      # -> (n_chan, n_vis, 2)
+
+    # sig: (n_pol, n_chan, n_vis, 2) — sigma_real/sigma_imag on last axis
+    sig_avg = 0.5 * np.sqrt(sig[0] ** 2 + sig[1] ** 2)     # -> (n_chan, n_vis, 2)
+
+If your science *does* care about polarisation, keep each pol as a separate
+dataset and fit them jointly — contact us on Slack for the current state of
+joint-polarisation modeling.
+
+__Combining Spectral Windows__
+
+Once you have per-SPW pol-averaged arrays, flatten channels into the n_vis
+axis and concatenate across SPWs. All three arrays (visibilities, sigma,
+uv-wavelengths) use the same ordering so they stay aligned.
+
+    # Per-SPW (pol-averaged) shapes:
+    #   vis_avg  : (n_chan_spw, n_vis_spw, 2)
+    #   sig_avg  : (n_chan_spw, n_vis_spw, 2)
+    #   uv       : (n_chan_spw, n_vis_spw, 2)
+
+    vis_all = np.concatenate(
+        [v.reshape(-1, 2) for v in per_spw_vis], axis=0
+    )
+    sig_all = np.concatenate(
+        [s.reshape(-1, 2) for s in per_spw_sig], axis=0
+    )
+    uv_all = np.concatenate(
+        [u.reshape(-1, 2) for u in per_spw_uv], axis=0
+    )
+
+After this step all three arrays have shape `(n_vis_total, 2)` — exactly
+what `al.Interferometer.from_fits` expects.
+
+__Building the Interferometer Object__
+
+Write the three concatenated arrays to FITS (using `astropy.io.fits.writeto`
+or `autoconf.fitsable.output_to_fits`) and load them via the canonical
+workspace pattern used in `start_here.py`:
+
+    import autolens as al
+
+    # Small, fast real-space mask — keep shape_native and radius modest while
+    # you are iterating on the reduction. Increase later for production fits.
+    real_space_mask = al.Mask2D.circular(
+        shape_native=(64, 64),
+        pixel_scales=0.05,
+        radius=1.5,
+    )
+
+    dataset = al.Interferometer.from_fits(
+        data_path="data.fits",
+        noise_map_path="noise_map.fits",
+        uv_wavelengths_path="uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerNUFFT,   # NUFFT scales to large n_vis
+    )
+
+The 64x64 / 0.05" mask above keeps the Fourier transform and any dirty-image
+sanity plots fast while you iterate — a first-pass check of your reduction
+should finish in seconds, not minutes. Bump `shape_native` up (e.g. 256x256)
+and drop `pixel_scales` (e.g. 0.02") for the real modeling run. Choosing
+these numbers sensibly for your instrument is covered in
+`scripts/interferometer/data_preparation.py`.
+
+__Troubleshooting__
+
+- **`uv_wavelengths` values look way too big/small** — you forgot the
+  metres → wavelengths conversion, or you used the wrong frequency column.
+- **Dirty image is offset / upside-down** — the `(u, v)` sign convention or
+  the `(y, x)` axis order may disagree with your real-space mask. Plot the
+  dirty image with `aplt.subplot_interferometer_dirty_images` as a sanity
+  check.
+- **Sigmas produce a flat chi-squared map** — you probably forgot `statwt`.
+- **n_vis is enormous** — use a larger `width` in `split`, or switch from
+  `TransformerDFT` to `TransformerNUFFT` (and the pixelized source workflow
+  if n_vis > 10,000).
+- **Only one polarisation present** — if CASA has flagged one pol the
+  averaging code above will produce NaNs. Check with `get_visibilities`
+  and branch accordingly.
+
+__SLACK__
+
+These scripts are a starting point, not a polished pipeline. If your
+observation has mosaicking, heterogeneous SPWs, unusual correlators, or you
+just can't get the numbers to line up — ping us on the PyAutoLens Slack.
+Direct user feedback is actively shaping this workflow and we're happy to
+help debug real datasets.
+
+__Running as a Script__
+
+The block below is illustrative — edit the paths/widths for your own reduction
+and run inside CASA with `casa -c scripts/interferometer/casa_reduction.py`.
+It assumes you have already run `split`, `uvcontsub` (optional) and `statwt`
+by hand on the `.ms`.
+"""
+
+if __name__ == "__main__":
+
+    uid = "my_obs_field_SPT-0418"
+    width = 128
+
+    ms_chanavg = f"{uid}_spw0_chanavg.ms"
+    ms_statwt = f"{ms_chanavg}.statwt"
+
+    export_uv_wavelengths(ms=ms_chanavg, filename=f"uv_wavelengths_{uid}_width_{width}")
+    export_visibilities(ms=ms_chanavg, filename=f"visibilities_{uid}_width_{width}")
+    export_sigma(ms=ms_statwt, filename=f"sigma_{uid}_width_{width}_statwt")


### PR DESCRIPTION
## Summary

Rewrites `scripts/interferometer/casa_reduction.py` from an incomplete stub
into a coherent walkthrough of how to go from a CASA-calibrated ALMA `.ms`
to the three FITS files consumed by `al.Interferometer.from_fits`. Intended
as a **starting point** for Slack back-and-forth with interferometer users
— not a polished pipeline.

## Scripts Changed
- `scripts/interferometer/casa_reduction.py` — full rewrite. Covers: PyAutoLens
  input requirements (shapes, units), the 5-step CASA pipeline (split →
  channel avg → optional uvcontsub → statwt → FITS export), Python helpers
  pulled from a working ALMA user script (`get_visibilities`,
  `get_uv_wavelengths`, `get_sigma`, `export_*`), polarisation-averaging and
  SPW concatenation ordering, the canonical `al.Interferometer.from_fits`
  load pattern with a small fast real-space mask (64×64, 0.05"/px) for
  iteration plus guidance on scaling up for production fits, and a
  troubleshooting / Slack pointer section.

## Notes
- The notebook `notebooks/interferometer/casa_reduction.ipynb` is stale
  and should be regenerated via `/generate_and_merge` in a follow-up.
- Script cannot be executed outside a CASA session (depends on CASA's
  `tb` global); syntax-parse verified.

## Test Plan
- [x] ast.parse passes on the rewritten script
- [ ] Slack review by interferometer users

🤖 Generated with [Claude Code](https://claude.com/claude-code)