### PR TITLE
chore: complete pyprojroot boilerplate removal in remaining scripts

### DIFF
--- a/dataset/imaging/slacs1430+4105/data.py
+++ b/dataset/imaging/slacs1430+4105/data.py
@@ -10,11 +10,6 @@ In this script, we fit `Imaging` with a strong lens model where:
 """
 
 # %matplotlib inline
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from os import path
 import numpy as np
 import autofit as af

--- a/notebooks/imaging/features/advanced/double_einstein_ring/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/double_einstein_ring/simulator.ipynb
@@ -43,12 +43,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "import autolens as al\n",
         "import autolens.plot as aplt"

--- a/notebooks/imaging/features/advanced/operated_light_profile/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/operated_light_profile/simulator.ipynb
@@ -49,12 +49,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "import autolens as al\n",
         "import autolens.plot as aplt"

--- a/notebooks/imaging/features/advanced/subhalo/simulator.ipynb
+++ b/notebooks/imaging/features/advanced/subhalo/simulator.ipynb
@@ -44,12 +44,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "import autolens as al\n",
         "import autolens.plot as aplt"

--- a/notebooks/imaging/features/extra_galaxies/simulator.ipynb
+++ b/notebooks/imaging/features/extra_galaxies/simulator.ipynb
@@ -70,12 +70,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "\n",
         "import numpy as np\n",

--- a/notebooks/imaging/features/multi_gaussian_expansion/simulator.ipynb
+++ b/notebooks/imaging/features/multi_gaussian_expansion/simulator.ipynb
@@ -49,12 +49,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "import autolens as al\n",
         "import autolens.plot as aplt"

--- a/notebooks/interferometer/features/extra_galaxies/simulator.ipynb
+++ b/notebooks/interferometer/features/extra_galaxies/simulator.ipynb
@@ -59,12 +59,6 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "\n",
-        "# from pyprojroot import here\n",
-        "# workspace_path = str(here())\n",
-        "# %cd $workspace_path\n",
-        "# print(f\"Working Directory has been set to `{workspace_path}`\")\n",
-        "\n",
         "from pathlib import Path\n",
         "import autolens as al\n",
         "import autolens.plot as aplt"

--- a/scripts/imaging/features/advanced/double_einstein_ring/simulator.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/simulator.py
@@ -34,11 +34,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 import autolens as al
 import autolens.plot as aplt

--- a/scripts/imaging/features/advanced/operated_light_profile/simulator.py
+++ b/scripts/imaging/features/advanced/operated_light_profile/simulator.py
@@ -40,11 +40,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 import autolens as al
 import autolens.plot as aplt

--- a/scripts/imaging/features/advanced/subhalo/simulator.py
+++ b/scripts/imaging/features/advanced/subhalo/simulator.py
@@ -35,11 +35,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 import autolens as al
 import autolens.plot as aplt

--- a/scripts/imaging/features/extra_galaxies/simulator.py
+++ b/scripts/imaging/features/extra_galaxies/simulator.py
@@ -61,11 +61,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 
 import numpy as np

--- a/scripts/imaging/features/multi_gaussian_expansion/simulator.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/simulator.py
@@ -40,11 +40,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 import autolens as al
 import autolens.plot as aplt

--- a/scripts/interferometer/features/extra_galaxies/simulator.py
+++ b/scripts/interferometer/features/extra_galaxies/simulator.py
@@ -50,11 +50,6 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `simulators/start_here.ipynb` notebook.
 """
 
-# from pyprojroot import here
-# workspace_path = str(here())
-# %cd $workspace_path
-# print(f"Working Directory has been set to `{workspace_path}`")
-
 from pathlib import Path
 import autolens as al
 import autolens.plot as aplt


### PR DESCRIPTION
## Summary

Removes the leftover pyprojroot magic-cell stub from 7 scripts that the April 13 cleanup ([1c09fdae](https://github.com/PyAutoLabs/autolens_workspace/commit/1c09fdae)) missed.

**Affected scripts:**
- `dataset/imaging/slacs1430+4105/data.py`
- `scripts/imaging/features/advanced/double_einstein_ring/simulator.py`
- `scripts/imaging/features/advanced/operated_light_profile/simulator.py`
- `scripts/imaging/features/advanced/subhalo/simulator.py`
- `scripts/imaging/features/extra_galaxies/simulator.py`
- `scripts/imaging/features/multi_gaussian_expansion/simulator.py`
- `scripts/interferometer/features/extra_galaxies/simulator.py`

The deleted lines per script are the standard 5-line scaffolding:

```python
# from pyprojroot import here
# workspace_path = str(here())
# %cd $workspace_path
# print(f"Working Directory has been set to `{workspace_path}`")
```

`dataset/imaging/slacs1430+4105/data.py` was also CRLF; normalised to LF to match the rest of the repo. Notebooks regenerated to match scripts.

## Test plan

- [ ] Spot-check one notebook in JupyterLab — content unchanged.
- [ ] Run `python scripts/imaging/features/extra_galaxies/simulator.py` from the workspace root in PYAUTO_TEST_MODE=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)