### PR TITLE
Add datacube/ feature — ALMA datacube modeling tutorial scripts

### DIFF
--- a/scripts/interferometer/features/datacube/README.md
+++ b/scripts/interferometer/features/datacube/README.md
@@ -7,6 +7,7 @@ The following example scripts illustrate datacube lens modeling where:
 - `start_here`: A first walkthrough — load a 4-channel cube, build the FactorGraph, fit with Nautilus.
 - `simulator`: Simulate a representative cube with a Gaussian emission line in the source.
 - `modeling`: Focused FactorGraph + pixelization fit, ready to point at your own cube.
+- `modeling_parametric`: Same wiring with a parametric `Sersic` source — shared morphology, per-channel intensity. Faster than the pixelization variant; appropriate when the source is well-described by a single Sersic.
 
 # Overview
 

--- a/scripts/interferometer/features/datacube/README.md
+++ b/scripts/interferometer/features/datacube/README.md
@@ -1,0 +1,15 @@
+The `datacube` folder contains example scripts showing how to model an ALMA-style spectral-line interferometer datacube as a list of per-channel `Interferometer` datasets sharing a single lens model.
+
+# Files
+
+The following example scripts illustrate datacube lens modeling where:
+
+- `start_here`: A first walkthrough — load a 4-channel cube, build the FactorGraph, fit with Nautilus.
+- `simulator`: Simulate a representative cube with a Gaussian emission line in the source.
+- `modeling`: Focused FactorGraph + pixelization fit, ready to point at your own cube.
+
+# Overview
+
+A "datacube" here is a Python list of `Interferometer` objects, one per spectral channel. The lens galaxy is shared across channels, and each channel reconstructs its own pixelized source — capturing the source's emission-line morphology channel by channel. The likelihood is the sum of per-channel log-evidences, which `af.FactorGraphModel` does for you.
+
+This Phase 1 prototype runs each channel's NUFFT and inversion independently — simple, but the per-channel inversion cost dominates runtime on CPU. The shared-`Lᵀ W̃ L` optimisation that exploits channel-invariant `uv_wavelengths` and `noise_map` is a follow-up.

--- a/scripts/interferometer/features/datacube/modeling.py
+++ b/scripts/interferometer/features/datacube/modeling.py
@@ -17,7 +17,9 @@ walkthrough; this file is the one to copy and adapt for your own cube.
 __Contents__
 
 **Mask:** Define the 2D real-space mask applied to every channel.
-**Dataset Loading:** Auto-simulate the cube if missing, then load each channel as an `Interferometer` object.
+**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
 **Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the pixelized source inversion.
 **Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
 **Mesh Shape:** Pixelization mesh size — fixed before modeling because JAX needs static-shape arrays.
