### PR TITLE
Add Delaunay datacube modeling + RectangularAdaptDensity + PositionsLH

### DIFF
--- a/scripts/interferometer/features/datacube/README.md
+++ b/scripts/interferometer/features/datacube/README.md
@@ -5,9 +5,12 @@ The `datacube` folder contains example scripts showing how to model an ALMA-styl
 The following example scripts illustrate datacube lens modeling where:
 
 - `start_here`: A first walkthrough — load a 4-channel cube, build the FactorGraph, fit with Nautilus.
-- `simulator`: Simulate a representative cube with a Gaussian emission line in the source.
-- `modeling`: Focused FactorGraph + pixelization fit, ready to point at your own cube.
+- `simulator`: Simulate a representative cube with a Gaussian emission line in the source. Also writes `positions.json` with the multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
+- `modeling`: Focused FactorGraph + `RectangularAdaptDensity` pixelization fit, ready to point at your own cube.
 - `modeling_parametric`: Same wiring with a parametric `Sersic` source — shared morphology, per-channel intensity. Faster than the pixelization variant; appropriate when the source is well-described by a single Sersic.
+- `delaunay`: Same wiring with a Delaunay-pixelized source — image-plane `Overlay` mesh ray-traced and triangulated in the source plane, with `ConstantSplit` regularization. More flexible than the rectangular mesh; the canonical follow-up once the rectangular fit converges on a sensible lens model.
+
+Every modeling script loads `positions.json` and applies an `al.PositionsLH` penalty. **For pixelized fits this is essentially required** — without the penalty the search routinely converges on demagnified-source local maxima where the source pixels are reconstructed in low-magnification regions of the source plane.
 
 # Overview
 

