### PR TITLE
docs: comprehensive output folder layout in modeling tutorials and use search.paths in results/start_here

### DIFF
--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -33,7 +33,7 @@ __Contents__
 **Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs each analysis it with the model.
 **Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
 **Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder:** Now this is running you should checkout the `autolens_workspace/output` folder.
+**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
 **Result:** Overview of the results of the model-fit.
 **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
 
@@ -578,32 +578,44 @@ result = search.fit(model=model, analysis=analysis)
 print("The search has finished run - you may now continue the notebook.")
 
 """
-__Output Folder__
+__Output Folder Layout__
 
-Now this is running you should checkout the `autolens_workspace/output` folder. This is where the results of the 
-search are written to hard-disk (in the `start_here` folder), where all outputs are human readable (e.g. as .json,
-.csv or text files).
+Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
+written to hard-disk in human-readable formats — `.json`, `.csv`, `.fits`, `.png` and plain text.
 
-As the fit progresses, results are written to the `output` folder on the fly using the highest likelihood model found
-by the non-linear search so far. This means you can inspect the results of the model-fit as it runs, without having to
-wait for the non-linear search to terminate.
+As the fit progresses, results are written on the fly using the highest likelihood model found by the
+non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
+non-linear search to terminate.
 
-The `output` folder includes:
+Each completed fit lives at a path like::
 
- - `model.info`: Summarizes the lens model, its parameters and their priors discussed in the next tutorial.
+    output/cluster/<dataset_name>/modeling/<unique_hash>/
+        files/                         <- JSON + CSV: loadable Python objects
+            tracer.json                <- max log likelihood Tracer (full cluster lens model)
+            model.json                 <- fitted af.Collection model (scaling-relation parameters)
+            samples.csv                <- full Nautilus samples
+            samples_summary.json       <- max log likelihood parameter values + errors
+            samples_info.json          <- metadata about the samples
+            search.json                <- non-linear search configuration
+            settings.json              <- search settings
+            cosmology.json             <- cosmology used for the fit
+            covariance.csv             <- parameter covariance matrix
+        image/                         <- FITS + PNG: imaging + point-source products
+            dataset.fits               <- data, noise-map and PSF
+            fit.fits                   <- model image, residuals, chi-squared map
+            tracer.fits                <- tracer image-plane images per cluster galaxy
+            source_plane_images.fits   <- source plane reconstructions
+            galaxy_images.fits         <- per-galaxy images
+            positions.png              <- observed vs model-predicted multiple-image positions
+            dataset.png, fit.png, tracer.png   <- visualisations
+        model.info                     <- human-readable model summary
+        model.results                  <- human-readable fit summary
+        search.summary                 <- search run summary
+        search_internal/               <- internal files used to resume / visualise the search
+        metadata                       <- run metadata
 
- - `model.results`: Summarizes the highest likelihood lens model inferred so far including errors.
-
- - `images`: Visualization of the highest likelihood model-fit to the dataset, (e.g. a fit subplot showing the lens 
- and source galaxies, model data and residuals).
-
- - `files`: A folder containing .fits files of the dataset, the model as a human-readable .json file, 
- a `.csv` table of every non-linear search sample and other files containing information about the model-fit.
-
- - search.summary: A file providing summary statistics on the performance of the non-linear search.
-
- - `search_internal`: Internal files of the non-linear search (in this case Nautilus) used for resuming the fit and
-  visualizing the search.
+The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
+same configuration resumes from the existing fit automatically.
 
 __Result__
 

--- a/scripts/group/modeling.py
+++ b/scripts/group/modeling.py
@@ -41,7 +41,7 @@ __Contents__
 **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
 **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU's available VRAM.
 **Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder:** Now this is running you should checkout the `autolens_workspace/output` folder.
+**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
 **Result:** Overview of the results of the model-fit.
 **Features:** The examples in the `autolens_workspace/*/imaging/features` package illustrate other lens modeling.
 **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
@@ -650,32 +650,44 @@ result = search.fit(model=model, analysis=analysis)
 print("The search has finished run - you may now continue the notebook.")
 
 """