@@ -56,25 +58,36 @@ real_space_mask = al.Mask2D.circular(
 )
 
 """
-__Dataset Loading__
+__Dataset__
 
-The datacube lives under `dataset/interferometer/datacube/<dataset_name>/`, with one subfolder per channel.
-We discover the channel folders by sorted directory listing — that way you can drop your own simulator output
-in there with the same `channel_NNN/` layout and this script will pick it up unchanged.
-
-The auto-simulation block runs the sibling `simulator.py` if the cube is missing, so this file is runnable
-end-to-end on a fresh checkout.
+The datacube lives under `dataset/interferometer/datacube/<dataset_name>/`, with one subfolder per channel
+(`channel_000/`, `channel_001/`, ...). To point this script at your own cube, drop your channel folders in
+alongside the reference cube and update `dataset_name`. Each channel folder must contain `data.fits`,
+`noise_map.fits` and `uv_wavelengths.fits` in the shape produced by `al.SimulatorInterferometer`.
 """
 dataset_label = "datacube"
 dataset_name = "sim_simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
 if not dataset_path.exists():
     subprocess.run(
         [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
         check=True,
     )
 
+"""
+__Dataset Loading__
+
+Build the cube by loading each channel folder as an `Interferometer` object. The result is a Python list — no
+new dataset class involved. Channels are discovered by sorted directory listing, so you can add channels by
+simply dropping more `channel_NNN/` folders in.
+"""
 channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
 print(f"Loading {len(channel_paths)} channels from {dataset_path}")
 

--- a/scripts/interferometer/features/datacube/modeling.py
+++ b/scripts/interferometer/features/datacube/modeling.py
@@ -1,0 +1,229 @@
+"""
+Modeling: Datacube
+===================
+
+This script fits a list of `Interferometer` channels — a "datacube" — with a single shared lens model and a
+per-channel pixelized source reconstruction. Each channel is an independent `Interferometer` dataset; the
+`af.FactorGraphModel` ties them together by feeding the same lens parameters into every channel's
+`AnalysisInterferometer.log_likelihood_function` and summing the per-channel log-evidences.
+
+A datacube modeled this way captures spatially-resolved spectral-line emission: every channel reconstructs its
+own source-plane pixelization, so an emission line that brightens-and-fades across the cube produces a sequence
+of source-plane reconstructions whose total flux traces the line profile while the lens mass stays fixed.
+
+This script is the focused-modeling sibling of `start_here.py`. Read `start_here.py` first for the narrative
+walkthrough; this file is the one to copy and adapt for your own cube.
+
+__Contents__
+
+**Mask:** Define the 2D real-space mask applied to every channel.
+**Dataset Loading:** Auto-simulate the cube if missing, then load each channel as an `Interferometer` object.
+**Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the pixelized source inversion.
+**Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
+**Mesh Shape:** Pixelization mesh size — fixed before modeling because JAX needs static-shape arrays.
+**Model:** Compose the shared `Isothermal + ExternalShear` lens and pixelized source.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True`.
+**FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
+**Search:** Configure the `Nautilus` non-linear search.
+**Model Fit:** Run the fit. Per-channel inversion cost dominates runtime — see notes inline.
+**Wrap Up:** Summary of the script and pointers to the JAX likelihood walkthrough in
+``autolens_workspace_developer/datacube/likelihood_function.py``.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import subprocess
+import sys
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+
+"""
+__Mask__
+
+Every channel uses the same `real_space_mask` — the lens galaxy and source position don't depend on frequency,
+so masking once is correct. The mask radius is generous enough to contain the lensed source's full extent.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset Loading__
+
+The datacube lives under `dataset/interferometer/datacube/<dataset_name>/`, with one subfolder per channel.
+We discover the channel folders by sorted directory listing — that way you can drop your own simulator output
+in there with the same `channel_NNN/` layout and this script will pick it up unchanged.
+
+The auto-simulation block runs the sibling `simulator.py` if the cube is missing, so this file is runnable
+end-to-end on a fresh checkout.
+"""
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
+
+if not dataset_path.exists():
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
+print(f"Loading {len(channel_paths)} channels from {dataset_path}")
+
+dataset_list = [
+    al.Interferometer.from_fits(
+        data_path=channel_path / "data.fits",
+        noise_map_path=channel_path / "noise_map.fits",
+        uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerDFT,
+    )
+    for channel_path in channel_paths
+]
+
+"""
+__Sparse Operators__
+
+Pixelized source modeling uses sparse linear algebra to keep memory and runtime manageable. We pre-compute a
+sparse-operator matrix per channel so each `AnalysisInterferometer.log_likelihood_function` reuses it directly
+during the fit. For SMA-scale data this finishes in seconds per channel; for ALMA-scale cubes it can take
+minutes per channel on CPU, in which case see `pixelization/many_visibilities_preparation.py` for how to
+compute and cache them once.
+"""
+dataset_list = [
+    dataset.apply_sparse_operator(use_jax=True, show_progress=False)
+    for dataset in dataset_list
+]
+
+"""
+__Settings__
+
+Interferometer pixelizations disable the positive-only inversion solver — the visibility measurement process
+can produce genuinely negative dirty-image pixel values, so the source-plane reconstruction must be allowed
+to go negative.
+"""
+settings = al.Settings(use_positive_only_solver=False)
+
+"""
+__Mesh Shape__
+
+The pixelization mesh shape is fixed before modeling because JAX needs static array shapes. We use a
+14 x 14 ``RectangularUniform`` mesh — small enough to keep the prototype cheap, large enough to capture the
+emission-line source morphology produced by the simulator.
+"""
+mesh_pixels_yx = 14
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+"""
+__Model__
+
+The lens galaxy is a shared `Isothermal + ExternalShear`, identical across every channel. The source galaxy is
+a `Pixelization` with a `RectangularUniform` mesh and `Constant` regularization — the inversion runs
+independently per channel inside each `AnalysisInterferometer`, giving each channel its own source-plane
+reconstruction without adding any model parameters.
+
+There are no per-channel free parameters: every prior in this base model is identified across factors when the
+`FactorGraph` deduplicates them below.
+"""
+# Lens:
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+# Source (pixelization, no free priors):
+mesh = af.Model(al.mesh.RectangularUniform, shape=mesh_shape)
+regularization = af.Model(al.reg.Constant)
+pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall lens model:
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+print(model.info)
+
+"""
+__Per-Channel Analyses__
+
+One `AnalysisInterferometer` per channel, all with `use_jax=True` so the FactorGraph fit runs on the JAX
+backend.
+"""
+analysis_list = [
+    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    for dataset in dataset_list
+]
+
+"""
+__FactorGraph__
+
+Each analysis is wrapped in an `af.AnalysisFactor` paired with a deep copy of the base model. With no per-factor
+prior overrides, every prior is identified across factors — so the global model has the same dimensionality as
+the single-channel base model. ``af.FactorGraphModel(..., use_jax=True)`` sums the per-channel log-evidences
+internally, which is exactly the cube log-likelihood you'd write by hand.
+"""
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=model.copy(), analysis=analysis)
+    for analysis in analysis_list
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(f"  channels in factor graph:           {len(analysis_factor_list)}")
+print(f"  global model free parameters:       {factor_graph.global_prior_model.total_free_parameters}")
+
+"""
+__Search__
+
+`Nautilus` is the standard non-linear search for PyAutoLens. Datacube fits typically need fewer live points
+than imaging fits because the lens dimensionality is unchanged — only the per-channel inversions multiply.
+Tune `n_live` for your problem.
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "datacube",
+    name="modeling",
+    unique_tag=dataset_name,
+    n_live=100,
+    n_batch=20,
+    iterations_per_quick_update=50000,
+)
+
+"""
+__Model Fit__
+
+Pass the factor graph's `global_prior_model` as the model and the factor graph itself as the analysis — that's
+the same shape you'd use for any multi-dataset PyAutoFit fit.
+
+**Run time on CPU is dominated by the per-channel inversion.** A 4-channel SMA-scale cube finishes in a few
+hours on CPU; ALMA-scale cubes with 50+ channels need GPU acceleration to complete in reasonable time. The
+``Lᵀ W̃ L`` shared-precompute optimisation (Aris's design — exploit the fact that ``uv_wavelengths`` and
+``noise_map`` change very little channel-to-channel) is the natural follow-up that brings ALMA-scale cubes
+back inside the budget.
+"""
+print(
+    """
+    The non-linear search has begun running.
+
+    This Jupyter notebook cell with progress once the search has completed - this could take a while
+    for a datacube fit, since per-channel inversions multiply the per-likelihood cost.
+    """
+)
+
+result_list = search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)
+
+"""
+__Wrap Up__
+
+The result returned by `search.fit` is a list of per-factor results — one entry per channel — each carrying its
+own `FitInterferometer` against the maximum-likelihood lens model. Use them to inspect the per-channel source
+reconstructions, dirty images, and residuals.
+
+For a step-by-step look at how the per-channel likelihood is summed (and at the JAX JIT pattern that drives
+this fit), see ``autolens_workspace_developer/datacube/likelihood_function.py``.
+"""

