### PR TITLE
fix: wire image-plane mesh grid + AdaptImages into group/features/pixelization scripts

### DIFF
--- a/scripts/group/features/pixelization/delaunay.py
+++ b/scripts/group/features/pixelization/delaunay.py
@@ -113,9 +113,31 @@ dataset = dataset.apply_over_sampling(
 )
 
 """
+__Image-Plane Mesh Grid__
+
+The Delaunay mesh requires an image-plane mesh grid whose ray-traced positions become the Delaunay
+vertices in the source plane. We build it via an `Overlay` image-mesh covering the masked field, then
+append a ring of edge pixels at the mask boundary so the linear inversion can zero them out. The same
+image-plane mesh grid is reused below for both the concrete fit and the modeling section.
+"""
+edge_pixels_total = 30
+
+image_mesh = al.image_mesh.Overlay(shape=(22, 22))
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(mask=dataset.mask)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=mask.mask_centre,
+    radius=mask_radius + mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+"""
 __Fit__
 
-We create a fit using a Delaunay mesh with 500 source pixels and constant regularization.
+We create a fit using a Delaunay mesh whose source-pixel count matches the image-plane mesh grid
+computed above, with constant regularization.
 
 For the group lens, we include the main lens galaxy and extra galaxies with their light and mass
 profiles, and a source galaxy with the Delaunay pixelization.
@@ -145,7 +167,9 @@ extra_galaxy_1 = al.Galaxy(
 )
 
 pixelization = al.Pixelization(
-    mesh=al.mesh.Delaunay(pixels=500),
+    mesh=al.mesh.Delaunay(
+        pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total
+    ),
     regularization=al.reg.Constant(coefficient=1.0),
 )
 
@@ -155,7 +179,11 @@ tracer = al.Tracer(
     galaxies=[lens_galaxy, extra_galaxy_0, extra_galaxy_1, source_galaxy]
 )
 
-fit = al.FitImaging(dataset=dataset, tracer=tracer)
+adapt_images = al.AdaptImages(
+    galaxy_image_plane_mesh_grid_dict={source_galaxy: image_plane_mesh_grid}
+)
+
+fit = al.FitImaging(dataset=dataset, tracer=tracer, adapt_images=adapt_images)
 
 """
 The fit subplot shows the pixelized source does a good job at capturing the appearance of the lensed
@@ -255,12 +283,21 @@ for centre in extra_galaxies_centres:
 
 extra_galaxies = af.Collection(extra_galaxies_list)
 
-# Source: Delaunay pixelization with AdaptSplit regularization.
+# Source: Delaunay pixelization with ConstantSplit regularization.
+#
+# The Delaunay mesh is constructed as a concrete instance (not `af.Model`) because its `pixels` count
+# is fixed by the image-plane mesh grid built above. JAX requires this to be static across samples.
+#
+# `ConstantSplit` is used for this first-pass model because adapt data (per-galaxy images from a
+# previous search) is not yet available. A SLaM pipeline can later upgrade to `AdaptSplit` once the
+# source has been imaged — see `scripts/group/slam.py` for the canonical chained pattern.
 
 pix = af.Model(
     al.Pixelization,
-    mesh=af.Model(al.mesh.Delaunay),
-    regularization=af.Model(al.reg.AdaptSplit),
+    mesh=al.mesh.Delaunay(
+        pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total
+    ),
+    regularization=al.reg.ConstantSplit,
 )
 
 source = af.Model(al.Galaxy, redshift=1.0, pixelization=pix)
@@ -288,9 +325,19 @@ search = af.Nautilus(
 
 """
 __Analysis__
+
+The image-plane mesh grid is paired with the source galaxy via `AdaptImages`, keyed by the model
+path so it resolves at instance time during the non-linear search.
 """
+adapt_images = al.AdaptImages(
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid
+    },
+)
+
 analysis = al.AnalysisImaging(
     dataset=dataset,
+    adapt_images=adapt_images,
     settings=al.Settings(use_mixed_precision=True),
 )
 

