### PR TITLE
fix(interferometer): strip lens light from pixelization SLaM scripts

### DIFF
--- a/scripts/interferometer/features/extra_galaxies/slam.py
+++ b/scripts/interferometer/features/extra_galaxies/slam.py
@@ -193,8 +193,9 @@ def source_pix_2(
             lens=af.Model(
                 al.Galaxy,
                 redshift=source_pix_result_1.instance.galaxies.lens.redshift,
-                bulge=source_pix_result_1.instance.galaxies.lens.bulge,
-                disk=source_pix_result_1.instance.galaxies.lens.disk,
+                # interferometry does not support lens light
+                bulge=None,
+                disk=None,
                 mass=source_pix_result_1.instance.galaxies.lens.mass,
                 shear=source_pix_result_1.instance.galaxies.lens.shear,
             ),

--- a/scripts/interferometer/features/pixelization/delaunay.py
+++ b/scripts/interferometer/features/pixelization/delaunay.py
@@ -485,13 +485,6 @@ def source_lp(
 ) -> af.Result:
     analysis = al.AnalysisInterferometer(dataset=dataset)
 
-    lens_bulge = al.model_util.mge_model_from(
-        mask_radius=mask_radius,
-        total_gaussians=20,
-        gaussian_per_basis=2,
-        centre_prior_is_uniform=True,
-    )
-
     source_bulge = al.model_util.mge_model_from(
         mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
     )
@@ -501,7 +494,8 @@ def source_lp(
             lens=af.Model(
                 al.Galaxy,
                 redshift=redshift_lens,
-                bulge=lens_bulge,
+                # interferometry does not support lens light
+                bulge=None,
                 disk=None,
                 mass=af.Model(al.mp.Isothermal),
                 shear=af.Model(al.mp.ExternalShear),
@@ -673,8 +667,9 @@ def source_pix_2(
             lens=af.Model(
                 al.Galaxy,
                 redshift=source_lp_result.instance.galaxies.lens.redshift,
-                bulge=source_lp_result.instance.galaxies.lens.bulge,
-                disk=source_lp_result.instance.galaxies.lens.disk,
+                # interferometry does not support lens light
+                bulge=None,
+                disk=None,
                 mass=source_pix_result_1.instance.galaxies.lens.mass,
                 shear=source_pix_result_1.instance.galaxies.lens.shear,
             ),

--- a/scripts/interferometer/features/pixelization/slam.py
+++ b/scripts/interferometer/features/pixelization/slam.py
@@ -179,8 +179,9 @@ def source_pix_2(
             lens=af.Model(
                 al.Galaxy,
                 redshift=source_pix_result_1.instance.galaxies.lens.redshift,
-                bulge=source_pix_result_1.instance.galaxies.lens.bulge,
-                disk=source_pix_result_1.instance.galaxies.lens.disk,
+                # interferometry does not support lens light
+                bulge=None,
+                disk=None,
                 mass=source_pix_result_1.instance.galaxies.lens.mass,
                 shear=source_pix_result_1.instance.galaxies.lens.shear,
             ),

--- a/scripts/interferometer/features/subhalo/detect/start_here.py
+++ b/scripts/interferometer/features/subhalo/detect/start_here.py
@@ -205,8 +205,9 @@ def source_pix_2(
             lens=af.Model(
                 al.Galaxy,
                 redshift=source_pix_result_1.instance.galaxies.lens.redshift,
-                bulge=source_pix_result_1.instance.galaxies.lens.bulge,
-                disk=source_pix_result_1.instance.galaxies.lens.disk,
+                # interferometry does not support lens light
+                bulge=None,
+                disk=None,
                 mass=source_pix_result_1.instance.galaxies.lens.mass,
                 shear=source_pix_result_1.instance.galaxies.lens.shear,
             ),


### PR DESCRIPTION
## Summary

The interferometer `InversionInterferometerSparse` path can't combine a `LinearObjFuncList` with a `Mapper` — its `curvature_matrix` only handles the single-Mapper diagonal case and indexes by `linear_obj_list[0].params`, producing a wrong-sized matrix when a lens light Basis sits in front of the source mapper. Under `PYAUTO_TEST_MODE=2`, `scripts/interferometer/features/pixelization/delaunay.py source_pix_2` crashed with:

```
TypeError: add got incompatible shapes for broadcasting: (40, 40), (1070, 1070)
```

inside `inversion.fast_chi_squared`. The `(40, 40)` came from a forwarded MGE lens bulge of 40 Gaussians; the `(1070, 1070)` was the regularization_matrix for 40 basis params + 1030 source-mapper pixels.

mm/radio interferometer data has no detectable lens light, and the file's own docstring states "no lens light model is included as interferometer data". `source_pix_1` and `mass_total` already used `bulge=None, disk=None`. This PR aligns `source_lp` and `source_pix_2` with that convention.

## Scripts Changed

- `scripts/interferometer/features/pixelization/delaunay.py` — `source_lp`: dropped the `lens_bulge` MGE definition and set `bulge=None, disk=None`. `source_pix_2`: replaced the forwarded `bulge=source_lp_result.instance.galaxies.lens.bulge` / `disk=...` with explicit `bulge=None, disk=None`. **This is the real fix** — the only script that was crashing.
- `scripts/interferometer/features/pixelization/slam.py` — `source_pix_2`: replaced the verbose `bulge=source_pix_result_1.instance.galaxies.lens.bulge` / `disk=...` forwarding with explicit `bulge=None, disk=None`. Stylistic only — the forwarded value was already `None` at runtime because `source_pix_1` sets `bulge=None`.
- `scripts/interferometer/features/extra_galaxies/slam.py` — same stylistic cleanup as `slam.py`.
- `scripts/interferometer/features/subhalo/detect/start_here.py` — same stylistic cleanup.

All four locations got a `# interferometry does not support lens light` comment above the `bulge=None, disk=None` lines.

## Test Plan
- [x] `PYAUTO_TEST_MODE=2` run of `scripts/interferometer/features/pixelization/delaunay.py` — all four SLaM stages (`source_lp[1]`, `source_pix[1]`, `source_pix[2]`, `mass_total[1]`) complete without the broadcasting crash.
- [ ] Smoke tests pass for autolens_workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)