### PR TITLE
fix: drop PYAUTO_SMALL_DATASETS workaround in group simulators

### DIFF
--- a/scripts/group/features/multi_gaussian_expansion/simulator.py
+++ b/scripts/group/features/multi_gaussian_expansion/simulator.py
@@ -226,10 +226,6 @@ if al.util.dataset.should_simulate(str(dataset_path)):
 
     Solve for the lensed positions of the source galaxy.
     """
-    import os
-
-    small_datasets = os.environ.pop("PYAUTO_SMALL_DATASETS", None)
-
     solver = al.PointSolver.for_grid(
         grid=al.Grid2D.uniform(shape_native=(500, 500), pixel_scales=0.1),
         pixel_scale_precision=0.001,
@@ -239,9 +235,6 @@ if al.util.dataset.should_simulate(str(dataset_path)):
     positions = solver.solve(
         tracer=tracer, source_plane_coordinate=source_galaxy.bulge.centre
     )
-
-    if small_datasets is not None:
-        os.environ["PYAUTO_SMALL_DATASETS"] = small_datasets
 
     al.output_to_json(
         obj=positions,

--- a/scripts/group/features/no_lens_light/simulator.py
+++ b/scripts/group/features/no_lens_light/simulator.py
@@ -254,10 +254,6 @@ __Positions__
 Solve for the lensed positions of the source galaxy, which are used as input for the group
 modeling scripts (e.g. SLaM pipeline) to help the non-linear search converge.
 """
-import os
-
-small_datasets = os.environ.pop("PYAUTO_SMALL_DATASETS", None)
-
 solver = al.PointSolver.for_grid(
     grid=al.Grid2D.uniform(shape_native=(500, 500), pixel_scales=0.1),
     pixel_scale_precision=0.001,
@@ -267,9 +263,6 @@ solver = al.PointSolver.for_grid(
 positions = solver.solve(
     tracer=tracer, source_plane_coordinate=source_galaxy.bulge.centre
 )
-
-if small_datasets is not None:
-    os.environ["PYAUTO_SMALL_DATASETS"] = small_datasets
 
 al.output_to_json(
     obj=positions,

--- a/scripts/group/simulator.py
+++ b/scripts/group/simulator.py
@@ -291,10 +291,6 @@ __Positions__
 Solve for the lensed positions of the source galaxy, which are used as input for the group
 modeling scripts (e.g. SLaM pipeline) to help the non-linear search converge.
 """
-import os
-
-small_datasets = os.environ.pop("PYAUTO_SMALL_DATASETS", None)
-
 solver = al.PointSolver.for_grid(
     grid=al.Grid2D.uniform(shape_native=(500, 500), pixel_scales=0.1),
     pixel_scale_precision=0.001,
@@ -304,9 +300,6 @@ solver = al.PointSolver.for_grid(
 positions = solver.solve(
     tracer=tracer, source_plane_coordinate=source_galaxy.bulge.centre
 )
-
-if small_datasets is not None:
-    os.environ["PYAUTO_SMALL_DATASETS"] = small_datasets
 
 al.output_to_json(
     obj=positions,


### PR DESCRIPTION
## Summary

Now that `PointSolver.solve` short-circuits to a fixed pair of positions when `PYAUTO_SMALL_DATASETS=1` (PyAutoLabs/PyAutoLens#479), the three group simulator scripts no longer need to pop the env var around `solver.solve` and restore it afterward. This PR deletes that workaround.

Refs PyAutoLabs/PyAutoLens#477.

## Scripts Changed

- `scripts/group/simulator.py` — removed `import os`, `small_datasets = os.environ.pop(...)`, and the restore block around `solver.solve`.
- `scripts/group/features/multi_gaussian_expansion/simulator.py` — same cleanup.
- `scripts/group/features/no_lens_light/simulator.py` — same cleanup.

Net change: -21 lines, no behavior change in production runs (the workaround was only relevant under `PYAUTO_SMALL_DATASETS=1`, which is now handled inside the solver itself).

## Upstream PR

https://github.com/PyAutoLabs/PyAutoLens/pull/479

## Test Plan

- [ ] `/smoke_test` passes for autolens_workspace
- [ ] Library PR #479 merges first (workspace PR is blocked by the library-first merge gate until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)