### PR TITLE
Remove PySwarms and UltraNest references

### DIFF
--- a/CITATIONS.rst
+++ b/CITATIONS.rst
@@ -14,7 +14,7 @@ entry in the above .bib file is under the citation key ``pyautolens``. Please al
 papers (https://academic.oup.com/mnras/article/452/3/2940/1749640 and https://academic.oup.com/mnras/article-abstract/478/4/4738/5001434?redirectedFrom=fulltext) which are included
 under the citation keys ``Nightingale2015`` and ``Nightingale2018``.
 
-You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, PySwarms, etc) in
+You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, etc) in
 the main body of text, and delete as appropriate any packages your analysis did not use. The citations.bib file includes
 the citation key for all of these projects.
 

--- a/config/non_linear/README.rst
+++ b/config/non_linear/README.rst
@@ -6,4 +6,4 @@ Files
 
 - ``mcmc.yaml``: Settings default behaviour of MCMC non-linear searches (e.g. Emcee).
 - ``nest.yaml``: Settings default behaviour of nested sampler non-linear searches (e.g. Dynesty).
-- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. PySwarms).
+- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. LBFGS).


### PR DESCRIPTION
## Summary
- Remove PySwarms and UltraNest references — these searches are no longer supported in PyAutoFit
- Strip scripts, notebooks, READMEs, config entries, tutorial prose, and citation lines that pointed users at broken examples
- The developer workspace is untouched (it intentionally preserves the legacy implementations)

## Test plan
- [ ] Grep sweep returns 0 hits for `pyswarm|ultranest` outside generated logs and `autofit_workspace_developer`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)