### PR TITLE
Cluster E: fix deblending simulator + add auto-simulate snippets to 3 guides

### DIFF
--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -233,6 +233,21 @@ We load an imaging dataset and illustrate its data structures below.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
 dataset = al.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -59,6 +59,21 @@ def fit():
     dataset_name = "simple"
     dataset_path = path.join("dataset", "imaging", dataset_name)
 
+    """
+    __Dataset Auto-Simulation__
+
+    If the dataset does not already exist on your system, it will be created by running the corresponding
+    simulator script. This ensures that all example scripts can be run without manually simulating data first.
+    """
+    if not path.exists(dataset_path):
+        import subprocess
+        import sys
+
+        subprocess.run(
+            [sys.executable, "scripts/imaging/simulator.py"],
+            check=True,
+        )
+
     dataset = al.Imaging.from_fits(
         data_path=path.join(dataset_path, "data.fits"),
         psf_path=path.join(dataset_path, "psf.fits"),

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -67,6 +67,21 @@ Load, plot and mask the `Imaging` data.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
 dataset = al.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/point_source/features/deblending/simulator.py
+++ b/scripts/point_source/features/deblending/simulator.py
@@ -246,6 +246,13 @@ The reason we choose this approach is because it is closer to how we model the m
 sources, where each multiple image is modeled in the image-plane as a separate light 
 profile (see `point_source/modeling/features/debeleing.ipynb` for a description of why).
 """
+point_image_kwargs = {
+    f"point_image_{i}": al.lp_operated.Gaussian(
+        centre=positions[i], intensity=fluxes[i], sigma=psf_sigma
+    )
+    for i in range(len(positions))
+}
+
 lens_galaxy = al.Galaxy(
     redshift=0.5,
     bulge=al.lp.Sersic(
@@ -255,23 +262,12 @@ lens_galaxy = al.Galaxy(
         effective_radius=0.6,
         sersic_index=3.0,
     ),
-    point_image_0=al.lp_operated.Gaussian(
-        centre=positions[0], intensity=fluxes[0], sigma=psf_sigma
-    ),
-    point_image_1=al.lp_operated.Gaussian(
-        centre=positions[1], intensity=fluxes[1], sigma=psf_sigma
-    ),
-    point_image_2=al.lp_operated.Gaussian(
-        centre=positions[2], intensity=fluxes[2], sigma=psf_sigma
-    ),
-    point_image_3=al.lp_operated.Gaussian(
-        centre=positions[3], intensity=fluxes[3], sigma=psf_sigma
-    ),
     mass=al.mp.Isothermal(
         centre=(0.0, 0.0),
         einstein_radius=1.6,
         ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
     ),
+    **point_image_kwargs,
 )
 
 """


### PR DESCRIPTION
## Summary

Clears 4 of the 5 failures grouped as Cluster E in the 2026-04-29 release-prep triage (`PyAutoBuild/test_results/runs/2026-04-29T14-48-47Z/triage.md`). All 4 stem from missing `dataset/*/data.fits` files: one because the deblending simulator crashed under `PYAUTO_SMALL_DATASETS=1`, and three because the consuming guides scripts had no auto-simulate snippet.

## Scripts Changed

- `scripts/point_source/features/deblending/simulator.py` — build `point_image_{i}` kwargs from `len(positions)` instead of hardcoding `[0..3]`. The `PointSolver` returns only 2 fixed positions under `PYAUTO_SMALL_DATASETS=1` (smoke-test short-circuit at `PyAutoLens/autolens/point/solver/point_solver.py:90`), which made the old `positions[2]` index raise `IndexError` and prevent `data.fits` from being written.
- `scripts/guides/data_structures.py` — add canonical auto-simulate snippet calling `scripts/imaging/simulator.py` when `dataset/imaging/simple/` is missing.
- `scripts/guides/modeling/bug_fix.py` — same auto-simulate snippet (uses `os.path.exists` to match the script's existing `path.join` style).
- `scripts/guides/modeling/chaining.py` — same auto-simulate snippet.

## Test Plan

- [x] All 4 scripts run to exit 0 from a wiped `dataset/imaging/simple/` and `dataset/point_source/deblending/` state under `PYAUTO_SMALL_DATASETS=1 PYAUTO_TEST_MODE=1 PYAUTO_FAST_PLOTS=1`
- [x] Downstream `deblending/modeling.py` runs after the simulator fix
- [ ] Smoke tests pass for the affected workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)