-__Output Folder__
+__Output Folder Layout__
 
-Now this is running you should checkout the `autolens_workspace/output` folder. This is where the results of the
-search are written to hard-disk (in the `start_here` folder), where all outputs are human readable (e.g. as .json,
-.csv or text files).
+Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
+written to hard-disk in human-readable formats — `.json`, `.csv`, `.fits`, `.png` and plain text.
 
-As the fit progresses, results are written to the `output` folder on the fly using the highest likelihood model found
-by the non-linear search so far. This means you can inspect the results of the model-fit as it runs, without having to
-wait for the non-linear search to terminate.
+As the fit progresses, results are written on the fly using the highest likelihood model found by the
+non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
+non-linear search to terminate.
 
-The `output` folder includes:
+Each completed fit lives at a path like::
 
- - `model.info`: Summarizes the lens model, its parameters and their priors discussed in the next tutorial.
+    output/group/<dataset_name>/modeling/<unique_hash>/
+        files/                         <- JSON + CSV: loadable Python objects
+            tracer.json                <- max log likelihood Tracer (all lens galaxies + source)
+            model.json                 <- fitted af.Collection model
+            samples.csv                <- full Nautilus samples
+            samples_summary.json       <- max log likelihood parameter values + errors
+            samples_info.json          <- metadata about the samples
+            search.json                <- non-linear search configuration
+            settings.json              <- search settings
+            cosmology.json             <- cosmology used for the fit
+            covariance.csv             <- parameter covariance matrix
+        image/                         <- FITS + PNG: imaging products
+            dataset.fits               <- data, noise-map and PSF
+            fit.fits                   <- model image, residuals, chi-squared map
+            tracer.fits                <- tracer image-plane images per galaxy
+            source_plane_images.fits   <- source plane reconstructions
+            model_galaxy_images.fits   <- per-galaxy model images (lens_0, lens_1, ..., source)
+            galaxy_images.fits         <- per-galaxy images
+            dataset.png, fit.png, tracer.png   <- visualisations
+        model.info                     <- human-readable model summary
+        model.results                  <- human-readable fit summary
+        search.summary                 <- search run summary
+        search_internal/               <- internal files used to resume / visualise the search
+        metadata                       <- run metadata
 
- - `model.results`: Summarizes the highest likelihood lens model inferred so far including errors.
-
- - `image`: Visualization of the highest likelihood model-fit to the dataset, (e.g. a fit subplot showing the lens
- and source galaxies, model data and residuals) in .png and .fits formats.
-
- - `files`: A folder containing human-readable .json file describing the model, search and other aspects of the fit and
-   a `.csv` table of every non-linear search sample.
-
- - search.summary: A file providing summary statistics on the performance of the non-linear search.
-
- - `search_internal`: Internal files of the non-linear search (in this case Nautilus) used for resuming the fit and
-  visualizing the search.
+The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
+same configuration resumes from the existing fit automatically.
 
 __Result__
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -17,10 +17,11 @@ This guide shows two complementary ways to get those results back into Python:
     ...) via Python generators, so you can iterate over hundreds of fits without holding them all in memory at
     once. This is the right tool when you want to analyse a sample of lenses together.
 
-Both sections appear below in that order. The aggregator section first runs a quick model-fit so a results
-directory exists, then walks through the deeper API (samples, fits, tracer, units, pixelization). Where each
-aggregator section reaches a result that the simple-loading API also exposes, this is noted — both routes return
-the same PyAutoFit / PyAutoLens objects, just sourced from disk in different ways.
+Both sections appear below in that order. To keep them runnable from a fresh checkout, this script first
+performs a quick model-fit so a results directory exists for both halves to read from. The aggregator
+section then walks through the deeper API (samples, fits, tracer, units, pixelization). Where each
+aggregator section reaches a result that the simple-loading API also exposes, this is noted — both routes
+return the same PyAutoFit / PyAutoLens objects, just sourced from disk in different ways.
 
 __Output Folder Layout__
 
