### PR TITLE
Add CSV I/O examples to point-source workspace scripts

### DIFF
--- a/notebooks/cluster/modeling.ipynb
+++ b/notebooks/cluster/modeling.ipynb
@@ -184,8 +184,29 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "We can print this dictionary to see the dataset's `name` and `positions` and noise-map values."
+        "__CSV Loading__\n",
+        "\n",
+        "The ``dataset_list`` above is equivalent to a single CSV loaded in one call.  If the\n",
+        "simulator also wrote ``point_datasets.csv`` (see ``cluster/simulator.py``), the same\n",
+        "``dataset_list`` can be recovered with::\n",
+        "\n",
+        "    dataset_list = al.list_from_csv(file_path=dataset_path / \"point_datasets.csv\")\n",
+        "\n",
+        "This is the recommended form for hand-edited cluster datasets with tens of sources."
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "\n",
+        "# %%\n",
+        "'''\n",
+        "We can print this dictionary to see the dataset's `name` and `positions` and noise-map values.\n",
+        "'''"
+      ],
+      "outputs": [],
+      "execution_count": null
     },
     {
       "cell_type": "code",

--- a/notebooks/cluster/simulator.ipynb
+++ b/notebooks/cluster/simulator.ipynb
@@ -512,6 +512,29 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "__CSV Output__\n",
+        "\n",
+        "For cluster-scale workflows with tens or hundreds of sources, a single CSV with one row\n",
+        "per observed image \u2014 grouped by ``name`` \u2014 is often easier to edit in a spreadsheet than\n",
+        "many per-source JSON files.  ``al.output_to_csv`` writes all datasets into one file."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "al.output_to_csv(\n",
+        "    datasets=dataset_list,\n",
+        "    file_path=dataset_path / \"point_datasets.csv\",\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "__Visualize__\n",
         "\n",
         "Output a subplot of the simulated point source dataset as a .png file."

--- a/notebooks/point_source/features/double_einstein_cross/simulator.ipynb
+++ b/notebooks/point_source/features/double_einstein_cross/simulator.ipynb
@@ -362,6 +362,28 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "__CSV Output__\n",
+        "\n",
+        "Both datasets can also be saved to a single CSV \u2014 one row per observed image grouped by\n",
+        "``name`` \u2014 as the hand-editable spreadsheet format alternative to per-source JSON."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "al.output_to_csv(\n",
+        "    datasets=[dataset_0, dataset_1],\n",
+        "    file_path=dataset_path / \"point_datasets.csv\",\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "__Visualize__\n",
         "\n",
         "Output a subplot of the simulated point source dictionary and the tracer's quantities to the dataset path as .png files."

--- a/notebooks/point_source/simulator.ipynb
+++ b/notebooks/point_source/simulator.ipynb
@@ -314,6 +314,29 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "__CSV Output__\n",
+        "\n",
+        "In addition to JSON, a point dataset can be written to a CSV file.  CSV is a hand-editable,\n",
+        "spreadsheet-friendly format that becomes especially convenient for cluster-scale datasets\n",
+        "with tens of sources where a single file with one row per observed image is easier to curate\n",
+        "than many per-source JSON files."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "dataset.to_csv(\n",
+        "    file_path=dataset_path / \"point_dataset_positions_only.csv\",\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "__Visualize__\n",
         "\n",
         "Output a subplot of the simulated point source dataset as a .png file."
@@ -724,6 +747,27 @@
         "al.output_to_json(\n",
         "    obj=dataset,\n",
         "    file_path=dataset_path / \"point_dataset_with_fluxes_and_time_delays.json\",\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "__CSV Output__\n",
+        "\n",
+        "The full-column dataset (positions, fluxes and time delays) can also be saved to CSV\n",
+        "as the spreadsheet-friendly counterpart to the JSON above."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "dataset.to_csv(\n",
+        "    file_path=dataset_path / \"point_dataset_with_fluxes_and_time_delays.csv\",\n",
         ")"
       ],
       "outputs": [],

