### PR TITLE
Add version.python_version_check toggle to general.yaml

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -48,3 +48,5 @@ test:
   check_likelihood_function: true   # if True, when a search is resumed the likelihood of a previous sample is recalculated to ensure it is consistent with the previous run.
   lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   disable_positions_lh_inversion_check: true
+version:
+  python_version_check: True        # If False, bypass the PyAutoConf Python 3.12+ recommendation (3.9/3.10/3.11 technically work but are not officially supported).


### PR DESCRIPTION
## Summary

- Adds a new top-level `version:` section to `config/general.yaml` with `python_version_check: True` as the shipped default.
- Setting it to `False` bypasses the PyAutoConf Python 3.12+ recommendation for workspaces run on Python 3.9/3.10/3.11 — useful for the PyAutoGPU venv (still on 3.10) and any other older-Python environments where the code actually runs fine.

## Why

Paired with the PyAutoConf change that replaces the hard `RuntimeError` with a config-driven bypass. Shipping the key defaulted to `True` keeps the current behaviour for users who don't touch anything, and gives users on older Pythons a single-line flip to proceed.

## Paired PR

- PyAutoConf: PyAutoLabs/PyAutoConf#96 — must land before this one for the bypass to have a consumer.

## Scripts Changed

None — this is a config-only change. The key is read at `import autoconf` time by the paired library PR; nothing in `scripts/` touches the value directly.

## Test plan

- [x] On PyAutoGPU (Python 3.10): default `True` → `import autoconf` raises the new message pointing at this YAML snippet
- [x] On PyAutoGPU (Python 3.10): flip to `False` → `scripts/imaging/modeling.py` with `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_* PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` runs past imports into model-fitting (model tree, priors, fit start)
- [ ] Merge order: PyAutoConf#96 first, then this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)