@@ -52,6 +53,9 @@ Each completed fit lives at a path like::
 
 __Contents__
 
+**Model Fit:** Run a quick fit once so both halves of this guide have a real result on disk to read from.
+**Info:** Print the result in a readable format.
+
 **Simple Loading (one fit at a time):**
 
 **Tracer:** Load the maximum log likelihood `Tracer` from `tracer.json`.
@@ -61,8 +65,6 @@ __Contents__
 
 **Aggregator (many fits, generator-based):**
 
-**Model Fit:** Run a quick fit so a results directory exists for the aggregator examples.
-**Info:** Print the result in a readable format.
 **Loading From Hard-disk:** Use `Aggregator.from_directory(...)` to scrape `output/`.
 **Generators:** How Python generators give the aggregator its memory efficiency.
 **Database File:** Loading from a `.sqlite` database for very large samples.
@@ -92,124 +94,41 @@ import autolens.plot as aplt
 
 """
 ==============================================================================
-                              SIMPLE LOADING
+                                MODEL FIT
 ==============================================================================
 
-The first half of this guide loads a single fit directly from `output/`. This is the fastest way to inspect one
-fit — every file under `files/` and `image/` is a Python object away.
+Both halves of this guide — simple loading and the aggregator — need a real fit on disk to read from. We
+perform that fit once here. The rest of the file then uses the resulting `search` object (via
+`search.paths.output_path`) and the in-memory `result`.
 
-__Result Path__
+The model and search match `aggregator/samples.py` and `_quick_fit.py`, so re-running this tutorial resumes
+from the cached fit instead of redoing the search.
 
-Set the path to the folder of the fit you want to load. Replace the values below with the path to your own fit.
+__Quick Fit Auto-Trigger__
 
-The layout below assumes the canonical `output/imaging/<dataset>/modeling/<hash>/` structure produced by
-`scripts/imaging/modeling.py`. The `<unique_hash>` placeholder is a 32-character identifier specific to the fit;
-each load below is guarded with `.exists()` so this script runs cleanly even before you replace it.
+If a previous fit has not been run yet, the shared helper ``_quick_fit.py`` is invoked to produce one.
+The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tutorial has results to
+work with. When that folder already exists the helper exits immediately, so re-running this tutorial is
+cheap.
 """
