### PR TITLE
Refactor guides/results aggregator to share quick-fit helper

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -18,9 +18,6 @@
 #   the NEEDS_FIX marker.
 
 - tutorial_searches
-- guides/results/examples/samples # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
-- guides/results/examples/samples_via_aggregator # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
-- guides/results/examples/queries # SLOW 2026-04-10 - cascade from SLOW-skipped results/start_here.py; stub Model lacks sersic_index attribute
 - guides/results/database/start_here # SLOW 2026-04-10 - previously failed fast on a broken aggregator query; now runs the real aggregator and exceeds 60s
 - tutorial_5_borders # Cant get right masks, need proper update.
 - tutorial_6_model_fit # InversionException due to test mode
@@ -36,7 +33,6 @@
 - time_delays # Test mode does not support cosmology ift
 - hpc/example_cpu # HPC paths dont exist locally.
 - examples/searches # Test mode breaks search visualization.
-- data_fitting # Test mode breaks .fits file output
 - cluster/modeling # Cluster modeling is not maintained and test mode breaks it.
 - cluster/start_here # Cluster analysis is not maintained and test mode breaks it.
 - mass_stellar_dark/modeling # Requires CSE to be JAX enabled.

--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -1,0 +1,83 @@
+"""
+Results: Quick Fit Helper
+=========================
+
+Internal helper invoked via subprocess from the tutorials in this folder
+(``start_here.py`` and everything under ``aggregator/``). Produces a fast,
+capped Nautilus fit at ``output/results_folder/`` so the aggregator examples
+have a populated results directory to read from.
+
+Idempotent: exits immediately if ``output/results_folder/`` already exists,
+so concurrent or repeated invocations are cheap.
+
+Not a tutorial. The model and dataset mirror those used in ``start_here.py``
+(``simple__no_lens_light`` imaging, isothermal lens + MGE source), but the
+search is hard-capped at ``n_like_max=300`` likelihood evaluations rather
+than running to convergence. This produces a shallow but valid posterior
+fast enough to fit inside the per-script CI timeout.
+"""
+
+import sys
+from pathlib import Path
+
+results_path = Path("output") / "results_folder"
+if results_path.exists():
+    sys.exit(0)
+
+import autofit as af
+import autolens as al
+
+dataset_name = "simple__no_lens_light"
+dataset_path = Path("dataset") / "imaging" / dataset_name
+
+if al.util.dataset.should_simulate(str(dataset_path)):
+    import subprocess
+
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/no_lens_light/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Imaging.from_fits(
+    data_path=dataset_path / "data.fits",
+    psf_path=dataset_path / "psf.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    pixel_scales=0.1,
+)
+
+mask_radius = 3.0
+
+mask = al.Mask2D.circular(
+    shape_native=dataset.shape_native,
+    pixel_scales=dataset.pixel_scales,
+    radius=mask_radius,
+)
+
+dataset = dataset.apply_mask(mask=mask)
+
+bulge = al.model_util.mge_model_from(
+    mask_radius=mask_radius,
+    total_gaussians=20,
+    gaussian_per_basis=1,
+    centre_prior_is_uniform=False,
+)
+
+model = af.Collection(
+    galaxies=af.Collection(
+        lens=af.Model(al.Galaxy, redshift=0.5, mass=al.mp.Isothermal),
+        source=af.Model(al.Galaxy, redshift=1.0, bulge=bulge, disk=None),
+    ),
+)
+
+search = af.Nautilus(
+    path_prefix=Path("results_folder"),
+    name="results",
+    unique_tag=dataset_name,
+    n_live=100,
+    n_batch=50,
+    n_like_max=300,
+)
+
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
+
+search.fit(model=model, analysis=analysis)

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -54,7 +54,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -61,11 +61,31 @@ import autolens as al
 import autolens.plot as aplt
 
 """
+__Quick Fit Auto-Trigger__
+
+If a previous fit has not been run yet, the shared helper ``_quick_fit.py`` is invoked to produce one.
+The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tutorial (and its siblings
+in this folder) have results to work with. When that folder already exists the helper exits immediately,
+so re-running this tutorial is cheap.
+"""
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
+        check=True,
+    )
+
+"""
 __Model Fit__
 
 To illustrate results, we need to perform a model-fit in order to create a `Result` object.
 
-The code below performs a model-fit using nautilus. 
+The code below performs a model-fit using nautilus. The helper above already wrote a completed fit to
+``output/results_folder/``, so the ``search.fit(...)`` call below resumes from that checkpoint and
+returns the in-memory ``Result`` object without redoing the search.
 
 You should be familiar with modeling already, if not read the `modeling/start_here.py` script before reading this one.
 """
