### PR TITLE
Cluster F triage: 4 script fixes (items 2, 3, 5, 9)

### DIFF
--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -400,18 +400,20 @@ solver = al.PointSolver.for_grid(
 
 @jax.jit
 def jitted_solve(tracer, source_plane_coordinate):
+    # Grid2DIrregular is not a JAX pytree, so unwrap to the raw jnp array
+    # before returning out of the jit trace.
     return solver.solve(
         tracer=tracer,
         source_plane_coordinate=source_plane_coordinate,
         xp=jnp,
         remove_infinities=False,
-    )
+    ).array
 
 
 positions_list = []
 for i, src_centre in enumerate(source_centres):
     coord = jnp.asarray(src_centre)
-    raw = np.asarray(jitted_solve(tracer, coord).array)
+    raw = np.asarray(jitted_solve(tracer, coord))
     finite = ~(np.isinf(raw).any(axis=1) | np.isnan(raw).any(axis=1))
     positions_list.append(al.Grid2DIrregular(raw[finite]))
 

--- a/scripts/group/features/advanced/subhalo/detect/start_here.py
+++ b/scripts/group/features/advanced/subhalo/detect/start_here.py
@@ -346,7 +346,7 @@ def light_lp(
         shear=source_result_for_lens.instance.galaxies.lens_0.shear,
     )
 
-    lens_dict = {"lens_0": lens_0, "source": source}
+    lens_dict = {"lens_0": lens_0}
 
     extra_galaxies = source_result_for_lens.instance.extra_galaxies
 
@@ -417,7 +417,7 @@ def mass_total(
         shear=source_result_for_lens.model.galaxies.lens_0.shear,
     )
 
-    lens_dict = {"lens_0": lens_0, "source": source}
+    lens_dict = {"lens_0": lens_0}
 
     extra_galaxies = light_result.instance.extra_galaxies
 
@@ -467,7 +467,7 @@ def subhalo_no_subhalo(
     source = al.util.chaining.source_from(result=mass_result)
     lens_0 = mass_result.model.galaxies.lens_0
 
-    lens_dict = {"lens_0": lens_0, "source": source}
+    lens_dict = {"lens_0": lens_0}
 
     extra_galaxies = mass_result.instance.extra_galaxies
 
@@ -542,7 +542,7 @@ def subhalo_grid_search(
     lens_0 = mass_result.model.galaxies.lens_0
     source = al.util.chaining.source_from(result=mass_result)
 
-    lens_dict = {"lens_0": lens_0, "subhalo": subhalo, "source": source}
+    lens_dict = {"lens_0": lens_0, "subhalo": subhalo}
 
     extra_galaxies = mass_result.instance.extra_galaxies
 
@@ -626,7 +626,6 @@ def subhalo_refine(
     lens_dict = {
         "lens_0": subhalo_grid_search_result.model.galaxies.lens_0,
         "subhalo": subhalo,
-        "source": subhalo_grid_search_result.model.galaxies.source,
     }
 
     extra_galaxies = mass_result.instance.extra_galaxies

--- a/scripts/group/features/linear_light_profiles/slam.py
+++ b/scripts/group/features/linear_light_profiles/slam.py
@@ -241,9 +241,11 @@ def source_lp_1(
             abs(galaxy_with_intensity.bulge.luminosity_within_circle_from(radius=10.0))
             / pixel_scale**2
         )
+        luminosity_cap = 5 * 0.5 * total_luminosity**0.6
+        upper_limit = min(luminosity_cap, 5.0) if luminosity_cap > 0 else 5.0
         mass.einstein_radius = af.UniformPrior(
             lower_limit=0.0,
-            upper_limit=min(5 * 0.5 * total_luminosity**0.6, 5.0),
+            upper_limit=upper_limit,
         )
 
         extra_mass_models.append(

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -348,6 +348,15 @@ A point source fit is plotted with `aplt.subplot_fit_point()`.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "point_source" / dataset_name
 
+if not (dataset_path / "point_dataset_positions_only.json").exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/point_source/simulator.py"],
+        check=True,
+    )
+
 dataset = al.from_json(
     file_path=Path(dataset_path, "point_dataset_positions_only.json"),
 )


### PR DESCRIPTION
## Summary
Four isolated script fixes from triage Cluster F (release-prep run 2026-04-29).

| Item | Script | Fix |
|---|---|---|
| 2 | `group/features/advanced/subhalo/detect/start_here.py` (5 sites) | Drop redundant `"source"` key from `lens_dict` literals — `Collection(**lens_dict, source=source)` was hitting duplicate-kwarg TypeError |
| 3 | `group/features/linear_light_profiles/slam.py` | Floor the luminosity-derived prior `upper_limit` to 5.0 when the synthetic test-mode instance gives zero luminosity, otherwise prior raises `upper > lower` |
| 5 | `cluster/simulator.py` | Return raw `jax.Array` from `jitted_solve` instead of `Grid2DIrregular` (autoarray wrappers are not JAX pytrees per PyAutoArray CLAUDE.md) |
| 9 | `guides/plot/examples/plotters.py` | Add point-source auto-sim block (other dataset sections already had one) so `point_dataset_positions_only.json` is regenerated when missing |

Item 4 (`double_einstein_ring/slam.py`) is fixed library-side via PyAutoLens #491 (merged) — no script change in this repo.

## Scripts Changed
- `scripts/cluster/simulator.py` — JAX `.array` unwrap inside `@jax.jit` boundary (item 5)
- `scripts/group/features/advanced/subhalo/detect/start_here.py` — remove duplicate `"source"` key from 5 `lens_dict` literals (item 2)
- `scripts/group/features/linear_light_profiles/slam.py` — guard prior `upper_limit` against zero-luminosity test-mode instance (item 3)
- `scripts/guides/plot/examples/plotters.py` — add point-source auto-sim block (item 9)

## Test plan
- [x] All 4 affected scripts run to completion under `PYAUTO_TEST_MODE=2` (verified pre-shipping)
- [x] `double_einstein_ring/slam.py` runs to completion (depends on PyAutoLens #491, merged)
- [x] Workspace smoke tests (7/7) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)