--- a/scripts/interferometer/features/datacube/delaunay.py
+++ b/scripts/interferometer/features/datacube/delaunay.py
@@ -1,0 +1,260 @@
+"""
+Modeling: Datacube — Delaunay Source
+=====================================
+
+This script fits a datacube — a list of `Interferometer` channels — with a single shared lens model and a
+per-channel **Delaunay-pixelized** source reconstruction. It is the Delaunay sibling of `modeling.py`, which
+fits the same cube with a `RectangularAdaptDensity` mesh.
+
+A Delaunay mesh adapts the source-plane reconstruction to the lensed source's morphology more flexibly than a
+rectangular mesh: source pixels are placed via a triangulation of (y, x) image-plane points that are ray-traced
+into the source plane for each candidate lens model. This gives more pixels to the highly-magnified parts of
+the source-plane, which is usually where the emission-line signal is concentrated.
+
+For ALMA datacubes Delaunay is often the right default once the simpler rectangular fit has converged on a
+sensible lens model — the canonical workflow is rectangular for the global fit, Delaunay (or a more adaptive
+image-mesh like `Hilbert`) for the source-science follow-up. This script demonstrates the wiring.
+
+The FactorGraph wiring is identical to `modeling.py`: shared lens, per-channel inversion. Only the source-plane
+mesh (and its regularization) changes.
+
+__Contents__
+
+**Mask:** Define the 2D real-space mask applied to every channel.
+**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+**Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the Delaunay inversion.
+**Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
+**Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
+**Image Mesh:** Build the image-plane mesh of (y, x) points that get ray-traced and Delaunay-triangulated.
+**Edge Zeroing:** Append a ring of edge pixels so the source-plane reconstruction zeroes at the mesh boundary.
+**Adapt Images:** Pair the image-plane mesh with the source galaxy via `al.AdaptImages`.
+**Model:** Compose the shared `Isothermal + ExternalShear` lens and Delaunay-pixelized source.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with shared `adapt_images` and `PositionsLH`.
+**FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
+**Search:** Configure the `Nautilus` non-linear search.
+**Model Fit:** Run the fit. Per-channel cost is comparable to the rectangular variant.
+**Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import subprocess
+import sys
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+
+"""
+__Mask__
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+The datacube lives under `dataset/interferometer/datacube/<dataset_name>/`, with one subfolder per channel.
+"""
+dataset_label = "datacube"
+dataset_name = "sim_simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_label / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+"""
+__Dataset Loading__
+"""
+channel_paths = sorted(p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_"))
+print(f"Loading {len(channel_paths)} channels from {dataset_path}")
+
+dataset_list = [
+    al.Interferometer.from_fits(
+        data_path=channel_path / "data.fits",
+        noise_map_path=channel_path / "noise_map.fits",
+        uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerDFT,
+    )
+    for channel_path in channel_paths
+]
+
+"""
+__Sparse Operators__
+"""
+dataset_list = [
+    dataset.apply_sparse_operator(use_jax=True, show_progress=False)
+    for dataset in dataset_list
+]
+
+"""
+__Positions__
+
+Multiple-image positions + `PositionsLH` are essential for Delaunay fits — without them, the search routinely
+finds demagnified-source local maxima.
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=dataset_path / "positions.json")
+)
+positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
+
+"""
+__Settings__
+"""
+settings = al.Settings(use_positive_only_solver=False)
+
+"""
+__Image Mesh__
+
+The Delaunay mesh is built by ray-tracing (y, x) coordinates from the image-plane to the source-plane and
+triangulating the source-plane points. We start with an `Overlay` image-mesh: a regular grid of points spread
+across the image-plane mask. This has a mild adaptive effect — regions of high lens magnification receive more
+source pixels once they are ray-traced. For more aggressive adaptation, swap `Overlay` for `Hilbert` (which
+weights points by the source's surface brightness).
+
+The number of `pixels` passed to `al.mesh.Delaunay` must equal the number of points in `image_plane_mesh_grid`,
+because JAX uses `pixels` to define static-shape arrays.
+"""
+image_mesh = al.image_mesh.Overlay(shape=(26, 26))
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(mask=real_space_mask)
+
+"""
+__Edge Zeroing__
+
+Pixels at the edge of the source-plane mesh are forced to zero brightness during the inversion to prevent
+unphysical solutions where edge pixels reconstruct bright surface brightnesses (often by absorbing residuals).
+For a Delaunay mesh we manually add a ring of edge points to the image-plane mesh and tell `al.mesh.Delaunay`
+how many of those trailing points to zero.
+"""
+edge_pixels_total = 30
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=real_space_mask.mask_centre,
+    radius=mask_radius + real_space_mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+"""
+__Adapt Images__
+
+The image-plane mesh is passed into modeling via `al.AdaptImages`, keyed on the source galaxy's path in the
+model. The same `adapt_images` object is reused for every channel because the lens model and image-plane mesh
+are shared.
+"""
+adapt_images = al.AdaptImages(
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid,
+    },
+)
+
+"""
+__Model__
+
+Shared `Isothermal + ExternalShear` lens + Delaunay-pixelized source. `ConstantSplit` is the canonical Delaunay
+regularizer (split-prior on inner-vs-edge mesh pixels). The mesh `pixels` is fixed at the number of points in
+`image_plane_mesh_grid`, which is `26*26 + 30` after the edge-ring append.
+"""
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+mesh = af.Model(
+    al.mesh.Delaunay,
+    pixels=image_plane_mesh_grid.shape[0],
+    zeroed_pixels=edge_pixels_total,
+)
+regularization = af.Model(al.reg.ConstantSplit)
+pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+print(model.info)
+
+"""
+__Per-Channel Analyses__
+
+Each `AnalysisInterferometer` receives the same `adapt_images` (image-plane mesh is shared) and the same
+`positions_likelihood` (lens model is shared via the FactorGraph).
+"""
+analysis_list = [
+    al.AnalysisInterferometer(
+        dataset=dataset,
+        settings=settings,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[positions_likelihood],
+        use_jax=True,
+    )
+    for dataset in dataset_list
+]
+
+"""
+__FactorGraph__
+"""
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=model.copy(), analysis=analysis)
+    for analysis in analysis_list
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(f"  channels in factor graph:           {len(analysis_factor_list)}")
+print(f"  global model free parameters:       {factor_graph.global_prior_model.total_free_parameters}")
+
+"""
+__Search__
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "datacube",
+    name="delaunay",
+    unique_tag=dataset_name,
+    n_live=100,
+    n_batch=20,
+    iterations_per_quick_update=50000,
+)
+
+"""
+__Model Fit__
+
+Per-channel cost is dominated by the Delaunay inversion + the per-channel NUFFT — comparable to the rectangular
+variant in `modeling.py`. On CPU expect this to take a few hours for the 4-channel reference cube; on GPU,
+tens of minutes.
+"""
+print(
+    """
+    The non-linear search has begun running.
+
+    Per-channel inversions multiply the per-likelihood cost — expect this to take longer than a single-channel
+    interferometer fit.
+    """
+)
+
+result_list = search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)
+
+"""
+__Wrap Up__
+
+For the rectangular variant, see `modeling.py`. For the parametric variant, see `modeling_parametric.py`. For
+the narrative walkthrough, see `start_here.py`. For a step-by-step JAX likelihood walkthrough, see
+`autolens_workspace_developer/datacube/likelihood_function.py`.
+"""

--- a/scripts/interferometer/features/datacube/modeling.py
+++ b/scripts/interferometer/features/datacube/modeling.py
@@ -117,6 +117,22 @@ dataset_list = [
 ]
 
 """
