### PR TITLE
refactor: drop xp=jnp from PointSolver.for_grid call sites

### DIFF
--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -75,7 +75,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 # from autoconf import setup_notebook; setup_notebook()
 
-import jax.numpy as jnp
 import numpy as np
 from pathlib import Path
 import autofit as af
@@ -248,7 +247,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """

--- a/scripts/guides/modeling/advanced/graphical.py
+++ b/scripts/guides/modeling/advanced/graphical.py
@@ -50,7 +50,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 # from autoconf import setup_notebook; setup_notebook()
 
 import numpy as np
-import jax.numpy as jnp
 from pathlib import Path
 import autolens as al
 import autofit as af
@@ -109,7 +108,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """

--- a/scripts/point_source/features/fluxes.py
+++ b/scripts/point_source/features/fluxes.py
@@ -44,7 +44,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 # from autoconf import setup_notebook; setup_notebook()
 
-import jax.numpy as jnp
 from pathlib import Path
 import autofit as af
 import autolens as al
@@ -117,7 +116,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """

--- a/scripts/point_source/features/time_delays.py
+++ b/scripts/point_source/features/time_delays.py
@@ -45,7 +45,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 # from autoconf import setup_notebook; setup_notebook()
 
-import jax.numpy as jnp
 from pathlib import Path
 import autofit as af
 import autolens as al
@@ -121,7 +120,6 @@ solver = al.PointSolver.for_grid(
     grid=grid,
     pixel_scale_precision=0.001,
     magnification_threshold=0.1,
-    xp=jnp,
 )
 
 """

--- a/scripts/point_source/modeling.py
+++ b/scripts/point_source/modeling.py
@@ -56,7 +56,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 # from autoconf import setup_notebook; setup_notebook()
 
-import jax.numpy as jnp
 from pathlib import Path
 import autofit as af
 import autolens as al
@@ -327,18 +326,9 @@ JAX will still provide a speed up via multithreading, with fits taking around 20
 
 If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
 """
-# Hacky way to use JAX PointSolver, fix soon
-
-solver_jax = al.PointSolver.for_grid(
-    grid=grid,
-    pixel_scale_precision=0.001,
-    magnification_threshold=0.1,
-    xp=jnp,
-)
-
 analysis = al.AnalysisPoint(
     dataset=dataset,
-    solver=solver_jax,
+    solver=solver,
     fit_positions_cls=al.FitPositionsImagePairRepeat,  # Image-plane chi-squared with repeat image pairs.
     use_jax=True,  # JAX will use GPUs for acceleration if available, else JAX will use multithreaded CPUs.
 )

--- a/scripts/point_source/start_here.py
+++ b/scripts/point_source/start_here.py
@@ -88,7 +88,6 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 # from autoconf import setup_notebook; setup_notebook()
 
-import jax.numpy as jnp
 import numpy as np
 from pathlib import Path
 
@@ -190,7 +189,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """
@@ -265,18 +264,9 @@ search = af.Nautilus(
     iterations_per_quick_update=250000,  # Every N iterations the max likelihood model is visualized and written to output folder.
 )
 
-# Hacky way to use JAX PointSolver, fix soon
-
-solver_jax = al.PointSolver.for_grid(
-    grid=grid,
-    pixel_scale_precision=0.001,
-    magnification_threshold=0.1,
-    xp=jnp,
-)
-
 analysis = al.AnalysisPoint(
     dataset=dataset,
-    solver=solver_jax,
+    solver=solver,
     use_jax=True,  # JAX will use GPUs for acceleration if available, else JAX will use multithreaded CPUs.
 )
 


### PR DESCRIPTION
## Summary

Migrates all `PointSolver.for_grid(xp=jnp)` call sites after the ergonomic refactor in PyAutoLabs/PyAutoLens#469. With the library change, a single solver works for both numpy and JAX paths; the "Hacky way to use JAX PointSolver, fix soon" dual-solver workaround is no longer needed.

## Scripts Changed
- `scripts/cluster/modeling.py` — drop `xp=jnp` from `PointSolver.for_grid`, remove unused `jnp` import
- `scripts/guides/modeling/advanced/graphical.py` — drop `xp=jnp` from `PointSolver.for_grid`, remove unused `jnp` import
- `scripts/point_source/features/fluxes.py` — drop `xp=jnp` from `PointSolver.for_grid`, remove unused `jnp` import
- `scripts/point_source/features/time_delays.py` — drop `xp=jnp` from `PointSolver.for_grid`, remove unused `jnp` import
- `scripts/point_source/modeling.py` — remove dual-solver "Hacky way to use JAX PointSolver" block; `AnalysisPoint(use_jax=True)` now reuses the single `solver`
- `scripts/point_source/start_here.py` — remove dual-solver block as above

## Upstream PR
https://github.com/PyAutoLabs/PyAutoLens/pull/469

## Test Plan
- [ ] Smoke tests pass for affected point-source scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)