--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -135,6 +135,18 @@ for i in range(5):
     dataset_list.append(dataset)
 
 """
+__CSV Loading__
+
+The ``dataset_list`` above is equivalent to a single CSV loaded in one call.  If the
+simulator also wrote ``point_datasets.csv`` (see ``cluster/simulator.py``), the same
+``dataset_list`` can be recovered with::
+
+    dataset_list = al.list_from_csv(file_path=dataset_path / "point_datasets.csv")
+
+This is the recommended form for hand-edited cluster datasets with tens of sources.
+"""
+
+"""
 We can print this dictionary to see the dataset's `name` and `positions` and noise-map values.
 """
 for dataset in dataset_list:

--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -353,6 +353,18 @@ for i, dataset in enumerate(dataset_list):
     )
 
 """
+__CSV Output__
+
+For cluster-scale workflows with tens or hundreds of sources, a single CSV with one row
+per observed image — grouped by ``name`` — is often easier to edit in a spreadsheet than
+many per-source JSON files.  ``al.output_to_csv`` writes all datasets into one file.
+"""
+al.output_to_csv(
+    datasets=dataset_list,
+    file_path=dataset_path / "point_datasets.csv",
+)
+
+"""
 __Visualize__
 
 Output a subplot of the simulated point source dataset as a .png file.

--- a/scripts/point_source/features/double_einstein_cross/simulator.py
+++ b/scripts/point_source/features/double_einstein_cross/simulator.py
@@ -226,6 +226,17 @@ al.output_to_json(
 )
 
 """
+__CSV Output__
+
+Both datasets can also be saved to a single CSV — one row per observed image grouped by
+``name`` — as the hand-editable spreadsheet format alternative to per-source JSON.
+"""
+al.output_to_csv(
+    datasets=[dataset_0, dataset_1],
+    file_path=dataset_path / "point_datasets.csv",
+)
+
+"""
 __Visualize__
 
 Output a subplot of the simulated point source dictionary and the tracer's quantities to the dataset path as .png files.

--- a/scripts/point_source/simulator.py
+++ b/scripts/point_source/simulator.py
@@ -199,6 +199,18 @@ al.output_to_json(
 )
 
 """
+__CSV Output__
+
+In addition to JSON, a point dataset can be written to a CSV file.  CSV is a hand-editable,
+spreadsheet-friendly format that becomes especially convenient for cluster-scale datasets
+with tens of sources where a single file with one row per observed image is easier to curate
+than many per-source JSON files.
+"""
+dataset.to_csv(
+    file_path=dataset_path / "point_dataset_positions_only.csv",
+)
+
+"""
 __Visualize__
 
 Output a subplot of the simulated point source dataset as a .png file.
@@ -439,6 +451,16 @@ dataset = al.PointDataset(
 al.output_to_json(
     obj=dataset,
     file_path=dataset_path / "point_dataset_with_fluxes_and_time_delays.json",
+)
+
+"""
+__CSV Output__
+
+The full-column dataset (positions, fluxes and time delays) can also be saved to CSV
+as the spreadsheet-friendly counterpart to the JSON above.
+"""
+dataset.to_csv(
+    file_path=dataset_path / "point_dataset_with_fluxes_and_time_delays.csv",
 )
 
 """


### PR DESCRIPTION
## Summary

- Adds `to_csv` calls after the JSON writes in `point_source/simulator.py` (positions-only and full-feature), `cluster/simulator.py`, and `point_source/features/double_einstein_cross/simulator.py`
- Adds a docstring-only `al.list_from_csv` placeholder after the per-source JSON load loop in `cluster/modeling.py`
- Surfaces the public `al.output_to_csv` / `al.list_from_csv` / `PointDataset.to_csv` API (shipped in PyAutoConf #95 + PyAutoLens #455) in the tutorial tree alongside JSON
- JSON remains the canonical round-trip format; CSV is a parallel hand-editable output aimed at cluster-scale datasets

## Test plan

- [x] `py_compile` all 4 modified scripts
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1 python scripts/point_source/simulator.py` — both CSVs land under `dataset/point_source/simple/`
- [x] Round-trip `al.PointDataset.from_csv` on both generated CSVs (positions-only and full-feature)
- [ ] `cluster/simulator.py` and `double_einstein_cross/simulator.py` have pre-existing runtime issues on main (covered by py_compile only, per plan)
- [x] Notebooks regenerated via `PyAutoBuild/autobuild/generate.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)