+__Positions__
+
+Load the cube's multiple-image positions (saved by `simulator.py`) and wrap them in an `al.PositionsLH` penalty.
+For pixelized fits this is essentially required: without the penalty, the search routinely converges on
+demagnified-source local maxima where the source pixels are reconstructed in low-magnification regions of the
+source plane that fit the noise rather than the lensed signal.
+
+The lens model is shared across every channel via the FactorGraph, so a single `PositionsLH` (built once and
+passed to every per-channel analysis) applies the same global constraint everywhere.
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=dataset_path / "positions.json")
+)
+positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
+
+"""
 __Settings__
 
 Interferometer pixelizations disable the positive-only inversion solver — the visibility measurement process
@@ -129,8 +145,10 @@ settings = al.Settings(use_positive_only_solver=False)
 __Mesh Shape__
 
 The pixelization mesh shape is fixed before modeling because JAX needs static array shapes. We use a
-14 x 14 ``RectangularUniform`` mesh — small enough to keep the prototype cheap, large enough to capture the
-emission-line source morphology produced by the simulator.
+14 x 14 ``RectangularAdaptDensity`` mesh — small enough to keep the prototype cheap, large enough to capture the
+emission-line source morphology produced by the simulator. `RectangularAdaptDensity` adapts the source-plane
+pixel density to the lensing magnification map, giving more pixels to the highly-magnified source-plane regions
+where the lensed signal is concentrated.
 """
 mesh_pixels_yx = 14
 mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
@@ -139,7 +157,7 @@ mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
 __Model__
 
 The lens galaxy is a shared `Isothermal + ExternalShear`, identical across every channel. The source galaxy is
-a `Pixelization` with a `RectangularUniform` mesh and `Constant` regularization — the inversion runs
+a `Pixelization` with a `RectangularAdaptDensity` mesh and `Constant` regularization — the inversion runs
 independently per channel inside each `AnalysisInterferometer`, giving each channel its own source-plane
 reconstruction without adding any model parameters.
 
@@ -152,7 +170,7 @@ shear = af.Model(al.mp.ExternalShear)
 lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
 
 # Source (pixelization, no free priors):
-mesh = af.Model(al.mesh.RectangularUniform, shape=mesh_shape)
+mesh = af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape)
 regularization = af.Model(al.reg.Constant)
 pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
 source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
@@ -166,10 +184,15 @@ print(model.info)
 __Per-Channel Analyses__
 
 One `AnalysisInterferometer` per channel, all with `use_jax=True` so the FactorGraph fit runs on the JAX
