### PR TITLE
Cluster simulator fixes + no_lens_light positions output

### DIFF
--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -23,7 +23,7 @@ __Contents__
 **Galaxy Centres:** Define the centres of the main lens galaxies and sources; used for over-sampling and JSON output.
 **Over Sampling:** Adaptive over-sampling grid for accurate light profile evaluation near galaxy centres.
 **Main Lens Galaxies:** The 5 cluster member galaxies — each has a `SersicSph` light profile and a `dPIEMassSph` mass.
-**Host Dark Matter Halo:** A standalone `NFWMCRLudlowSph` halo with `mass_at_200 = 10^14.5` at z=0.5.
+**Host Dark Matter Halo:** A standalone `NFWMCRLudlowSph` halo with `mass_at_200 = 10^15.3` at z=0.5.
 **Source Galaxies:** The 2 background sources at the same redshift, each a `SersicCore` light + a `Point` model.
 **Ray Tracing:** Combine all galaxies into a single `Tracer`.
 **Point Solver:** Solve for image-plane multiple-image positions of each source.
@@ -155,13 +155,6 @@ over_sample_size = al.util.over_sample.over_sample_size_via_radial_bins_from(
 )
 
 grid = grid.apply_over_sampling(over_sample_size=over_sample_size)
-
-"""
-Simulate a simple Gaussian PSF for the image.
-"""
-psf = al.Convolver.from_gaussian(
-    shape_native=(11, 11), sigma=0.1, pixel_scales=grid.pixel_scales
-)
 
 """
 __Main Lens Galaxies__
@@ -389,6 +382,10 @@ imaging_grid = al.Grid2D.uniform(
         radial_list=[0.3, 0.6],
         centre_list=main_lens_centres,
     )
+)
+
+psf = al.Convolver.from_gaussian(
+    shape_native=(11, 11), sigma=0.1, pixel_scales=imaging_grid.pixel_scales
 )
 
 simulator = al.SimulatorImaging(

--- a/scripts/imaging/features/no_lens_light/simulator.py
+++ b/scripts/imaging/features/no_lens_light/simulator.py
@@ -174,5 +174,36 @@ al.output_to_json(
 )
 
 """
+__Multiple Images__
+
+Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x) 
+coordinates of multiple images of a source galaxy to positions which are far apart from one another 
+in the source plane are penalized in the lens model's overall likelihood.
+
+This speeds up lens modeling, helps the non-linear search avoid local maxima and is vital for inferred 
+accurate solutions when using pixelized source reconstructions.
+
+For real data, the multiple image positions are determined by eye from the data, for example
+using a Graphical User Interface (GUI) to mark them with mouse clicks. For simulated data, we can save
+ourselves time by using the `PointSolver` to determine the multiple image positions automatically and
+output to a .json file.
+
+If you have not looked in the `point_source` package, the point solver is the core tool used to find
+multiple image positions for point source lens modeling (e.g. lensed quasars).
+"""
+solver = al.PointSolver.for_grid(
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
+)
+
+positions = solver.solve(
+    tracer=tracer, source_plane_coordinate=source_galaxy.bulge.centre
+)
+
+al.output_to_json(
+    file_path=dataset_path / "positions.json",
+    obj=positions,
+)
+
+"""
 The dataset can be viewed in the folder `autolens_workspace/imaging/simple__no_lens_light`.
 """

--- a/scripts/imaging/features/pixelization/delaunay.py
+++ b/scripts/imaging/features/pixelization/delaunay.py
@@ -123,18 +123,6 @@ if not dataset_path.exists():
         check=True,
     )
 
-if not (dataset_path / "positions.json").exists():
-    import subprocess
-    import sys
-
-    subprocess.run(
-        [
-            sys.executable,
-            "scripts/imaging/data_preparation/examples/optional/positions.py",
-        ],
-        check=True,
-    )
-
 dataset = al.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",


### PR DESCRIPTION
## Summary

Three unrelated workspace fixes bundled together:

**Cluster simulator (`scripts/cluster/simulator.py`)**
- PSF was built with `pixel_scales=grid.pixel_scales` (0.2") but the imaging was simulated on `imaging_grid` with `pixel_scales=0.1"` — the PSF scale did not match the imaging it was convolved with. Move the PSF construction next to the `imaging_grid` definition and key it off `imaging_grid.pixel_scales` so the two stay in lockstep.
- Fix the `__Contents__` summary line, which listed `mass_at_200 = 10^14.5` while the code and the `__NFWMCRLudlow Host Halo__` section both use `10^15.3`.

**no_lens_light simulator (`scripts/imaging/features/no_lens_light/simulator.py`)**
- Run `PointSolver` on the tracer and write `positions.json` alongside the other dataset outputs.

**Delaunay pixelization example (`scripts/imaging/features/pixelization/delaunay.py`)**
- Remove the subprocess fallback that regenerated `positions.json` via `scripts/imaging/data_preparation/examples/optional/positions.py` — `no_lens_light/simulator.py` now produces positions directly.

## Scripts Changed

- `scripts/cluster/simulator.py` — PSF pixel_scales + docstring
- `scripts/imaging/features/no_lens_light/simulator.py` — emit `positions.json`
- `scripts/imaging/features/pixelization/delaunay.py` — drop subprocess fallback

## Companion PR

Depends on the companion library fix: PyAutoLabs/PyAutoLens#471 (short-circuits `set_snr_of_snr_light_profiles` when no SNR profiles are present, which was hanging the cluster simulator before any of these workspace edits could be exercised end-to-end).

## Test plan

- [x] `scripts/cluster/simulator.py` — runs past the previously-hanging `set_snr_of_snr_light_profiles` call, writes `data.fits`, `noise_map.fits`, `psf.fits`, `point_dataset_*.json`, `point_datasets.csv`, `tracer.json`, centre JSON files. (Final visualization step is slow on the 500×500 over-sampled grid, pre-existing, out of scope here.)
- [ ] `scripts/imaging/features/no_lens_light/simulator.py` — run and confirm `positions.json` appears.
- [ ] `scripts/imaging/features/pixelization/delaunay.py` — run with the positions file already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)