--- a/scripts/interferometer/features/datacube/modeling_parametric.py
+++ b/scripts/interferometer/features/datacube/modeling_parametric.py
@@ -1,0 +1,223 @@
+"""
+Modeling: Datacube — Parametric Source
+=======================================
+
+This script fits a datacube — a list of `Interferometer` channels — with a single shared lens model and a
+**parametric** source (`al.lp.Sersic`) whose morphology is shared across channels and whose `intensity` varies
+channel-to-channel. It is the parametric-fit sibling of `modeling.py`, which fits the same cube with a
+pixelized source instead.
+
+Use this script when:
+
+ - You expect the source emission to be well-described by a single Sersic-like shape across the line — for
+   example, a high-signal-to-noise unresolved emission line in a kinematically simple galaxy.
+ - You want a cheaper fit than the pixelization variant. Parametric inversions are 1–2 orders of magnitude
+   faster than per-channel pixelizations because there is no source-plane linear inversion.
+ - You want the per-channel `intensity` posterior directly, with no need to integrate a pixelized
+   reconstruction back to a total flux.
+
+Use `modeling.py` (the pixelized variant) instead when the source has complex morphology, internal velocity
+structure that varies across the cube, or signal-to-noise too low for a Sersic fit to converge.
+
+The FactorGraph wiring here is the canonical "extend the model per dataset" pattern from
+`autolens_workspace/scripts/multi/modeling.py`: every prior in the base model is shared across channels by
+default, and we explicitly override the source `intensity` prior per `AnalysisFactor` to make it per-channel.
+
+__Contents__
+
+**Mask:** Define the 2D real-space mask applied to every channel.
+**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+**Settings:** Default `al.Settings()` — no positive-only-solver tweak needed (no inversion).
+**Model:** Compose the shared `Isothermal + ExternalShear` lens and `Sersic` source.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True`.
+**FactorGraph:** Per-factor `model.copy()` with the source `intensity` prior overridden per channel.
+**Search:** Configure the `Nautilus` non-linear search.
+**Model Fit:** Run the fit. Per-channel cost is much cheaper than the pixelization variant.
+**Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import subprocess
+import sys
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+
+"""
+__Mask__
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+The datacube lives under `dataset/interferometer/datacube/<dataset_name>/`, with one subfolder per channel.
+"""
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+"""
+__Dataset Loading__
+"""
+channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
+print(f"Loading {len(channel_paths)} channels from {dataset_path}")
+
+dataset_list = [
+    al.Interferometer.from_fits(
+        data_path=channel_path / "data.fits",
+        noise_map_path=channel_path / "noise_map.fits",
+        uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerDFT,
+    )
+    for channel_path in channel_paths
+]
+
+"""
+__Settings__
+
+Parametric sources don't run a source-plane inversion, so we don't need to disable a positive-only solver
+here. Default settings are fine.
+"""
+settings = al.Settings()
+
+"""
+__Model__
+
+The cube model has two ingredients:
+
+ - A shared `Isothermal + ExternalShear` lens (7 free parameters).
+ - A parametric `al.lp.Sersic` source. Its morphology — `centre`, `ell_comps`, `effective_radius`,
+   `sersic_index` — is shared across channels (4 free parameters). Its `intensity` will be overridden
+   per-factor below to give each channel its own free `intensity` parameter, capturing the emission-line
+   spectrum.
+
+Total free parameters:
+   7 (lens)  +  4 (source morphology, shared)  +  N_channels * 1 (per-channel intensity)
+   = 11 + N_channels
+
+For the 4-channel reference cube that's 15 free parameters total — tractable for `Nautilus`.
+"""
+# Lens:
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+# Source (parametric Sersic — base prior on intensity gets overridden per factor below):
+bulge = af.Model(al.lp.Sersic)
+source = af.Model(al.Galaxy, redshift=1.0, bulge=bulge)
+
+# Overall lens model:
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+print(model.info)
+
+"""
+__Per-Channel Analyses__
+"""
+analysis_list = [
+    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    for dataset in dataset_list
+]
+
+"""
+__FactorGraph__
+
+Each analysis is wrapped in an `af.AnalysisFactor` paired with a deep copy of the base model. We then override
+the source `intensity` prior per factor — overwriting the prior with a fresh `LogUniformPrior` makes that
+parameter per-channel rather than identified across factors. Every other source parameter (centre, ell_comps,
+effective_radius, sersic_index) is left untouched, so the FactorGraph identifies them across channels.
+
+This is the canonical "extend the model per dataset" pattern from `autolens_workspace/scripts/multi/modeling.py`.
+"""
+analysis_factor_list = []
+
+for analysis in analysis_list:
+    model_analysis = model.copy()
+
+    # Per-channel intensity prior — overrides the shared default with a fresh prior object,
+    # which the FactorGraph treats as a distinct (per-factor) parameter.
+    model_analysis.galaxies.source.bulge.intensity = af.LogUniformPrior(
+        lower_limit=1e-3, upper_limit=10.0
+    )
+
+    analysis_factor_list.append(
+        af.AnalysisFactor(prior_model=model_analysis, analysis=analysis)
+    )
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(f"  channels in factor graph:           {len(analysis_factor_list)}")
+print(f"  global model free parameters:       {factor_graph.global_prior_model.total_free_parameters}")
+
+"""
+__Search__
+
+Parametric datacube fits have a higher non-linear dimensionality than the pixelization variant (per-channel
+intensity adds one parameter per channel) but a much cheaper per-likelihood cost. Tuning depends on your cube;
+`n_live=150` is a reasonable starting point.
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "datacube",
+    name="modeling_parametric",
+    unique_tag=dataset_name,
+    n_live=150,
+    n_batch=20,
+    iterations_per_quick_update=50000,
+)
+
+"""
+__Model Fit__
+
+Run the fit. Per-channel cost is much cheaper than `modeling.py` because there is no source-plane inversion,
+just a forward Sersic evaluation per channel followed by the Fourier transform.
+"""
+print(
+    """
+    The non-linear search has begun running.
+
+    Parametric datacube fits are typically faster than pixelized ones — the per-likelihood cost is dominated
+    by the per-channel NUFFT, with no per-channel inversion on top.
+    """
+)
+
+result_list = search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)
+
+"""
+__Wrap Up__
+
+The result returned by `search.fit` is a list of per-factor results — one entry per channel — each carrying
+its own `FitInterferometer` against the maximum-likelihood lens + source-morphology model and the per-channel
+intensity. The recovered per-channel intensities should trace the input emission-line spectrum stored in
+`dataset/interferometer/datacube/<name>/cube_summary.json`.
+
+For the pixelized variant of this fit (free-form per-channel source reconstruction), see `modeling.py`. For
+the narrative walkthrough, see `start_here.py`. For a step-by-step JAX likelihood walkthrough of how the
+per-channel log-evidences are summed inside the FactorGraph, see
+`autolens_workspace_developer/datacube/likelihood_function.py`.
+"""