@@ -125,6 +145,7 @@ search = af.Nautilus(
     unique_tag=dataset_name,
     n_live=100,
     n_batch=50,  # GPU lens model fits are batched and run simultaneously, see VRAM section below.
+    n_like_max=300,
 )
 
 analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -41,7 +41,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -41,7 +41,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -49,11 +49,31 @@ import autolens as al
 import autolens.plot as aplt
 
 """
+__Quick Fit Auto-Trigger__
+
+If a previous fit has not been run yet, the shared helper ``_quick_fit.py`` is invoked to produce one.
+The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tutorial (and its siblings
+in this folder) have results to work with. When that folder already exists the helper exits immediately,
+so re-running this tutorial is cheap.
+"""
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
+        check=True,
+    )
+
+"""
 __Model Fit__
 
 To illustrate results, we need to perform a model-fit in order to create a `Result` object.
 
-The code below performs a model-fit using Nautilus. 
+The code below performs a model-fit using Nautilus. The helper above already wrote a completed fit to
+``output/results_folder/``, so the ``search.fit(...)`` call below resumes from that checkpoint and
+returns the in-memory ``Result`` object without redoing the search.
 
 You should be familiar with modeling already, if not read the `modeling/start_here.py` script before reading this one!
 """
@@ -105,6 +125,7 @@ search = af.Nautilus(
     unique_tag=dataset_name,
     n_live=100,
     n_batch=50,  # GPU batching and VRAM use explained in `modeling` examples.
+    n_like_max=300,
 )
 
 analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -97,7 +97,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -242,25 +242,18 @@ model = af.Collection(
     ),
 )
 
-test_mode_was_on = os.environ.get("PYAUTO_TEST_MODE") == "1"
-if test_mode_was_on:
-    os.environ.pop("PYAUTO_TEST_MODE", None)
-
 search = af.Nautilus(
     path_prefix=Path("results_folder"),
     name="results",
     unique_tag=dataset_name,
     n_live=100,
     n_batch=50,  # GPU batching and VRAM use explained in `modeling` examples.
-    **({"n_like_max": 300} if test_mode_was_on else {}),
+    n_like_max=300,
 )
 
 analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result = search.fit(model=model, analysis=analysis)
-
-if test_mode_was_on:
-    os.environ["PYAUTO_TEST_MODE"] = "1"
 
 """
 __Info__


### PR DESCRIPTION
## Summary

Refactors `scripts/guides/results/` so the aggregator examples no longer each run their own ~10-minute Nautilus search and cascade-fail off each other in CI. Each aggregator example now auto-triggers a shared `_quick_fit.py` helper if `output/results_folder/` is missing. The helper writes a capped fit (`n_like_max=300`, ~14-33s end-to-end) to a fixed location, and every example loads from there. `start_here.py`'s previously-conditional `n_like_max=300` cap is now unconditional.

## Why

In the 2026-04-29 release-prep run, Cluster D in `triage.md` flagged 8 failures across this folder: 4 timeouts (each example duplicated the `search.fit()` block uncapped) and 4 cascading `NoneType` errors (downstream readers loaded the partial output of the timed-out scripts). Root cause: each example was duplicating a slow, uncapped search instead of routing through one helper, and `n_like_max` was gated on `PYAUTO_TEST_MODE` which `env_vars.yaml` unsets for this folder.

## API Changes

None.

## Scripts Changed

- `scripts/guides/results/_quick_fit.py` (new) - internal helper, capped Nautilus fit, idempotent (early-exits if `output/results_folder/` already exists).
- `scripts/guides/results/start_here.py` - drops the `test_mode_was_on` conditional gate on `n_like_max`; cap is now unconditional.
- `scripts/guides/results/aggregator/galaxies_fit.py` (autogalaxy) / `galaxies_fits.py` (autolens) - adds auto-trigger guard at top + `n_like_max=300` to the search.
- `scripts/guides/results/aggregator/samples.py` - same.
- `scripts/guides/results/aggregator/{models,queries,data_fitting,samples_via_aggregator}.py` - existing subprocess targets redirected from `start_here.py` to `_quick_fit.py`.
- `config/build/no_run.yaml` - removed: `guides/results/start_here` (autogalaxy), three stale `guides/results/examples/*` lines (both), stale `data_fitting` stem skip (both).

## Test plan

- [x] `_quick_fit.py` runs to completion locally with `n_like_max=300` cap and produces populated `output/results_folder/` (autogalaxy: ~14s, autolens: ~33s).
- [x] After the helper has run, `aggregator/models.py` exits 0 in both workspaces (loads result via `Aggregator.from_directory`, computes max-log-likelihood quantities).
- [x] Idempotency: re-running `_quick_fit.py` exits in 0.04s when output exists.
- [ ] CI release-prep run shows zero `guides/results/aggregator/*` failures.

Co-authored by Claude Code.