-result_path = (
-    Path("output")
-    / "imaging"
-    / "simple"
-    / "modeling"
-    / "<unique_hash>"  # The 32-character identifier for the specific fit.
-)
-
-files_path = result_path / "files"
-image_path = result_path / "image"
-
-"""
-__Tracer__
-
-The maximum log likelihood `Tracer` is saved to `files/tracer.json` and can be loaded in one line.
-
-The `Tracer` contains every `Galaxy`, light profile and mass profile at their max log likelihood values, so it can
-be used directly to compute convergence maps, deflection angles, source-plane images and more — exactly as if it
-had been returned by `search.fit()`.
-"""
-if (files_path / "tracer.json").exists():
-    tracer = from_json(file_path=files_path / "tracer.json")
-
-    print(tracer)
-    print(tracer.galaxies)
-
-"""
-__Model__
-
-The fitted `af.Collection` model is saved to `files/model.json`. This is the *prior* model (with free parameters),
-not the max log likelihood instance — useful for inspecting the structure of what was fitted.
-"""
-if (files_path / "model.json").exists():
-    model = from_json(file_path=files_path / "model.json")
-    print(model.info)
-
-"""
-__Samples__
-
-The full set of non-linear search samples is saved to `files/samples.csv` and its summary to
-`files/samples_summary.json`. Both can be loaded without re-running the search.
-"""
-if (files_path / "samples.csv").exists() and (files_path / "model.json").exists():
-    model = from_json(file_path=files_path / "model.json")
-    samples = af.SamplesNest.from_csv(file_path=files_path / "samples.csv", model=model)
-    print(samples.max_log_likelihood())
-
-"""
-__FITS Files__
-
-The `image/` folder contains the imaging products of the fit as `.fits` files. These load with the standard
-`al.Imaging` / `al.Array2D` APIs and can be plotted with `aplt`.
-"""
-if (image_path / "dataset.fits").exists():
-    dataset = al.Imaging.from_fits(
-        data_path=image_path / "dataset.fits",
-        noise_map_path=image_path / "dataset.fits",
-        psf_path=image_path / "dataset.fits",
-        data_hdu=0,
-        noise_map_hdu=1,
-        psf_hdu=2,
-        pixel_scales=0.1,
-    )
-
-if (image_path / "tracer.fits").exists():
-    tracer_images = al.Array2D.from_fits(
-        file_path=image_path / "tracer.fits", hdu=0, pixel_scales=0.1
-    )
-
-"""
-==============================================================================
-                                AGGREGATOR
-==============================================================================
-
-Everything above loaded one fit at a time, by pointing at a specific output directory. To analyse many fits — for
-example a sample of hundreds of lenses — use the **aggregator** instead. It scrapes a directory of fits and yields
-the same objects (`Tracer`, `Samples`, `Model`, ...) via Python generators, keeping memory use low.
-
-The remainder of this file is the aggregator entry point. After reading it, the sibling files in `aggregator/`
-provide more detailed examples for analysing different aspects of the results.
-
-To make the examples below runnable from a fresh checkout, we first perform a quick model-fit so the aggregator
-has a results directory to scrape. Anything `from_json(...)` reaches in the simple-loading section above can also
-be reached through the aggregator below — both APIs return the same Python objects.
-
-If you are not familiar with the lens modeling API, see `autolens_workspace/*/examples/modeling/` first.
-"""
-dataset_name = "simple__no_lens_light"
-dataset_path = Path("dataset") / "imaging" / dataset_name
-
-"""
-__Dataset Auto-Simulation__
-
-If the dataset does not already exist on your system, it will be created by running the corresponding
-simulator script. This ensures that all example scripts can be run without manually simulating data first.
-"""
-if al.util.dataset.should_simulate(str(dataset_path)):
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
     import subprocess
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/imaging/features/no_lens_light/simulator.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
+
+"""
+__Dataset and Model__
+
+Set up the same dataset and model as `_quick_fit.py`, then call `search.fit(...)`. Because the search has
+already run, this resumes from the checkpoint and returns the in-memory `Result` object instantly.
+"""
+dataset_name = "simple__no_lens_light"
+dataset_path = Path("dataset") / "imaging" / dataset_name
 
 dataset = al.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
