### PR TITLE
docs: update stale admin_jammy/prompt/ refs to PyAutoPrompt/

### DIFF
--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -549,7 +549,7 @@ Output .png plots of the simulated dataset, the tracer, and the per-source point
 
 These use the default galaxy-scale plotters and are known to be suboptimal for cluster-scale systems —
 arcs span a much larger field, per-source images benefit from distinct colours, and multi-source overlays
-are useful. A follow-up prompt (`admin_jammy/prompt/cluster/1_visualization.md`) addresses these
+are useful. A follow-up prompt (`PyAutoPrompt/cluster/1_visualization.md`) addresses these
 visualization requirements.
 """
 for i, pd in enumerate(dataset_list):


### PR DESCRIPTION
## Summary

The PyAuto prompt registry was moved from `admin_jammy/prompt/` to `PyAutoPrompt/` on 2026-04-27. This PR updates stale comment / docstring / YAML / Markdown references in this repo to point at the new location.

## Files Changed

- `scripts/cluster/simulator.py` — module docstring ref to the cluster-visualization follow-up prompt updated

## Test Plan

- [x] Pure text-substitution edits — comments, docstrings, YAML comments, Markdown text only
- [x] Zero runtime behavior change; no executable code paths modified
- [N/A] Smoke tests skipped — not justified for comment-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)