### PR TITLE
fix: replace undefined aa.Array2D with al.Array2D in welcome.py

### DIFF
--- a/welcome.py
+++ b/welcome.py
@@ -106,10 +106,10 @@ isothermal_mass_profile = al.mp.Isothermal(
 )
 
 deflections = isothermal_mass_profile.deflections_yx_2d_from(grid=grid)
-deflections_y = aa.Array2D(values=deflections.slim[:, 0], mask=grid.mask)
+deflections_y = al.Array2D(values=deflections.slim[:, 0], mask=grid.mask)
 aplt.plot_array(array=deflections_y, title="Deflections Y")
 deflections = isothermal_mass_profile.deflections_yx_2d_from(grid=grid)
-deflections_x = aa.Array2D(values=deflections.slim[:, 1], mask=grid.mask)
+deflections_x = al.Array2D(values=deflections.slim[:, 1], mask=grid.mask)
 aplt.plot_array(array=deflections_x, title="Deflections X")
 
 input(


### PR DESCRIPTION
## Summary
`welcome.py` crashed with `NameError: name 'aa' is not defined` because
lines 109 and 112 used the `aa` prefix without importing `autoarray`.
The script imports `autolens as al`, and `autolens` re-exports `Array2D`,
so the fix is to use `al.Array2D` directly.

## Scripts Changed
- `welcome.py` — `aa.Array2D` → `al.Array2D` on lines 109 and 112

## Test Plan
- [x] `yes "" | python welcome.py` runs to completion (exit 0)
- [x] Smoke tests pass

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)