@@ -263,6 +182,107 @@ As seen throughout the workspace, the `info` attribute shows the result in a rea
 print(result.info)
 
 """
+==============================================================================
+                              SIMPLE LOADING
+==============================================================================
+
+The first half of this guide loads a single fit directly from `output/`. This is the fastest way to inspect
+one fit — every file under `files/` and `image/` is a Python object away.
+
+__Result Path__
+
+Point at the fit's output folder. Because the fit ran above, ``search.paths.output_path`` already points at
+the right location — there is no need to construct the path manually or know the unique hash.
+"""
+result_path = search.paths.output_path
+
+files_path = result_path / "files"
+image_path = result_path / "image"
+
+"""
+__Tracer__
+
+The maximum log likelihood `Tracer` is saved to `files/tracer.json` and can be loaded in one line.
+
+The `Tracer` contains every `Galaxy`, light profile and mass profile at their max log likelihood values, so it can
+be used directly to compute convergence maps, deflection angles, source-plane images and more — exactly as if it
+had been returned by `search.fit()`.
+"""
+if (files_path / "tracer.json").exists():
+    tracer = from_json(file_path=files_path / "tracer.json")
+
+    print(tracer)
+    print(tracer.galaxies)
+
+"""
+__Model__
+
+The fitted `af.Collection` model is saved to `files/model.json`. This is the *prior* model (with free parameters),
+not the max log likelihood instance — useful for inspecting the structure of what was fitted.
+"""
+if (files_path / "model.json").exists():
+    model = from_json(file_path=files_path / "model.json")
+    print(model.info)
+
+"""
+__Samples__
+
+The full set of non-linear search samples is saved to `files/samples.csv` and its summary to
+`files/samples_summary.json`. Both can be loaded without re-running the search.
+"""
+if (files_path / "samples.csv").exists() and (files_path / "model.json").exists():
+    model = from_json(file_path=files_path / "model.json")
+    samples = af.SamplesNest.from_table(filename=files_path / "samples.csv", model=model)
+    print(samples.max_log_likelihood())
+
+"""
+__FITS Files__
+
+The `image/` folder contains the imaging products of the fit as `.fits` files. These load with the standard
+`al.Imaging` / `al.Array2D` APIs and can be plotted with `aplt`.
+"""
+if (image_path / "dataset.fits").exists():
+    dataset = al.Imaging.from_fits(
+        data_path=image_path / "dataset.fits",
+        noise_map_path=image_path / "dataset.fits",
+        psf_path=image_path / "dataset.fits",
+        data_hdu=0,
+        noise_map_hdu=1,
+        psf_hdu=2,
+        pixel_scales=0.1,
+    )
+
+if (image_path / "tracer.fits").exists():
+    tracer_images = al.Array2D.from_fits(
+        file_path=image_path / "tracer.fits", hdu=0, pixel_scales=0.1
+    )
+
+"""
+==============================================================================
+                                AGGREGATOR
+==============================================================================
+
+Simple loading is the right tool when you have a single fit and you want to pull a specific object off
+disk. The **aggregator** is a different tool — it scrapes a directory of fits and yields the same objects
+(`Tracer`, `Samples`, `Model`, ...) via **Python generators**, so memory use stays bounded no matter how
+many fits the directory contains. That generator-based design is its core feature, and it's what lets the
+aggregator scale from one fit to hundreds.
+
+The two routes are complementary, not a hierarchy:
+
+  - **Simple loading** is the most direct way to inspect one fit you already have a path to — one Python
+    object per call, all in memory.
+  - **Aggregator** is the right tool when you want to *iterate* over fits — even a single fit — and rely
+    on lazy evaluation, query filtering across many runs, or a `.sqlite` database back-end for very large
+    samples. It is also the API used by the workflow tools (`csv_maker.py`, `png_maker.py`, `fits_maker.py`)
+    that build scientific summaries of large fit samples.
+
+Anything reached via `from_json(...)` in the simple-loading section above can also be reached through the
+aggregator below — both APIs return the same PyAutoFit / PyAutoLens objects. After reading this section,
+the sibling files in `aggregator/` provide deeper examples for samples, fits, queries and database use.
+
+If you are not familiar with the lens modeling API, see `autolens_workspace/*/examples/modeling/` first.
+
 __Loading From Hard-disk__
 
 When performing fits which output results to hard-disk, a `files` folder is created containing .json / .csv files of

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -25,7 +25,7 @@ __Contents__
 **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
 **VRAM Use:** When running with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
 **Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder:** Now this is running you should checkout the `autolens_workspace/output` folder.
+**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
 **Result:** Overview of the results of the model-fit.
 **Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
 **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
@@ -476,32 +476,44 @@ result = search.fit(model=model, analysis=analysis)
 print("The search has finished run - you may now continue the notebook.")
 
 """
-__Output Folder__
+__Output Folder Layout__
 
-Now this is running you should checkout the `autolens_workspace/output` folder. This is where the results of the 
-search are written to hard-disk (in the `start_here` folder), where all outputs are human readable (e.g. as .json,
-.csv or text files).
+Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
+written to hard-disk in human-readable formats — `.json`, `.csv`, `.fits`, `.png` and plain text.
 