-backend.
+backend. The shared `positions_likelihood` is passed to every analysis — same penalty, every channel.
 """
 analysis_list = [
-    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    al.AnalysisInterferometer(
+        dataset=dataset,
+        settings=settings,
+        positions_likelihood_list=[positions_likelihood],
+        use_jax=True,
+    )
     for dataset in dataset_list
 ]
 

--- a/scripts/interferometer/features/datacube/modeling_parametric.py
+++ b/scripts/interferometer/features/datacube/modeling_parametric.py
@@ -29,9 +29,10 @@ __Contents__
 **Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
 **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
 **Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+**Positions:** Load multiple-image positions and build a shared `PositionsLH` penalty.
 **Settings:** Default `al.Settings()` — no positive-only-solver tweak needed (no inversion).
 **Model:** Compose the shared `Isothermal + ExternalShear` lens and `Sersic` source.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True`.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True` and the shared `PositionsLH`.
 **FactorGraph:** Per-factor `model.copy()` with the source `intensity` prior overridden per channel.
 **Search:** Configure the `Nautilus` non-linear search.
 **Model Fit:** Run the fit. Per-channel cost is much cheaper than the pixelization variant.
@@ -99,6 +100,18 @@ dataset_list = [
 ]
 
 """
+__Positions__
+
+Load the cube's multiple-image positions and wrap them in an `al.PositionsLH` penalty. Pixelized fits really
+need this; parametric Sersic fits less so, but the penalty still helps the search avoid local maxima where the
+mass model places multiple images far apart in the source plane.
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=dataset_path / "positions.json")
+)
+positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
+
+"""
 __Settings__
 
 Parametric sources don't run a source-plane inversion, so we don't need to disable a positive-only solver
@@ -139,9 +152,17 @@ print(model.info)
 
 """
 __Per-Channel Analyses__
+
+The shared `positions_likelihood` is passed to every per-channel analysis so the multiple-image penalty applies
+globally to the lens model.
 """
 analysis_list = [
-    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    al.AnalysisInterferometer(
+        dataset=dataset,
+        settings=settings,
+        positions_likelihood_list=[positions_likelihood],
+        use_jax=True,
+    )
     for dataset in dataset_list
 ]
 

--- a/scripts/interferometer/features/datacube/simulator.py
+++ b/scripts/interferometer/features/datacube/simulator.py
@@ -25,6 +25,7 @@ __Contents__
 **Lens Galaxy:** Shared `Isothermal + ExternalShear` lens, identical for every channel.
 **Per-Channel Source:** A Gaussian emission line in channel index drives the per-channel `Sersic.intensity`.
 **Per-Channel Simulate:** Loop over channels: build the tracer, simulate, write FITS + tracer.json to disk.
+**Multiple Images:** Compute and save the lensed multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
 **Cube Summary:** Dump the emission-line parameters and per-channel intensities to `cube_summary.json`.
 **Cube Overview Plot:** Row-per-channel sanity figure (lensed image, uv-plane Re/Im, |vis| vs baseline length).
 **Spectrum Plot:** Source intensity as a function of channel index.
@@ -190,6 +191,34 @@ for channel in range(N_CHANNELS):
         f"  channel {channel:03d}: intensity={intensity:.4f}, "
         f"|vis|_max={np.max(np.abs(dataset.data)):.3e}"
     )
+
+"""
+__Multiple Images__
+
+Pixelized source modeling can drift toward unphysical demagnified-source local maxima — the source pixels are
+reconstructed in low-magnification regions of the source plane that fit the noise rather than the lensed signal.
+The `PositionsLH` penalty defends against that by reading a small set of multiple-image positions from disk and
+adding a likelihood penalty for any candidate lens model whose source-plane back-projection of those positions
+spreads them apart.
+
+For simulated data we can compute the multiple-image positions automatically with `al.PointSolver`. The lens model
+and source centre are channel-invariant, so a single `positions.json` covers the entire cube — every modeling
+script in this folder loads the same file.
+"""
+solver = al.PointSolver.for_grid(
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
+)
+positions = solver.solve(
+    tracer=tracers[0],
+    source_plane_coordinate=tracers[0].planes[-1][0].bulge.centre,
+)
+
+al.output_to_json(
+    obj=positions,
+    file_path=dataset_path / "positions.json",
+)
+
+print(f"  multiple-image positions: {len(positions)}")
 
 """
 __Cube Summary__