--- a/scripts/interferometer/features/datacube/simulator.py
+++ b/scripts/interferometer/features/datacube/simulator.py
@@ -1,0 +1,276 @@
+"""
+Simulator: Datacube
+====================
+
+This script simulates an ALMA-style spectral-line `Interferometer` datacube of a 'galaxy-scale' strong lens where:
+
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`, identical across all channels.
+ - The source galaxy's light is an `Sersic`, whose `intensity` follows a Gaussian emission-line profile in the
+   channel index (peaking near the cube centre and falling off at the edges).
+
+A "datacube" here is a Python list of `Interferometer` objects, one per spectral channel. Each channel writes its
+own ``data.fits`` / ``noise_map.fits`` / ``uv_wavelengths.fits`` into a separate folder, alongside the true tracer
+for that channel. The modeling examples in this folder load the cube by listing those folders.
+
+For Phase 1 of datacube modeling we keep things deliberately simple: every channel uses the same `uv_wavelengths`
+and the same noise level, and only the source `intensity` varies. That mirrors what most ALMA spectral-line
+datasets look like once narrow-band continuum subtraction has been performed.
+
+__Contents__
+
+**Cube Configuration:** Number of channels and the emission-line shape used to drive the per-channel intensity.
+**Dataset Paths:** Where the per-channel datasets, summary JSON and overview plots are written.
+**uv_wavelengths:** Reuse the SMA `uv_wavelengths.fits` shipped with the workspace as a stand-in for ALMA coverage.
+**Real-Space Grid:** The 2D image-plane grid each channel is evaluated on before the Fourier transform.
+**Lens Galaxy:** Shared `Isothermal + ExternalShear` lens, identical for every channel.
+**Per-Channel Source:** A Gaussian emission line in channel index drives the per-channel `Sersic.intensity`.
+**Per-Channel Simulate:** Loop over channels: build the tracer, simulate, write FITS + tracer.json to disk.
+**Cube Summary:** Dump the emission-line parameters and per-channel intensities to `cube_summary.json`.
+**Cube Overview Plot:** Row-per-channel sanity figure (lensed image, uv-plane Re/Im, |vis| vs baseline length).
+**Spectrum Plot:** Source intensity as a function of channel index.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import autolens as al
+
+"""
+__Cube Configuration__
+
+The cube shape is set by ``N_CHANNELS`` and the emission-line shape by the Gaussian profile parameters below. Keep
+``N_CHANNELS`` small for the prototype: per-channel inversion cost grows linearly, and 4 channels are enough to
+exercise the FactorGraph wiring end-to-end.
+"""
+N_CHANNELS = 4
+PEAK_CHANNEL = 1.5
+SIGMA_CHANNEL = 1.2
+PEAK_INTENSITY = 0.6
+
+"""
+__Dataset Paths__
+
+Each channel lives in its own subfolder so the modeling scripts can iterate over them with a simple loop. The
+``cube_summary.json`` records the emission-line parameters used to simulate the cube — modeling can compare the
+recovered per-channel source amplitudes against those true values.
+"""
+dataset_type = "interferometer"
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+
+dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
+dataset_path.mkdir(parents=True, exist_ok=True)
+
+"""
+__uv_wavelengths__
+
+Load the SMA `uv_wavelengths.fits` shipped with the workspace at ``dataset/interferometer/uv_wavelengths/sma.fits``.
+SMA's coverage is small (~190 visibilities) but it makes the prototype fast to iterate on without paying the ALMA
+runtime cost. To swap in a real ALMA cube, point this path at your own per-channel `uv_wavelengths.fits` files
+inside the simulation loop below.
+"""
+uv_wavelengths_path = Path("dataset", dataset_type, "uv_wavelengths")
+uv_wavelengths = al.ndarray_via_fits_from(
+    file_path=uv_wavelengths_path / "sma.fits", hdu=0
+)
+
+"""
+__Real-Space Grid__
+
+For interferometer data this image is evaluated in real space and then Fourier-transformed. Interferometer
+calculations don't need over-sampling — the Fourier transform is the dominant numerical cost.
+"""
+grid = al.Grid2D.uniform(shape_native=(256, 256), pixel_scales=0.1)
+
+"""
+__Lens Galaxy__
+
+The lens mass + external shear is shared across channels — the lens doesn't change with frequency.
+"""
+lens_galaxy = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=1.6,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+    ),
+    shear=al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05),
+)
+
+"""
+__Per-Channel Source__
+
+The source intensity follows a Gaussian profile in channel index — that's the simplest model of an emission line
+peaking at one velocity and falling off symmetrically. The shape (centre, ellipticity, effective radius, Sersic
+index) is held fixed; only ``intensity`` varies channel-to-channel.
+"""
+
+
+def channel_intensity(channel: int) -> float:
+    return PEAK_INTENSITY * float(
+        np.exp(-0.5 * ((channel - PEAK_CHANNEL) / SIGMA_CHANNEL) ** 2)
+    )
+
+
+def source_galaxy_for(channel: int) -> al.Galaxy:
+    return al.Galaxy(
+        redshift=1.0,
+        bulge=al.lp.SersicCore(
+            centre=(0.1, 0.1),
+            ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+            intensity=channel_intensity(channel),
+            effective_radius=1.0,
+            sersic_index=2.5,
+        ),
+    )
+
+
+"""
+__Per-Channel Simulate__
+
+For each channel we build a tracer with the shared lens + the per-channel source, run
+``SimulatorInterferometer.via_tracer_from``, and write the resulting visibilities, noise map, baselines and true
+tracer into ``channel_NNN/``. The `noise_seed` is incremented per channel so each channel sees an independent noise
+realisation.
+"""
+channel_intensities = []
+datasets = []
+tracers = []
+
+for channel in range(N_CHANNELS):
+    intensity = channel_intensity(channel)
+    channel_intensities.append(intensity)
+
+    channel_path = dataset_path / f"channel_{channel:03d}"
+    channel_path.mkdir(parents=True, exist_ok=True)
+
+    source_galaxy = source_galaxy_for(channel)
+    tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
+
+    simulator = al.SimulatorInterferometer(
+        uv_wavelengths=uv_wavelengths,
+        exposure_time=300.0,
+        noise_sigma=1000.0,
+        transformer_class=al.TransformerDFT,
+        noise_seed=1 + channel,
+    )
+
+    dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)
+    datasets.append(dataset)
+    tracers.append(tracer)
+
+    al.output_to_fits(
+        values=np.stack([dataset.data.real, dataset.data.imag], axis=-1),
+        file_path=channel_path / "data.fits",
+        overwrite=True,
+    )
+    al.output_to_fits(
+        values=np.stack([dataset.noise_map.real, dataset.noise_map.imag], axis=-1),
+        file_path=channel_path / "noise_map.fits",
+        overwrite=True,
+    )
+    al.output_to_fits(
+        values=dataset.uv_wavelengths,
+        file_path=channel_path / "uv_wavelengths.fits",
+        overwrite=True,
+    )
+    al.output_to_json(
+        obj=tracer,
+        file_path=channel_path / "tracer.json",
+    )
+
+    print(
+        f"  channel {channel:03d}: intensity={intensity:.4f}, "
+        f"|vis|_max={np.max(np.abs(dataset.data)):.3e}"
+    )
+
+"""
+__Cube Summary__
+
+A small JSON sidecar lets downstream scripts (and the user) recover the emission-line parameters used during
+simulation without re-running the script.
+"""
+summary = {
+    "n_channels": N_CHANNELS,
+    "peak_channel": PEAK_CHANNEL,
+    "sigma_channel": SIGMA_CHANNEL,
+    "peak_intensity": PEAK_INTENSITY,
+    "channel_intensities": channel_intensities,
+}
+with open(dataset_path / "cube_summary.json", "w") as f:
+    json.dump(summary, f, indent=2)
+
+"""
+__Cube Overview Plot__
+
+Row-per-channel sanity figure: lensed real-space image, Re(visibilities) and Im(visibilities) in the uv-plane,
+and |vis| as a function of baseline length. Useful for eyeballing whether the emission-line modulation has
+propagated through the simulator end-to-end.
+"""
+fig, axes = plt.subplots(N_CHANNELS, 4, figsize=(16, 3.4 * N_CHANNELS), squeeze=False)
+
+for c in range(N_CHANNELS):
+    dataset = datasets[c]
+    tracer = tracers[c]
+    uv = np.asarray(dataset.uv_wavelengths)
+    re = np.asarray(dataset.data.real)
+    im = np.asarray(dataset.data.imag)
+    amp = np.hypot(re, im)
+    baseline = np.hypot(uv[:, 0], uv[:, 1])
+
+    image = tracer.image_2d_from(grid=grid)
+    axes[c, 0].imshow(np.asarray(image.native), origin="lower", cmap="hot")
+    axes[c, 0].set_title(f"channel {c}: lensed image (I={channel_intensities[c]:.3f})")
+    axes[c, 0].set_axis_off()
+
+    sc = axes[c, 1].scatter(uv[:, 0], uv[:, 1], c=re, s=8, cmap="RdBu_r")
+    axes[c, 1].set_title("Re(visibilities)")
+    axes[c, 1].set_aspect("equal")
+    axes[c, 1].set_xlabel("u")
+    axes[c, 1].set_ylabel("v")
+    plt.colorbar(sc, ax=axes[c, 1], fraction=0.046)
+
+    sc = axes[c, 2].scatter(uv[:, 0], uv[:, 1], c=im, s=8, cmap="RdBu_r")
+    axes[c, 2].set_title("Im(visibilities)")
+    axes[c, 2].set_aspect("equal")
+    axes[c, 2].set_xlabel("u")
+    axes[c, 2].set_ylabel("v")
+    plt.colorbar(sc, ax=axes[c, 2], fraction=0.046)
+
+    axes[c, 3].scatter(baseline, amp, s=8, alpha=0.6)
+    axes[c, 3].set_title("|vis| vs baseline length")
+    axes[c, 3].set_xlabel(r"$\sqrt{u^2 + v^2}$")
+    axes[c, 3].set_ylabel("|visibilities|")
+
+fig.tight_layout()
+fig.savefig(dataset_path / "cube_overview.png", dpi=120, bbox_inches="tight")
+plt.close(fig)
+
+"""
+__Spectrum Plot__
+
+Source intensity vs channel index — the input emission-line profile this cube was simulated from. Modeling
+scripts can compare the recovered per-channel inversion magnitude against this curve to sanity-check the fit.
+"""
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.plot(range(N_CHANNELS), channel_intensities, "o-")
+ax.set_xlabel("channel index")
+ax.set_ylabel("source intensity")
+ax.set_title(f"emission-line spectrum (peak={PEAK_CHANNEL}, sigma={SIGMA_CHANNEL})")
+ax.grid(True, alpha=0.3)
+fig.tight_layout()
+fig.savefig(dataset_path / "spectrum.png", dpi=120, bbox_inches="tight")
+plt.close(fig)
+
+print(f"  cube simulated: {dataset_path}")
+print(f"    channels:           {N_CHANNELS}")
+print(f"    visibilities/chan:  {uv_wavelengths.shape[0]}")
+print(f"    real-space grid:    256 x 256")
+print(f"    peak intensity:     {PEAK_INTENSITY}")

--- a/scripts/interferometer/features/datacube/start_here.py
+++ b/scripts/interferometer/features/datacube/start_here.py
@@ -26,8 +26,9 @@ __Contents__
 
 **JAX:** GPU/CPU acceleration via JAX — the same backend that single-channel interferometer fits use.
 **Imports:** Standard PyAutoLens imports + `autofit` for the FactorGraph wiring.
-**Cube on Disk:** Where the per-channel data lives, and how to auto-simulate a reference cube.
 **Mask:** A single 2D real-space mask shared across all channels.
+**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
 **Dataset Loading:** Loop over channel folders to build a `dataset_list` of `Interferometer` objects.
 **Sparse Operators:** Per-channel sparse-operator pre-compute used by the pixelized source inversion.
 **Settings:** Disable the positive-only solver (visibility inversions can take negative pixel values).
@@ -63,32 +64,6 @@ import autolens as al
 import autolens.plot as aplt
 
 """