-As the fit progresses, results are written to the `output` folder on the fly using the highest likelihood model found
-by the non-linear search so far. This means you can inspect the results of the model-fit as it runs, without having to
-wait for the non-linear search to terminate.
- 
-The `output` folder includes:
+As the fit progresses, results are written on the fly using the highest likelihood model found by the
+non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
+non-linear search to terminate.
 
- - `model.info`: Summarizes the lens model, its parameters and their priors discussed in the next tutorial.
- 
- - `model.results`: Summarizes the highest likelihood lens model inferred so far including errors.
- 
- - `image`: Visualization of the highest likelihood model-fit to the dataset, (e.g. a fit subplot showing the lens 
- and source galaxies, model data and residuals) in .png and .fits formats.
- 
- - `files`: A folder containing human-readable .json file describing the model, search and other aspects of the fit and 
-   a `.csv` table of every non-linear search sample.
- 
- - search.summary: A file providing summary statistics on the performance of the non-linear search.
- 
- - `search_internal`: Internal files of the non-linear search (in this case Nautilus) used for resuming the fit and
-  visualizing the search.
+Each completed fit lives at a path like::
+
+    output/imaging/<dataset_name>/modeling/<unique_hash>/
+        files/                         <- JSON + CSV: loadable Python objects
+            tracer.json                <- max log likelihood Tracer
+            model.json                 <- fitted af.Collection model
+            samples.csv                <- full Nautilus samples
+            samples_summary.json       <- max log likelihood parameter values + errors
+            samples_info.json          <- metadata about the samples
+            search.json                <- non-linear search configuration
+            settings.json              <- search settings
+            cosmology.json             <- cosmology used for the fit
+            covariance.csv             <- parameter covariance matrix
+        image/                         <- FITS + PNG: imaging products
+            dataset.fits               <- data, noise-map and PSF
+            fit.fits                   <- model image, residuals, chi-squared map
+            tracer.fits                <- tracer image-plane images per galaxy
+            source_plane_images.fits   <- source plane reconstructions
+            model_galaxy_images.fits   <- per-galaxy model images
+            galaxy_images.fits         <- per-galaxy images
+            dataset.png, fit.png, tracer.png   <- visualisations
+        model.info                     <- human-readable model summary
+        model.results                  <- human-readable fit summary
+        search.summary                 <- search run summary
+        search_internal/               <- internal files used to resume / visualise the search
+        metadata                       <- run metadata
+
+The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
+same configuration resumes from the existing fit automatically.
 
 __Result__
 

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -23,7 +23,7 @@ __Contents__
 **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
 **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
 **Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder:** Now this is running you should checkout the `autolens_workspace/output` folder.
+**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
 **Result:** Overview of the results of the model-fit.
 **Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
 **Data Preparation:** Data standards required for fitting with PyAutoLens.