--- a/scripts/group/features/pixelization/fit.py
+++ b/scripts/group/features/pixelization/fit.py
@@ -112,12 +112,34 @@ dataset = dataset.apply_over_sampling(
 )
 
 """
+__Image-Plane Mesh Grid__
+
+The Delaunay mesh requires an image-plane mesh grid whose ray-traced positions become the Delaunay
+vertices in the source plane. We build it via an `Overlay` image-mesh covering the masked field, then
+append a ring of edge pixels at the mask boundary so the linear inversion can zero them out.
+"""
+edge_pixels_total = 30
+
+image_mesh = al.image_mesh.Overlay(shape=(22, 22))
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(mask=dataset.mask)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=mask.mask_centre,
+    radius=mask_radius + mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+"""
 __Fitting__
 
 We create concrete galaxy objects for the group lens system. The main lens and extra galaxies have
 light and mass profiles, while the source galaxy uses a pixelized reconstruction.
 
-The `Pixelization` is created with a `Delaunay` mesh (500 pixels) and `Constant` regularization.
+The `Pixelization` uses a `Delaunay` mesh whose pixel count matches the image-plane mesh grid
+computed above (with `edge_pixels_total` boundary vertices reserved for zeroing) and `Constant`
+regularization.
 """
 lens_galaxy = al.Galaxy(
     redshift=0.5,
@@ -144,7 +166,9 @@ extra_galaxy_1 = al.Galaxy(
 )
 
 pixelization = al.Pixelization(
-    mesh=al.mesh.Delaunay(pixels=500),
+    mesh=al.mesh.Delaunay(
+        pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total
+    ),
     regularization=al.reg.Constant(coefficient=1.0),
 )
 
@@ -161,8 +185,15 @@ tracer = al.Tracer(
 The `FitImaging` object handles the full group-scale fit automatically: it sums the lens light from all
 galaxies, computes the combined deflection field from all mass profiles, ray-traces to the source plane,
 performs the pixelized source reconstruction, convolves with the PSF, and computes the log likelihood.
+
+The image-plane mesh grid is supplied via an `AdaptImages` object, which pairs it with the source
+galaxy so the Delaunay vertices can be ray-traced to the source plane during the fit.
 """
-fit = al.FitImaging(dataset=dataset, tracer=tracer)
+adapt_images = al.AdaptImages(
+    galaxy_image_plane_mesh_grid_dict={source_galaxy: image_plane_mesh_grid}
+)
+
+fit = al.FitImaging(dataset=dataset, tracer=tracer, adapt_images=adapt_images)
 
 aplt.subplot_fit_imaging(fit=fit)
 

--- a/scripts/group/features/pixelization/likelihood_function.py
+++ b/scripts/group/features/pixelization/likelihood_function.py
@@ -150,6 +150,26 @@ extra_galaxy_1 = al.Galaxy(
 )
 
 """
+__Image-Plane Mesh Grid__
+
+The Delaunay mesh requires an image-plane mesh grid whose ray-traced positions become the Delaunay
+vertices in the source plane. We build it via an `Overlay` image-mesh covering the masked field, then
+append a ring of edge pixels at the mask boundary so the linear inversion can zero them out.
+"""
+edge_pixels_total = 30
+
+image_mesh = al.image_mesh.Overlay(shape=(22, 22))
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(mask=masked_dataset.mask)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=mask.mask_centre,
+    radius=mask_radius + mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+"""
 __Source Galaxy Pixelization__
 
 The source galaxy is reconstructed using a Delaunay mesh with constant regularization, rather than
@@ -157,14 +177,17 @@ an analytic light profile.
 
 The `Pixelization` consists of:
 
- - `mesh`: A `Delaunay` triangulation with 500 source pixels. The triangle vertices are determined by
-   ray-tracing a coarse image-plane grid to the source plane.
+ - `mesh`: A `Delaunay` triangulation whose source-pixel count matches the image-plane mesh grid
+   computed above (with `edge_pixels_total` boundary vertices reserved for zeroing). The triangle
+   vertices are determined by ray-tracing this image-plane grid to the source plane.
 
  - `regularization`: A `Constant` scheme that applies uniform smoothing across all source pixels, with
    a single free regularization coefficient.
 """
 pixelization = al.Pixelization(
-    mesh=al.mesh.Delaunay(pixels=500),
+    mesh=al.mesh.Delaunay(
+        pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total
+    ),
     regularization=al.reg.Constant(coefficient=1.0),
 )
 
@@ -292,8 +315,17 @@ __Fit__
 
 The `FitImaging` object performs all of the above steps automatically. We verify that it produces the
 correct result for the group-scale pixelized fit.
+
+The image-plane mesh grid is supplied via an `AdaptImages` object, which pairs it with the source
+galaxy so the Delaunay vertices can be ray-traced to the source plane during the fit.
 """
-fit = al.FitImaging(dataset=masked_dataset, tracer=tracer)
+adapt_images = al.AdaptImages(
+    galaxy_image_plane_mesh_grid_dict={source_galaxy: image_plane_mesh_grid}
+)
+
+fit = al.FitImaging(
+    dataset=masked_dataset, tracer=tracer, adapt_images=adapt_images
+)
 fit_figure_of_merit = fit.figure_of_merit
 print(f"Log Likelihood: {fit_figure_of_merit}")
 

--- a/scripts/group/features/pixelization/modeling.py
+++ b/scripts/group/features/pixelization/modeling.py
@@ -12,7 +12,8 @@ whereas a pixelized mesh can reconstruct arbitrarily complex source-plane emissi
 
 The main lens galaxies and extra galaxies are modeled with MGE light profiles (via ``al.model_util.mge_model_from``)
 and Isothermal mass profiles, following the standard group modeling pattern. The source galaxy uses a
-Delaunay pixelization with AdaptSplit regularization.
+Delaunay pixelization with ConstantSplit regularization (`AdaptSplit` requires adapt data from a
+prior search and is wired up later by the SLaM pipeline — see `scripts/group/slam.py`).
 
 __Contents__
 
@@ -30,7 +31,7 @@ This script fits an `Imaging` dataset of a 'group-scale' strong lens where:
 
  - There is a main lens galaxy whose light is an MGE and total mass is `Isothermal` with `ExternalShear`.
  - There are two extra lens galaxies with MGE light and `IsothermalSph` mass, centres fixed.
- - The source galaxy's light is reconstructed using a `Delaunay` mesh with `AdaptSplit` regularization.
+ - The source galaxy's light is reconstructed using a `Delaunay` mesh with `ConstantSplit` regularization.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports
@@ -103,13 +104,39 @@ extra_galaxies_centres = al.from_json(
 )
 
 """
+__Image-Plane Mesh Grid__
+
+The Delaunay mesh requires an image-plane mesh grid whose ray-traced positions become the Delaunay
+vertices in the source plane. We build it via an `Overlay` image-mesh covering the masked field, then
+append a ring of edge pixels at the mask boundary so the linear inversion can zero them out.
+
+This grid is reused below: its shape sets the number of source pixels in the mesh, and the grid
+itself is paired with the source galaxy via `AdaptImages` when the analysis is constructed.
+"""
+edge_pixels_total = 30
+
+image_mesh = al.image_mesh.Overlay(shape=(22, 22))
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(mask=dataset.mask)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=mask.mask_centre,
+    radius=mask_radius + mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+"""
 __Model__
 
 We compose a group lens model where:
 
  - Each main lens galaxy has MGE light and Isothermal mass. Only lens_0 carries ExternalShear.
  - Each extra galaxy has MGE light and IsothermalSph mass with fixed centres and bounded Einstein radii.
- - The source galaxy uses a Delaunay pixelization with AdaptSplit regularization.
+ - The source galaxy uses a Delaunay pixelization with ConstantSplit regularization. `ConstantSplit`
+   is used for this first-pass model because adapt data (per-galaxy images from a previous search)
+   is not yet available; a SLaM pipeline can later upgrade to `AdaptSplit` once the source has been
+   imaged — see `scripts/group/slam.py` for the chained pattern.
 
 The pixelized source captures complex lensed morphologies far better than parametric profiles, which is
 especially important for group lenses where the extended mass distribution creates intricate arc structures.
@@ -164,11 +191,16 @@ for centre in extra_galaxies_centres:
 extra_galaxies = af.Collection(extra_galaxies_list)
 
 # Source:
+#
+# The Delaunay mesh is built as a concrete instance (not `af.Model`) because its `pixels` count is
+# fixed by the image-plane mesh grid built above. JAX requires this to be static across samples.
 
 pixelization = af.Model(
     al.Pixelization,
-    mesh=af.Model(al.mesh.Delaunay),
-    regularization=af.Model(al.reg.AdaptSplit),
+    mesh=al.mesh.Delaunay(
+        pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total
+    ),
+    regularization=al.reg.ConstantSplit,
 )
 
 source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
@@ -229,9 +261,19 @@ __Analysis__
 The `AnalysisImaging` object defines how the model is fitted to the data.
 
 For pixelized source fits, we enable mixed precision to speed up GPU run times on consumer hardware.
+
+The image-plane mesh grid is paired with the source galaxy via `AdaptImages`, keyed by the model
+path so it resolves at instance time during the non-linear search.
 """
+adapt_images = al.AdaptImages(
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid
+    },
+)
+
 analysis = al.AnalysisImaging(
     dataset=dataset,
+    adapt_images=adapt_images,
     settings=al.Settings(use_mixed_precision=True),
 )
 
@@ -278,7 +320,9 @@ The pixelized source is particularly powerful for group lenses because:
 
  - The combined mass of multiple galaxies creates complex arc structures that parametric profiles cannot capture.
  - The Delaunay mesh adapts to the source morphology, placing more triangles where the source is brightest.
- - AdaptSplit regularization allows different smoothing in bright vs. faint source regions.
+ - `ConstantSplit` regularization is used as a first-pass scheme; chained pipelines can upgrade to
+   `AdaptSplit` once an adapt image of the source is available, allowing different smoothing in
+   bright vs. faint source regions.
 
 For automated modeling of large samples, the SLaM pipeline (see `group/features/pixelization/slam.py`) provides
 a robust framework that chains parametric and pixelized source fits.


### PR DESCRIPTION
## Summary

Five integration scripts under `scripts/group/features/pixelization/` were failing the smoke profile (`PYAUTO_TEST_MODE=2 PYAUTO_SKIP_CHECKS=1`):

- `fit.py`, `likelihood_function.py`, `delaunay.py` → `AttributeError: 'NoneType' object has no attribute 'array'` in `border_relocator.py:450`
- `modeling.py` → `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'` in `Delaunay.__init__`
- `slam.py` → `AttributeError: 'NoneType' object has no attribute 'positions'` at line 737

The first 4 share a root cause: the scripts created `al.Pixelization(mesh=al.mesh.Delaunay(...))` without supplying an `image_plane_mesh_grid` via `AdaptImages`. Unlike `RectangularAdaptDensity`, `Delaunay` requires its mesh vertices to be supplied as a precomputed image-plane grid that ray-traces to the source plane.

This PR brings the 4 affected scripts in line with the canonical pattern in `scripts/imaging/features/pixelization/delaunay.py`. The 5th failure (`slam.py`) is fixed by a separate PyAutoLens library change — see "Depends on" below; this PR leaves `slam.py` untouched.

## Scripts Changed

- `scripts/group/features/pixelization/fit.py` — concrete fit; added `Overlay` image-mesh + `AdaptImages(galaxy_image_plane_mesh_grid_dict=...)`
- `scripts/group/features/pixelization/likelihood_function.py` — same pattern (uses `masked_dataset` variable name)
- `scripts/group/features/pixelization/delaunay.py` — concrete fit + modeling section. Modeling section switched `mesh=af.Model(al.mesh.Delaunay)` → concrete `Delaunay(pixels=image_plane_mesh_grid.shape[0], zeroed_pixels=edge_pixels_total)` and `AdaptSplit` → `ConstantSplit`.
- `scripts/group/features/pixelization/modeling.py` — same modeling-section fix.

`slam.py` is unchanged.

## Depends on

[PyAutoLens PR 490](https://github.com/PyAutoLabs/PyAutoLens/pull/490) — fixes the `positions_likelihood_from` `None` return under skip_checks that breaks `slam.py`. **Do not merge this PR until the library PR has merged.**

## Test Plan

- [x] `python scripts/group/features/pixelization/fit.py` passes under smoke profile
- [x] `python scripts/group/features/pixelization/likelihood_function.py` passes
- [x] `python scripts/group/features/pixelization/delaunay.py` passes
- [x] `python scripts/group/features/pixelization/modeling.py` passes
- [x] `python scripts/group/features/pixelization/slam.py` passes (with library PR's `result.py` fix)

All five run end-to-end under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_FAST_PLOTS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)