-__Cube on Disk__
-
-The reference cube ships in `dataset/interferometer/datacube/sim_simple/`, with one subfolder per channel
-(`channel_000/`, `channel_001/`, ...) each containing `data.fits`, `noise_map.fits`, `uv_wavelengths.fits` and
-the true `tracer.json`. If the cube isn't on disk yet — for example, on a fresh checkout — this block runs the
-sibling `simulator.py` to generate it.
-
-To point this script at your own cube, drop your channel folders in alongside the reference cube and update
-`dataset_name`. Each channel folder must contain `data.fits`, `noise_map.fits` and `uv_wavelengths.fits` in the
-shape produced by `al.SimulatorInterferometer` (visibilities and noise stored as ``(n_vis, 2)`` real/imag pairs;
-baselines as ``(n_vis, 2)`` u/v pairs).
-"""
-dataset_label = "datacube"
-dataset_name = "sim_simple"
-dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
-
-if not dataset_path.exists():
-    subprocess.run(
-        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
-        check=True,
-    )
-
-channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
-print(f"Found {len(channel_paths)} channels in {dataset_path}")
-
-"""
 __Mask__
 
 A single 2D circular mask shared across every channel. The lens galaxy and the source emission live in the same
@@ -103,6 +78,34 @@ real_space_mask = al.Mask2D.circular(
 )
 
 """
+__Dataset__
+
+The reference cube ships in `dataset/interferometer/datacube/sim_simple/`, with one subfolder per channel
+(`channel_000/`, `channel_001/`, ...) each containing `data.fits`, `noise_map.fits`, `uv_wavelengths.fits` and
+the true `tracer.json`.
+
+To point this script at your own cube, drop your channel folders in alongside the reference cube and update
+`dataset_name`. Each channel folder must contain `data.fits`, `noise_map.fits` and `uv_wavelengths.fits` in the
+shape produced by `al.SimulatorInterferometer` (visibilities and noise stored as ``(n_vis, 2)`` real/imag pairs;
+baselines as ``(n_vis, 2)`` u/v pairs).
+"""
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+"""
 __Dataset Loading__
 
 Build the cube by loading each channel folder as an `Interferometer` object. The result is a Python list — no
@@ -110,6 +113,9 @@ new dataset class involved. Every downstream component (analyses, factors, fits,
 list directly, which is the whole reason we picked the list-of-Interferometer design over a bespoke
 `Datacube3D` class.
 """
+channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
+print(f"Found {len(channel_paths)} channels in {dataset_path}")
+
 dataset_list = [
     al.Interferometer.from_fits(
         data_path=channel_path / "data.fits",

--- a/scripts/interferometer/features/datacube/start_here.py
+++ b/scripts/interferometer/features/datacube/start_here.py
@@ -1,0 +1,287 @@
+"""
+Start Here: Datacube
+====================
+
+A datacube is a stack of interferometer observations of the same lens taken across many spectral channels — for
+example, an ALMA observation of a CO emission line in a high-redshift lensed galaxy, where each channel records
+visibilities at a slightly different frequency. The lens galaxy is the same in every channel, but the source's
+emission-line morphology varies across the cube: bright in channels close to the line peak, faint in channels at
+the line wings, and shifting in shape if the source has internal velocity structure.
+
+This script shows how to model such a cube in PyAutoLens by treating it as exactly that — a Python list of
+`Interferometer` objects, one per channel — and tying them together with `af.FactorGraphModel`. The lens model is
+shared across every channel, and each channel reconstructs its own pixelized source. The result is a per-channel
+sequence of source-plane reconstructions whose combined likelihood drives a single, global lens model fit.
+
+This is Phase 1 of datacube modeling. It deliberately runs each channel's NUFFT and source inversion
+independently, because reusing existing single-channel code is the fastest path to a working end-to-end
+demonstration. The faster shared-`Lᵀ W̃ L` design — which exploits the fact that `uv_wavelengths` and
+`noise_map` change very little across an emission line — is a follow-up that lands once this prototype is proven.
+
+If you've already read `interferometer/start_here.py`, the bulk of this script will look familiar. The new
+ingredients are the loop that loads each channel, the `AnalysisFactor` per channel, and the `FactorGraphModel`
+that sums them.
+
+__Contents__
+
+**JAX:** GPU/CPU acceleration via JAX — the same backend that single-channel interferometer fits use.
+**Imports:** Standard PyAutoLens imports + `autofit` for the FactorGraph wiring.
+**Cube on Disk:** Where the per-channel data lives, and how to auto-simulate a reference cube.
+**Mask:** A single 2D real-space mask shared across all channels.
+**Dataset Loading:** Loop over channel folders to build a `dataset_list` of `Interferometer` objects.
+**Sparse Operators:** Per-channel sparse-operator pre-compute used by the pixelized source inversion.
+**Settings:** Disable the positive-only solver (visibility inversions can take negative pixel values).
+**Mesh Shape:** The pixelization mesh shape — fixed before modeling because JAX needs static shapes.
+**Model:** Shared lens galaxy + pixelized source. The same model is reused unchanged across every channel.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel.
+**FactorGraph:** Wrap each analysis in an `AnalysisFactor`; combine via `af.FactorGraphModel`.
+**Search:** Configure the `Nautilus` non-linear search.
+**Model Fit:** Fit the cube — the FactorGraph routes shared lens parameters into every channel's likelihood.
+**Result:** What the returned `result_list` contains and how to inspect per-channel reconstructions.
+**Wrap Up:** Pointers to `modeling.py`, `simulator.py`, and the JAX likelihood walkthrough.
+
+__JAX__
+
+PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU support, your
+fits will run much faster (tens of minutes instead of several hours for a 4-channel cube). On CPU, JAX still
+provides a meaningful speed-up via multithreading, but datacube fits are inherently more expensive than
+single-channel fits because the per-channel inversion cost multiplies by the number of channels.
+
+If you don't have a GPU locally, consider Google Colab, which provides free GPUs.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import subprocess
+import sys
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Cube on Disk__
+
+The reference cube ships in `dataset/interferometer/datacube/sim_simple/`, with one subfolder per channel
+(`channel_000/`, `channel_001/`, ...) each containing `data.fits`, `noise_map.fits`, `uv_wavelengths.fits` and
+the true `tracer.json`. If the cube isn't on disk yet — for example, on a fresh checkout — this block runs the
+sibling `simulator.py` to generate it.
+
+To point this script at your own cube, drop your channel folders in alongside the reference cube and update
+`dataset_name`. Each channel folder must contain `data.fits`, `noise_map.fits` and `uv_wavelengths.fits` in the
+shape produced by `al.SimulatorInterferometer` (visibilities and noise stored as ``(n_vis, 2)`` real/imag pairs;
+baselines as ``(n_vis, 2)`` u/v pairs).
+"""
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
+
+if not dataset_path.exists():
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
+print(f"Found {len(channel_paths)} channels in {dataset_path}")
+
+"""
+__Mask__
+
+A single 2D circular mask shared across every channel. The lens galaxy and the source emission live in the same
+sky region in every frequency channel, so masking once and reusing the mask is correct.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset Loading__
+
+Build the cube by loading each channel folder as an `Interferometer` object. The result is a Python list — no
+new dataset class involved. Every downstream component (analyses, factors, fits, plotters) operates on this
+list directly, which is the whole reason we picked the list-of-Interferometer design over a bespoke
+`Datacube3D` class.
+"""
+dataset_list = [
+    al.Interferometer.from_fits(
+        data_path=channel_path / "data.fits",
+        noise_map_path=channel_path / "noise_map.fits",
+        uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerDFT,
+    )
+    for channel_path in channel_paths
+]
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset_list[0])
+
+"""
+__Sparse Operators__
+
+Pixelized source modeling uses sparse linear algebra to keep memory and runtime manageable. We pre-compute a
+sparse-operator matrix per channel — `apply_sparse_operator()` does this work in seconds for SMA-scale data and
+in minutes per channel on CPU for ALMA-scale data. For very large cubes you'll want to compute these once and
+cache them; see `pixelization/many_visibilities_preparation.py` for the pattern.
+"""
+dataset_list = [
+    dataset.apply_sparse_operator(use_jax=True, show_progress=False)
+    for dataset in dataset_list
+]
+
+"""
+__Settings__
+
+Interferometer pixelizations disable the positive-only inversion solver. The visibility measurement process
+can produce genuinely negative dirty-image pixel values, so the source-plane reconstruction must be allowed to
+go negative — forcing positivity here would create unphysical bias.
+"""
+settings = al.Settings(use_positive_only_solver=False)
+
+"""
+__Mesh Shape__
+
+The pixelization mesh shape is fixed before modeling because JAX needs static-shape arrays for its source-plane
+linear algebra. We use a 14 x 14 `RectangularUniform` mesh — small enough to make the prototype iteration cheap,
+large enough to capture the emission-line source morphology produced by the simulator.
+"""
+mesh_pixels_yx = 14
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+"""
+__Model__
+
+The cube model has two ingredients:
+
+ - A shared `Isothermal + ExternalShear` lens. There are 7 free parameters (mass centre, ellipticity components,
+   einstein radius, two shear components). The lens does not change with frequency, so a single set of priors is
+   used for every channel.
+ - A pixelized source: a `RectangularUniform` mesh with `Constant` regularization (1 free parameter — the
+   regularization coefficient). The pixelization itself has no per-pixel priors; the source-plane fluxes are a
+   linear inversion output computed by each channel's `AnalysisInterferometer` at fit time. That is what makes
+   each channel an independent linear solve while sharing all of the non-linear parameters.
+
+The total dimensionality of the non-linear parameter space is therefore 8.
+"""
+# Lens:
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+# Source (pixelization, no per-pixel priors):
+mesh = af.Model(al.mesh.RectangularUniform, shape=mesh_shape)
+regularization = af.Model(al.reg.Constant)
+pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall lens model:
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+print(model.info)
+
+"""
+__Per-Channel Analyses__
+
+One `AnalysisInterferometer` per channel — there are no per-channel parameters here, only per-channel data.
+Each analysis runs its own NUFFT, builds its own visibility-space inversion, and returns its own log-evidence
+when called with a candidate lens model.
+"""
+analysis_list = [
+    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    for dataset in dataset_list
+]
+
+"""
+__FactorGraph__
+
+`af.AnalysisFactor` pairs each analysis with a deep copy of the base model, and `af.FactorGraphModel` combines
+the factors into a single global model whose log-likelihood is the sum of the per-factor log-likelihoods. With
+no per-factor prior overrides, every prior is *identified* across factors — the factor-graph machinery
+deduplicates them — so the global model has the same dimensionality as the single-channel base model.
+
+If you wanted per-channel free parameters (for example, a per-channel `intensity` for a parametric source),
+you'd override that prior on each `model.copy()` before wrapping it in an `AnalysisFactor`. See
+`autolens_workspace/scripts/multi/modeling.py` for how that works in the multi-band case.
+"""
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=model.copy(), analysis=analysis)
+    for analysis in analysis_list
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(f"  channels in factor graph:           {len(analysis_factor_list)}")
+print(f"  global model free parameters:       {factor_graph.global_prior_model.total_free_parameters}")
+
+"""
+__Search__
+
+`Nautilus` is the standard non-linear search for PyAutoLens. The lens dimensionality is unchanged from a
+single-channel fit, so `n_live=100` is a reasonable starting point — but the per-likelihood cost is N times
+larger because each likelihood call runs N inversions, so wall-clock time scales linearly with the number of
+channels.
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "datacube",
+    name="start_here",
+    unique_tag=dataset_name,
+    n_live=100,
+    n_batch=20,
+    iterations_per_quick_update=50000,
+)
+
+"""
+__Model Fit__
+
+We pass the factor graph's `global_prior_model` as the model and the factor graph itself as the analysis — this
+is the same shape used for any multi-dataset PyAutoFit fit. Internally the search proposes lens parameters from
+the global prior, hands them to the FactorGraph's `log_likelihood_function`, and the FactorGraph routes them
+into every channel's `AnalysisInterferometer.log_likelihood_function` and sums the per-channel log-evidences.
+
+**Run time on CPU is dominated by the per-channel inversion.** A 4-channel SMA-scale cube finishes in a few
+hours on CPU; ALMA-scale cubes with 50+ channels need GPU acceleration to complete in reasonable time.
+"""
+print(
+    """
+    The non-linear search has begun running.
+
+    Per-channel inversions multiply the per-likelihood cost — expect this to take longer than a single-channel
+    interferometer fit. On CPU plan for hours; on GPU, tens of minutes.
+    """
+)
+
+result_list = search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)
+
+"""
+__Result__
+
+`result_list` contains one entry per factor — one per channel — each carrying its own `FitInterferometer`
+against the maximum-likelihood lens model. Use them to inspect:
+
+ - Per-channel source reconstructions (each channel's pixelized source is independent).
+ - Per-channel dirty images and residuals.
+ - The shared maximum-likelihood lens parameters (identical across factors by construction).
+
+Compared against `dataset/interferometer/datacube/<name>/cube_summary.json`, the per-channel reconstructed total
+flux should trace the input emission-line spectrum.
+
+__Wrap Up__
+
+This script walks through the full datacube modeling pipeline. For deeper dives:
+
+ - `modeling.py` — the focused FactorGraph + Nautilus example, ready to copy and adapt for your own cube.
+ - `simulator.py` — how the reference cube is generated.
+ - `autolens_workspace_developer/datacube/likelihood_function.py` — a step-by-step JAX walkthrough of how the
+   per-channel log-evidences are built and summed inside the FactorGraph, with an explicit eager-vs-JIT
+   correctness check.
+
+Phase 2 work — the shared-`Lᵀ W̃ L` optimisation that exploits channel-invariant `uv_wavelengths` and
+`noise_map` to bring ALMA-scale cubes inside CPU runtime budgets — is a separate follow-up issue.
+"""


### PR DESCRIPTION
## Summary

Adds the user-facing tutorial scripts for ALMA datacube modeling under `scripts/interferometer/features/datacube/`. This is step 3 (and the final step) of issue [autolens_workspace#120](https://github.com/PyAutoLabs/autolens_workspace/issues/120). The developer-workspace prototype (4-channel reference cube + step-by-step JAX likelihood walkthrough) shipped earlier in [autolens_workspace_developer#46](https://github.com/PyAutoLabs/autolens_workspace_developer/pull/46).

A "datacube" here is a Python list of `Interferometer` objects, one per spectral channel, sharing a lens model and giving each channel its own pixelized source reconstruction. The user-facing scripts wrap the same `af.FactorGraphModel` wiring as the dev-workspace walkthrough, at workspace-tutorial scope: `start_here.py` is the narrative entry, `modeling.py` is the focused fit, `simulator.py` writes a 4-channel reference cube under `dataset/interferometer/datacube/sim_simple/`.

Once this lands, the alma-datacube task closes and two follow-up issues file: (1) Aris's shared-`Lᵀ W̃ L` optimisation that exploits channel-invariant `uv_wavelengths` / `noise_map`; (2) `Interferometer.list_from_fits_3d` helper in PyAutoArray.

## Scripts Changed
- `scripts/interferometer/features/datacube/__init__.py`, `README.md` — package + feature description.
- `scripts/interferometer/features/datacube/start_here.py` — narrative walkthrough: load the cube, build the FactorGraph, fit with Nautilus. Mirrors the multi-band `start_here.py` style and explains per-channel-vs-shared semantics, runtime cost, and the deferred optimisation.
- `scripts/interferometer/features/datacube/simulator.py` — 4-channel SMA-scale simulator: shared `Isothermal + ExternalShear` lens, per-channel `SersicCore` source whose intensity follows a Gaussian emission line (`peak_channel=1.5, sigma_channel=1.2, peak_intensity=0.6`). Writes per-channel `{data, noise_map, uv_wavelengths}.fits` + `tracer.json`, plus `cube_summary.json`, `cube_overview.png`, `spectrum.png`.
- `scripts/interferometer/features/datacube/modeling.py` — focused FactorGraph + Nautilus fit, ready to copy and adapt for your own cube. Loads the channel folders, builds per-channel `AnalysisInterferometer`, wraps each in an `af.AnalysisFactor` (no per-factor overrides — every prior is shared across channels via the FactorGraph's prior-deduplication), fits with `af.Nautilus`.

## Test Plan
- [x] `python scripts/interferometer/features/datacube/simulator.py` runs end-to-end and writes 4 channel folders.
- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_FAST_PLOTS=1 python scripts/interferometer/features/datacube/modeling.py` runs end-to-end (likelihood called once, search complete).
- [x] Same env vars + `python scripts/interferometer/features/datacube/start_here.py` runs end-to-end.
- [x] `/smoke_test autolens_workspace` corpus passes — no regressions in surrounding interferometer scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)