### PR TITLE
fix: chain image_plane_mesh_grid through light_lp / mass_total in delaunay SLaM

### DIFF
--- a/scripts/imaging/features/pixelization/delaunay.py
+++ b/scripts/imaging/features/pixelization/delaunay.py
@@ -803,7 +803,12 @@ def light_lp(
         result=source_result_for_lens
     )
 
-    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+    adapt_images = al.AdaptImages(
+        galaxy_name_image_dict=galaxy_image_name_dict,
+        galaxy_name_image_plane_mesh_grid_dict=(
+            source_result_for_source.analysis.adapt_images.galaxy_name_image_plane_mesh_grid_dict
+        ),
+    )
 
     analysis = al.AnalysisImaging(
         dataset=dataset,
@@ -867,7 +872,12 @@ def mass_total(
         result=source_result_for_lens
     )
 
-    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+    adapt_images = al.AdaptImages(
+        galaxy_name_image_dict=galaxy_image_name_dict,
+        galaxy_name_image_plane_mesh_grid_dict=(
+            source_result_for_source.analysis.adapt_images.galaxy_name_image_plane_mesh_grid_dict
+        ),
+    )
 
     analysis = al.AnalysisImaging(
         dataset=dataset,

--- a/scripts/interferometer/features/pixelization/delaunay.py
+++ b/scripts/interferometer/features/pixelization/delaunay.py
@@ -726,7 +726,12 @@ def mass_total(
         result=source_pix_result_1, use_model_images=True
     )
 
-    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+    adapt_images = al.AdaptImages(
+        galaxy_name_image_dict=galaxy_image_name_dict,
+        galaxy_name_image_plane_mesh_grid_dict=(
+            source_pix_result_2.analysis.adapt_images.galaxy_name_image_plane_mesh_grid_dict
+        ),
+    )
 
     analysis = al.AnalysisInterferometer(
         dataset=dataset,


### PR DESCRIPTION
## Summary
SLaM `light_lp` and `mass_total` helpers in the imaging and interferometer Delaunay pixelization scripts built a fresh `AdaptImages` carrying only the per-galaxy image dict — the `galaxy_name_image_plane_mesh_grid_dict` that `source_pix_2` had constructed was silently dropped at each chaining step. Under `PYAUTO_TEST_MODE=2` (and any other path that exercises the SLaM helpers' likelihood end-to-end with a Delaunay source) the chained Pixelization had no source-plane mesh grid, propagated `None` through `traced_mesh_grid_pg_list`, and crashed deep in `BorderRelocator.relocated_mesh_grid_from` with `AttributeError`. The crash was masked for a long time by the `positions_likelihood_from` zero-size-array crash (PyAutoLens #479).

The fix is the missing one or two lines per helper: forward the existing mesh-grid dict from `source_result_for_source.analysis.adapt_images` rather than constructing a fresh `AdaptImages` without it. No recipe re-execution, no new parameters, no library changes.

## Scripts Changed
- `scripts/imaging/features/pixelization/delaunay.py` — `light_lp` and `mass_total` SLaM helpers now propagate `galaxy_name_image_plane_mesh_grid_dict` from `source_result_for_source` into their `AdaptImages` constructor.
- `scripts/interferometer/features/pixelization/delaunay.py` — `mass_total` helper updated with the same one-line fix.

## Test Plan
- [x] `PYAUTO_TEST_MODE=2 python scripts/imaging/features/pixelization/delaunay.py` runs the full SLaM pipeline (`source_lp[1]` → `source_pix[1]` → `source_pix[2]` → `light[1]` → `mass_total[1]`) to completion. No relocator `AttributeError`.
- [ ] Same fix applied to interferometer; not exercised end-to-end here due to a pre-existing unrelated shape mismatch in `interferometer/.../source_pix_2` under `PYAUTO_TEST_MODE=2` that needs a separate fix. The fix shape is structurally identical to the verified imaging fix (single kwarg added to the same `AdaptImages` constructor).
- [ ] Smoke tests pass.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)