### PR TITLE
welcome: no-op input() prompts when stdin is not a tty

### DIFF
--- a/welcome.py
+++ b/welcome.py
@@ -1,6 +1,17 @@
+import sys
+
 import autolens as al
 
-input(
+
+def _prompt(msg: str) -> None:
+    """input() that gracefully no-ops on non-tty stdin (e.g. CI / piped runs)."""
+    if sys.stdin.isatty():
+        input(msg)
+    else:
+        print(msg)
+
+
+_prompt(
     "############################################\n"
     "### WELCOME TO THE AUTOLENS WORKSPACE ###\n"
     "############################################\n\n"
@@ -34,7 +45,7 @@ input(
     [Press Enter to continue]"""
 )
 
-input(
+_prompt(
     "\n"
     "###############################\n"
     "##### MATPLOTLIB BACKEND ######\n"
@@ -81,7 +92,7 @@ sersic_light_profile = al.lp.Exponential(
 
 aplt.plot_array(array=sersic_light_profile.image_2d_from(grid=grid), title="Image")
 
-input(
+_prompt(
     "\n"
     "##############################\n"
     "## LIGHT AND MASS PROFILES ###\n"
@@ -109,7 +120,7 @@ deflections = isothermal_mass_profile.deflections_yx_2d_from(grid=grid)
 deflections_x = al.Array2D(values=deflections.slim[:, 1], mask=grid.mask)
 aplt.plot_array(array=deflections_x, title="Deflections X")
 
-input(
+_prompt(
     "\n"
     "########################\n"
     "##### RAY TRACING ######\n"
@@ -129,7 +140,7 @@ tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
 
 aplt.plot_array(array=tracer.image_2d_from(grid=grid), title="Image")
 
-input(
+_prompt(
     "\n"
     "###########################\n"
     "##### WORKSPACE TOUR ######\n"


### PR DESCRIPTION
## Summary

Wrap the 5 `input("[Press Enter to continue]")` calls in `welcome.py` with a `_prompt()` helper that no-ops on non-tty stdin (printing the message but skipping the input read). Interactive runs are unchanged.

## Why

`welcome.py` is exercised in `/verify_install` Check A as part of the post-install smoke test (`(cd workspace && python welcome.py) |& tee log`). The pipe to `tee` makes stdin non-tty, so `input()` immediately raises `EOFError` on the first prompt, crashing the script and causing Check A to FAIL even when the install itself is healthy.

After this fix, non-interactive runs walk through every section of welcome.py end-to-end (matplotlib backend probe, light/mass profile plot, ray-tracing plot, workspace tour) — closer to a real install smoke test.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('welcome.py').read())"` — syntax OK.
- [ ] `python welcome.py < /dev/null` (or any non-tty stdin) reaches the end without EOFError.
- [ ] `python welcome.py` (interactive) still pauses at each [Press Enter to continue] prompt.
- [ ] Re-run `/verify_install --version 2026.5.1.4` — Check A welcome.py rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)