@@ -421,32 +421,45 @@ result = search.fit(model=model, analysis=analysis)
 print("The search has finished run - you may now continue the notebook.")
 
 """
-__Output Folder__
+__Output Folder Layout__
 
-Now this is running you should checkout the `autolens_workspace/output` folder. This is where the results of the 
-search are written to hard-disk (in the `start_here` folder), where all outputs are human readable (e.g. as .json,
-.csv or text files).
+Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
+written to hard-disk in human-readable formats — `.json`, `.csv`, `.fits`, `.png` and plain text.
 
-As the fit progresses, results are written to the `output` folder on the fly using the highest likelihood model found
-by the non-linear search so far. This means you can inspect the results of the model-fit as it runs, without having to
-wait for the non-linear search to terminate.
- 
-The `output` folder includes:
+As the fit progresses, results are written on the fly using the highest likelihood model found by the
+non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
+non-linear search to terminate.
 
- - `model.info`: Summarizes the lens model, its parameters and their priors discussed in the next tutorial.
- 
- - `model.results`: Summarizes the highest likelihood lens model inferred so far including errors.
- 
- - `image`: Visualization of the highest likelihood model-fit to the dataset, (e.g. a fit subplot showing the lens 
- and source galaxies, model data and residuals) in .png and .fits formats.
- 
- - `files`: A folder containing human-readable .json file describing the model, search and other aspects of the fit and 
-   a `.csv` table of every non-linear search sample.
- 
- - search.summary: A file providing summary statistics on the performance of the non-linear search.
- 
- - `search_internal`: Internal files of the non-linear search (in this case Nautilus) used for resuming the fit and
-  visualizing the search.
+Each completed fit lives at a path like::
+
+    output/interferometer/<dataset_name>/modeling/<unique_hash>/
+        files/                         <- JSON + CSV: loadable Python objects
+            tracer.json                <- max log likelihood Tracer
+            model.json                 <- fitted af.Collection model
+            samples.csv                <- full Nautilus samples
+            samples_summary.json       <- max log likelihood parameter values + errors
+            samples_info.json          <- metadata about the samples
+            search.json                <- non-linear search configuration
+            settings.json              <- search settings
+            cosmology.json             <- cosmology used for the fit
+            covariance.csv             <- parameter covariance matrix
+        image/                         <- FITS + PNG: visibility + image-plane products
+            dataset.fits               <- visibilities, noise-map and uv-coverage
+            fit.fits                   <- model visibilities, residuals, chi-squared
+            dirty_images.fits          <- dirty images of data, model and residuals
+            tracer.fits                <- tracer image-plane images per galaxy
+            source_plane_images.fits   <- source plane reconstructions
+            model_galaxy_images.fits   <- per-galaxy model images
+            galaxy_images.fits         <- per-galaxy images
+            dataset.png, fit.png, tracer.png   <- visualisations
+        model.info                     <- human-readable model summary
+        model.results                  <- human-readable fit summary
+        search.summary                 <- search run summary
+        search_internal/               <- internal files used to resume / visualise the search
+        metadata                       <- run metadata
+
+The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
+same configuration resumes from the existing fit automatically.
 
 __Result__
 

--- a/scripts/point_source/modeling.py
+++ b/scripts/point_source/modeling.py
@@ -21,7 +21,7 @@ __Contents__
 **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
 **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
 **Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder:** Now this is running you should checkout the `autolens_workspace/output` folder.
+**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
 **Result:** Overview of the results of the model-fit.
 **Results:** Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
 **Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
@@ -407,32 +407,40 @@ result = search.fit(model=model, analysis=analysis)
 print("The search has finished run - you may now continue the notebook.")
 
 """
-__Output Folder__
+__Output Folder Layout__
 
-Now this is running you should checkout the `autolens_workspace/output` folder. This is where the results of the 
-search are written to hard-disk (in the `start_here` folder), where all outputs are human readable (e.g. as .json,
-.csv or text files).
+Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
+written to hard-disk in human-readable formats — `.json`, `.csv`, `.png` and plain text.
 
-As the fit progresses, results are written to the `output` folder on the fly using the highest likelihood model found
-by the non-linear search so far. This means you can inspect the results of the model-fit as it runs, without having to
-wait for the non-linear search to terminate.
- 
-The `output` folder includes:
+As the fit progresses, results are written on the fly using the highest likelihood model found by the
+non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
+non-linear search to terminate.
 
