### PR TITLE
feat: embed workspace_version in config + drop welcome.py duplicate check

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -50,3 +50,5 @@ test:
   disable_positions_lh_inversion_check: true
 version:
   python_version_check: True        # If False, bypass the PyAutoConf Python 3.12+ recommendation (3.9/3.10/3.11 technically work but are not officially supported).
+  workspace_version: 2026.4.13.6    # Pinned by the release pipeline; must match the installed library version.
+  workspace_version_check: True     # If False, bypass the workspace/library version check. Set to False on `main`-branch clones — `main` updates faster than releases, so mismatches are expected and not actionable.

--- a/welcome.py
+++ b/welcome.py
@@ -1,7 +1,4 @@
 import autolens as al
-from autoconf import check_version
-
-check_version(al.__version__)
 
 input(
     "############################################\n"


### PR DESCRIPTION
## Summary
Extend the existing `version:` block in `config/general.yaml` with `workspace_version: 2026.4.13.6` and a user-facing `workspace_version_check: True` override flag, so the new config-aware `autoconf.workspace.check_version` (PyAutoLabs/PyAutoConf#101, now called from every `import autofit/autogalaxy/autolens`) can resolve the workspace version from a canonical source that travels with the user's config directory. The `version.txt` legacy fallback continues to work.

Also drop the now-redundant `check_version(al.__version__)` call from `welcome.py` — `import autolens` does the check on import, so calling it again was duplicate work that fired only when users explicitly ran `welcome.py`.

Setting `workspace_version_check: False` is the recommended bypass for users on `main`-branch workspace clones, where `main` updates faster than library releases and mismatches are expected.

## Scripts Changed
- `config/general.yaml` — append `workspace_version: 2026.4.13.6` and `workspace_version_check: True` to the existing `version:` block (keeps existing `python_version_check`)
- `welcome.py` — remove the redundant `from autoconf import check_version` import and the `check_version(al.__version__)` call (libraries now run the check on import via PyAutoLens `__init__.py`)

## Upstream PR
- PyAutoLabs/PyAutoConf#101 — config-aware `check_version` (core change)
- PyAutoLabs/PyAutoFit#1241, PyAutoLabs/PyAutoGalaxy#380, PyAutoLabs/PyAutoLens#484 — call `check_version` on library import
- PyAutoLabs/PyAutoBuild#70 — release pipeline writes the new YAML key; `verify_workspace_versions.sh` reads it

## Test Plan
- [x] `python -c "import autolens"` from this workspace runs silently (no warning, no error)
- [x] `bash PyAutoBuild/verify_workspace_versions.sh` reports `autolens_workspace` as `ok`
- [ ] CI smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)