--- a/scripts/interferometer/features/datacube/start_here.py
+++ b/scripts/interferometer/features/datacube/start_here.py
@@ -31,10 +31,11 @@ __Contents__
 **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
 **Dataset Loading:** Loop over channel folders to build a `dataset_list` of `Interferometer` objects.
 **Sparse Operators:** Per-channel sparse-operator pre-compute used by the pixelized source inversion.
+**Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
 **Settings:** Disable the positive-only solver (visibility inversions can take negative pixel values).
 **Mesh Shape:** The pixelization mesh shape — fixed before modeling because JAX needs static shapes.
 **Model:** Shared lens galaxy + pixelized source. The same model is reused unchanged across every channel.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel.
+**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, all sharing the same `PositionsLH`.
 **FactorGraph:** Wrap each analysis in an `AnalysisFactor`; combine via `af.FactorGraphModel`.
 **Search:** Configure the `Nautilus` non-linear search.
 **Model Fit:** Fit the cube — the FactorGraph routes shared lens parameters into every channel's likelihood.
@@ -143,6 +144,27 @@ dataset_list = [
 ]
 
 """
+__Positions__
+
+Pixelized source modeling has a known failure mode: without a position-likelihood penalty, the search routinely
+converges on demagnified-source local maxima where the source pixels are reconstructed in low-magnification
+regions of the source plane that fit the noise rather than the lensed signal. The `PositionsLH` penalty defends
+against that by reading a small set of multiple-image positions from disk and adding a likelihood penalty for
+any candidate lens model whose source-plane back-projection of those positions spreads them apart.
+
+For the cube we load `positions.json` (written by `simulator.py`) and build one `PositionsLH` that gets passed to
+every per-channel analysis below. The lens model is shared across channels via the FactorGraph, so applying the
+same penalty in every analysis enforces a single global constraint.
+
+The threshold of 0.3" is generous; for a real fit you'd tighten it (typically < 0.05") once the lens model has
+settled into the right region of parameter space.
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=dataset_path / "positions.json")
+)
+positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
+
+"""
 __Settings__
 
 Interferometer pixelizations disable the positive-only inversion solver. The visibility measurement process
@@ -155,8 +177,10 @@ settings = al.Settings(use_positive_only_solver=False)
 __Mesh Shape__
 
 The pixelization mesh shape is fixed before modeling because JAX needs static-shape arrays for its source-plane