- - `model.info`: Summarizes the lens model, its parameters and their priors discussed in the next tutorial.
- 
- - `model.results`: Summarizes the highest likelihood lens model inferred so far including errors.
- 
- - `image`: Visualization of the highest likelihood model-fit to the dataset, (e.g. a fit subplot showing the lens 
- and source galaxies, model data and residuals) in .png and .fits formats.
- 
- - `files`: A folder containing human-readable .json file describing the model, search and other aspects of the fit and 
-   a `.csv` table of every non-linear search sample.
- 
- - search.summary: A file providing summary statistics on the performance of the non-linear search.
- 
- - `search_internal`: Internal files of the non-linear search (in this case Nautilus) used for resuming the fit and
-  visualizing the search.
+Each completed fit lives at a path like::
+
+    output/point_source/<dataset_name>/modeling/<unique_hash>/
+        files/                         <- JSON + CSV: loadable Python objects
+            tracer.json                <- max log likelihood Tracer
+            model.json                 <- fitted af.Collection model
+            samples.csv                <- full Nautilus samples
+            samples_summary.json       <- max log likelihood parameter values + errors
+            samples_info.json          <- metadata about the samples
+            search.json                <- non-linear search configuration
+            settings.json              <- search settings
+            cosmology.json             <- cosmology used for the fit
+            covariance.csv             <- parameter covariance matrix
+        image/                         <- PNG: point-source fit visualisations
+            positions.png              <- observed vs model-predicted multiple-image positions
+            fluxes.png                 <- observed vs model-predicted point-source fluxes
+            tracer.png                 <- tracer image-plane and source-plane plots
+        model.info                     <- human-readable model summary
+        model.results                  <- human-readable fit summary
+        search.summary                 <- search run summary
+        search_internal/               <- internal files used to resume / visualise the search
+        metadata                       <- run metadata
+
+The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
+same configuration resumes from the existing fit automatically.
 
 __Result__
 


### PR DESCRIPTION
## Summary

Two paired documentation improvements to the modeling tutorials:

1. **Comprehensive output folder layout.** Every `modeling.py` tutorial replaces the brief flat-bullet `__Output Folder__` description with a full directory-tree `__Output Folder Layout__` block, adapted per data type — `tracer.json` / `tracer.fits` / `source_plane_images.fits` for autolens, customised `dataset.fits` contents for visibilities and positions, etc. Readers now see exactly which `.json`, `.csv`, `.fits` and human-readable artefacts a fit produces and where each lands.

2. **`results/start_here.py` no longer needs a `<unique_hash>` placeholder in code.** The model-fit now runs once at the top of the file (mirroring `_quick_fit.py` / `aggregator/samples.py`), and the simple-loading section reaches results via `result_path = search.paths.output_path`. Users no longer have to hand-edit a 32-character identifier into the script before it runs.

The aggregator section keeps all its existing narrative (Loading From Hard-disk, Generators, Database, Workflow Examples, Result, Samples, Linear Light Profiles, Tracer, Fits, Galaxies, Units, Pixelization). Its intro is rewritten to frame it as a first-class peer tool — generator-based, used by the `csv_maker` / `png_maker` / `fits_maker` workflow tools — rather than a "many fits" fallback.

Closes #124.

## Scripts Changed
- `scripts/imaging/modeling.py` — replaced `__Output Folder__` flat-bullet with full directory-tree `__Output Folder Layout__` block (imaging-specific products: dataset.fits with PSF, fit.fits, tracer.fits, source_plane_images.fits)
- `scripts/interferometer/modeling.py` — same treatment, adapted for visibility/uv-plane products (dirty_images.fits)
- `scripts/point_source/modeling.py` — same treatment, adapted for point-source visualisations (positions.png, fluxes.png — no FITS image products)
- `scripts/cluster/modeling.py` — same treatment, with cluster-specific products (positions.png, scaling-relation model)
- `scripts/group/modeling.py` — same treatment, with multi-lens-galaxy products
- `scripts/guides/results/start_here.py` — restructured: model-fit now runs first; simple-loading uses `search.paths.output_path` instead of a hardcoded `<unique_hash>` Path; aggregator intro rewritten to frame it as a peer tool (generator-based, used by workflow tools); fixed pre-existing latent `af.SamplesNest.from_csv` → `from_table` API bug uncovered once the path resolved to a real folder

## Test Plan
- [x] `python3 compile()` syntax check passes for all 6 modified scripts
- [x] `scripts/imaging/modeling.py` runs end-to-end under `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1`
- [x] `scripts/guides/results/start_here.py` runs end-to-end under the same env, reaching the final `chi_squared` / `log_likelihood` prints
- [x] `scripts/check_sizes.sh` clean (no accidental file truncation)
- [x] Smoke tests pass for the workspace as a whole

🤖 Generated with [Claude Code](https://claude.com/claude-code)