-linear algebra. We use a 14 x 14 `RectangularUniform` mesh — small enough to make the prototype iteration cheap,
-large enough to capture the emission-line source morphology produced by the simulator.
+linear algebra. We use a 14 x 14 `RectangularAdaptDensity` mesh — small enough to make the prototype iteration
+cheap, large enough to capture the emission-line source morphology produced by the simulator.
+`RectangularAdaptDensity` adapts the source-plane pixel density to the lensing magnification map, giving more
+pixels to the highly-magnified regions of the source plane where the lensed signal is concentrated.
 """
 mesh_pixels_yx = 14
 mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
@@ -169,7 +193,7 @@ The cube model has two ingredients:
  - A shared `Isothermal + ExternalShear` lens. There are 7 free parameters (mass centre, ellipticity components,
    einstein radius, two shear components). The lens does not change with frequency, so a single set of priors is
    used for every channel.
- - A pixelized source: a `RectangularUniform` mesh with `Constant` regularization (1 free parameter — the
+ - A pixelized source: a `RectangularAdaptDensity` mesh with `Constant` regularization (1 free parameter — the
    regularization coefficient). The pixelization itself has no per-pixel priors; the source-plane fluxes are a
    linear inversion output computed by each channel's `AnalysisInterferometer` at fit time. That is what makes
    each channel an independent linear solve while sharing all of the non-linear parameters.
@@ -182,7 +206,7 @@ shear = af.Model(al.mp.ExternalShear)
 lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
 
 # Source (pixelization, no per-pixel priors):
-mesh = af.Model(al.mesh.RectangularUniform, shape=mesh_shape)
+mesh = af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape)
 regularization = af.Model(al.reg.Constant)
 pixelization = af.Model(al.Pixelization, mesh=mesh, regularization=regularization)
 source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
@@ -197,10 +221,16 @@ __Per-Channel Analyses__
 
 One `AnalysisInterferometer` per channel — there are no per-channel parameters here, only per-channel data.
 Each analysis runs its own NUFFT, builds its own visibility-space inversion, and returns its own log-evidence
-when called with a candidate lens model.
+when called with a candidate lens model. The shared `positions_likelihood` is passed to every analysis to apply
+the same global multiple-image penalty across the cube.
 """
 analysis_list = [
-    al.AnalysisInterferometer(dataset=dataset, settings=settings, use_jax=True)
+    al.AnalysisInterferometer(
+        dataset=dataset,
+        settings=settings,
+        positions_likelihood_list=[positions_likelihood],
+        use_jax=True,
+    )
     for dataset in dataset_list
 ]
 


### PR DESCRIPTION
## Summary

Three follow-up improvements to the datacube feature shipped in autolens_workspace#122 and PyAutoLabs/autolens_workspace_developer#46:

1. **Mesh swap to `RectangularAdaptDensity`** in `modeling.py` and `start_here.py`. The new mesh adapts source-plane pixel density to the lensing magnification map, matching the canonical interferometer pixelization examples (`pixelization/modeling.py`, `pixelization/slam.py`).
2. **New `delaunay.py` sibling** — Delaunay-pixelized datacube fit with `Overlay` image-mesh, `append_with_circle_edge_points` edge zeroing, and `ConstantSplit` regularization. Mirrors the canonical sibling `pixelization/delaunay.py`.
3. **Multiple-image positions + `PositionsLH` penalty** added to all four modeling scripts and the simulator. The simulator now writes `positions.json` via `PointSolver.solve`; every modeling script loads it and passes a shared `PositionsLH(threshold=0.3)` to each per-channel `AnalysisInterferometer`. **For pixelized fits this is essentially required** — without the penalty, the search routinely converges on demagnified-source local maxima where the source pixels reconstruct in low-magnification regions of the source plane.

## Scripts Changed

- `scripts/interferometer/features/datacube/simulator.py` — add `PointSolver` block to compute and write `positions.json`. New `__Multiple Images__` section in the `__Contents__` TOC.
- `scripts/interferometer/features/datacube/start_here.py` — mesh swap + new `__Positions__` section, load positions, pass `PositionsLH` to every analysis.
- `scripts/interferometer/features/datacube/modeling.py` — same edits as `start_here.py`.
- `scripts/interferometer/features/datacube/modeling_parametric.py` — load positions + pass `PositionsLH` (no mesh change; parametric source).
- `scripts/interferometer/features/datacube/delaunay.py` — NEW file.
- `scripts/interferometer/features/datacube/README.md` — add `delaunay` bullet, note `PositionsLH` is required for pixelized fits.

## Test Plan

- [x] `python scripts/interferometer/features/datacube/simulator.py` writes `positions.json` (2 multiple-image positions for the SMA-scale prototype).
- [x] All four modeling scripts pass `TEST MODE 2`:
  - `start_here.py` — 8 free parameters
  - `modeling.py` — 8 free parameters
  - `modeling_parametric.py` — 17 free parameters
  - `delaunay.py` — 8 free parameters
- [x] `/smoke_test autolens_workspace` corpus passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)