### PR TITLE
docs: realistic position, time-delay, and flux noise in point source simulators

### DIFF
--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -426,13 +426,20 @@ matching `Point` component in the lens model during modeling.
 `redshift` is populated on each `PointDataset` so that the per-source redshifts round-trip through the
 combined CSV below. This is the piece that makes the CSV self-describing for cluster modeling — position,
 noise, and redshift live in a single spreadsheet.
+
+The position uncertainty is set to 0.005" (5 mas), reflecting the centroid precision achievable by PSF
+fitting on HST or adaptive-optics imaging — *not* the imaging pixel scale, which is the detector's
+sampling rather than its centroiding precision. See `scripts/point_source/simulator.py` for a full
+discussion of this value.
 """
+position_noise = 0.005
+
 dataset_list = []
 for i, positions in enumerate(positions_list):
     dataset = al.PointDataset(
         name=f"point_{i}",
         positions=positions,
-        positions_noise_map=imaging_grid.pixel_scale,
+        positions_noise_map=position_noise,
         redshift=source_redshifts[i],
     )
     dataset_list.append(dataset)
@@ -468,8 +475,10 @@ observed multiple image with the following columns:
 
  - `name`    — the source identifier (e.g. `point_0`). All rows sharing a `name` belong to the same source.
  - `y`, `x`  — the image-plane position of the multiple image, in arc-seconds.
- - `positions_noise` — the positional uncertainty (typically the pixel scale of the imaging used to
-   measure it).
+ - `positions_noise` — the positional uncertainty in arc-seconds. This is the PSF-fit centroid
+   uncertainty on each multiple image, *not* the imaging pixel scale. For HST or adaptive-optics
+   data on bright cluster member images, ~0.005" (5 mas) is a defensible default; ground-based
+   seeing-limited data may warrant a few × 0.01" depending on image SNR.
  - `redshift` — the source redshift. Every row for a given `name` must share the *same* redshift
    (validated on load; `list_from_csv` raises if a group's rows disagree). Leave the cell blank if the
    redshift is unknown; blank is tolerated as long as *all* rows in a group are blank.

--- a/scripts/point_source/features/deblending/simulator.py
+++ b/scripts/point_source/features/deblending/simulator.py
@@ -98,13 +98,21 @@ solver = al.PointSolver.for_grid(
 """
 We now pass the `Tracer` to the solver. This will then find the image-plane coordinates that map directly to the
 source-plane coordinate (0.0", 0.0").
+
+Position noise is set to 0.005" (5 mas), reflecting realistic PSF-centroiding precision on HST imaging
+rather than the imaging pixel scale. Flux noise is set to 5% relative, reflecting that lensed-quasar
+flux uncertainties are dominated by microlensing systematics rather than photon noise. See
+`scripts/point_source/simulator.py` for a full discussion of these values.
 """
+position_noise = 0.005
+flux_rel_noise = 0.05
+
 positions = solver.solve(
     tracer=tracer, source_plane_coordinate=source_galaxy.point_0.centre
 )
 
 positions_with_noise = positions + np.random.normal(
-    loc=0.0, scale=grid.pixel_scale, size=positions.shape
+    loc=0.0, scale=position_noise, size=positions.shape
 )
 
 positions_with_noise = al.Grid2DIrregular(
@@ -128,14 +136,12 @@ fluxes = [flux * np.abs(magnification) for magnification in magnifications]
 fluxes = al.ArrayIrregular(values=fluxes)
 
 fluxes_with_noise = fluxes + np.random.normal(
-    loc=0.0, scale=np.sqrt(fluxes), size=len(fluxes)
+    loc=0.0, scale=flux_rel_noise * np.asarray(fluxes), size=len(fluxes)
 )
 
 fluxes_with_noise = al.ArrayIrregular(values=fluxes_with_noise)
 
-fluxes_noise_map = al.ArrayIrregular(
-    values=[np.sqrt(flux) for _ in range(len(fluxes_with_noise))]
-)
+fluxes_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes))
 
 
 """
@@ -146,7 +152,7 @@ Create the `PointDataset`  and `PointDataset` objects using identical code to th
 dataset = al.PointDataset(
     name="point_0",
     positions=positions_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes_with_noise,
     fluxes_noise_map=fluxes_noise_map,
 )

--- a/scripts/point_source/features/multiple_sources/simulator.py
+++ b/scripts/point_source/features/multiple_sources/simulator.py
@@ -132,7 +132,14 @@ This finds the image-plane coordinates that map directly to the source-plane cen
 (0.0", 0.0"). A double Einstein cross is a multi-plane lensing system, therefore for each source we also pass
 their redshift into the solver as `plane_redshift` so that it finds the multiple images while properly accounting
 for the multi-plane lensing.
+
+Position noise is set to 0.005" (5 mas, realistic PSF-centroiding precision on HST imaging) and flux noise
+to 5% relative (microlensing-dominated regime). See `scripts/point_source/simulator.py` for a full
+discussion of these values.
 """
+position_noise = 0.005
+flux_rel_noise = 0.05
+
 positions_0 = solver.solve(
     tracer=tracer,
     source_plane_coordinate=source_galaxy_0.point_0.centre,
@@ -140,7 +147,7 @@ positions_0 = solver.solve(
 )
 
 positions_0_with_noise = positions_0 + np.random.normal(
-    loc=0.0, scale=grid.pixel_scale, size=positions_0.shape
+    loc=0.0, scale=position_noise, size=positions_0.shape
 )
 
 positions_0_with_noise = al.Grid2DIrregular(
@@ -154,7 +161,7 @@ positions_1 = solver.solve(
 )
 
 positions_1_with_noise = positions_1 + np.random.normal(
-    loc=0.0, scale=grid.pixel_scale, size=positions_1.shape
+    loc=0.0, scale=position_noise, size=positions_1.shape
 )
 
 positions_1_with_noise = al.Grid2DIrregular(
@@ -178,20 +185,16 @@ flux = 1.0
 fluxes_0 = [flux * np.abs(magnification) for magnification in magnifications_0]
 fluxes_0 = al.ArrayIrregular(values=fluxes_0)
 fluxes_0_with_noise = fluxes_0 + np.random.normal(
-    loc=0.0, scale=np.sqrt(fluxes_0), size=len(fluxes_0)
+    loc=0.0, scale=flux_rel_noise * np.asarray(fluxes_0), size=len(fluxes_0)
 )
-fluxes_0_noise_map = al.ArrayIrregular(
-    values=[np.sqrt(flux) for _ in range(len(fluxes_0_with_noise))]
-)
+fluxes_0_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes_0))
 
 fluxes_1 = [flux * np.abs(magnification) for magnification in magnifications_1]
 fluxes_1 = al.ArrayIrregular(values=fluxes_1)
 fluxes_1_with_noise = fluxes_1 + np.random.normal(
-    loc=0.0, scale=np.sqrt(fluxes_1), size=len(fluxes_1)
+    loc=0.0, scale=flux_rel_noise * np.asarray(fluxes_1), size=len(fluxes_1)
 )
-fluxes_1_noise_map = al.ArrayIrregular(
-    values=[np.sqrt(flux) for _ in range(len(fluxes_1_with_noise))]
-)
+fluxes_1_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes_1))
 
 """
 We now output the image of this strong lens to `.fits` which can be used for visualize when performing point-source 
@@ -216,14 +219,14 @@ analyse the dataset.
 dataset_0 = al.PointDataset(
     name="point_0",
     positions=positions_0_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes_0_with_noise,
     fluxes_noise_map=fluxes_0_noise_map,
 )
 dataset_1 = al.PointDataset(
     name="point_1",
     positions=positions_1_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes_1_with_noise,
     fluxes_noise_map=fluxes_1_noise_map,
 )

--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -231,8 +231,13 @@ Here is a visualization of the triangulation approach:
 __Dataset__
 
 We first create a `PointDataset` object, which is similar to an `Imaging` or `Interferometer` object but contains the
-positions of the multiple images of the point source and their noise-map values. The noise values are the pixel-scale
-of the data, as this is the uncertainty of where we measure the multiple images in the image.
+positions of the multiple images of the point source and their noise-map values.
+
+The noise values are the centroid uncertainty with which each multiple image is localised in the data. This is *not*
+the imaging pixel scale — that is the detector's sampling, not its centroiding precision. Bright point sources are
+localised by fitting the instrumental PSF to the image, and the resulting centroid uncertainty is typically a small
+fraction of a pixel: ~0.005" (5 mas) for HST or adaptive-optics imaging of lensed quasars in the strong-lensing
+literature (CASTLES, TDCOSMO/H0LiCOW). See `scripts/point_source/simulator.py` for a full discussion.
 
 We manually specify the positions of the multiple images below, which correspond to the multiple images of the
 isothermal mass model used above.
@@ -251,7 +256,7 @@ positions_data = al.Grid2DIrregular(
     ]
 )
 
-positions_noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
+positions_noise_map = al.ArrayIrregular([0.005, 0.005, 0.005, 0.005])
 
 dataset = al.PointDataset(
     name="point_0", positions=positions_data, positions_noise_map=positions_noise_map
@@ -424,10 +429,14 @@ fluxes = [flux * np.abs(magnification) for magnification in magnifications]
 fluxes = al.ArrayIrregular(values=fluxes)
 
 """
-The noise values of the fluxes are set to the square root of the flux, which is a common given that Poisson noise
-is expected to dominate the noise of the fluxes.
+We set the flux noise to 5% of each measured flux. For lensed quasars and supernovae, photometric flux
+uncertainties are dominated by microlensing systematics rather than photon noise, so models that exclude
+microlensing typically assume a few-percent flux uncertainty per image. See `scripts/point_source/simulator.py`
+for a fuller discussion.
 """
-fluxes_noise_map = al.ArrayIrregular(values=[np.sqrt(flux) for _ in range(len(fluxes))])
+flux_rel_noise = 0.05
+
+fluxes_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes))
 
 """
 __Flux Point Dataset__
@@ -505,14 +514,16 @@ light to travel through the gravitational potential of the lens galaxy).
 time_delays = tracer.time_delays_from(grid=positions)
 
 """
-In real observations, times delays are measured by taking photometric measurements of the multiple images over time,
-aligning the light curves, and measuring the time delays between the images.
-
-This processes estimates with it uncertainties, which are often represented as noise-map values in the dataset.
-For simplicity, in this simulation we assume the time delays have a noise value which is a quarter of their
-measurement value, however it is not typical that the noise value is directly proportional to the time delay.
+In real observations, time delays are measured by photometrically monitoring the multiple images over months
+to years and cross-correlating their light curves. State-of-the-art monitoring campaigns (COSMOGRAIL, TDCOSMO)
+achieve ~1–3% relative precision on the longest delays in well-sampled quad systems. For simplicity we adopt
+a 5% relative uncertainty here. Real-world uncertainties are not strictly proportional to the delay magnitude
+(they depend on monitoring cadence, length, and microlensing variability), but a constant fractional error is
+a reasonable simulator default. See `scripts/point_source/simulator.py` for a fuller discussion.
 """
-time_delays_noise_map = al.ArrayIrregular(values=time_delays * 0.25)
+time_delay_rel_noise = 0.05
+
+time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * time_delay_rel_noise)
 
 """
 The time delays are input into a `PointDataset` object, alongside the image-plane coordinates of the multiple images

--- a/scripts/point_source/simulator.py
+++ b/scripts/point_source/simulator.py
@@ -148,14 +148,24 @@ positions = solver.solve(
 )
 
 """
-We now add noise to the multiple image positions to simulate observational measurement errors.
+We now add Gaussian noise to the multiple image positions to simulate observational measurement errors.
 
-In real observations, the positions of point source multiple images are measured from CCD imaging data. The
-precision of these measurements is limited by factors such as the pixel scale of the CCD, which is the only
-source of noise we simulate here for simplicity.
+The positional uncertainty in real observations is *not* the pixel scale of the imaging — that is the
+detector's sampling, not its centroiding precision. Bright point sources (e.g. lensed quasars or supernovae)
+are localised by fitting the instrumental PSF to the image, and the resulting centroid uncertainty is
+typically a small fraction of a pixel. For HST/ACS or WFC3, this corresponds to ~3–5 mas (0.003–0.005");
+for adaptive optics on Keck or VLT it is similar; for VLBI radio observations of lensed quasars it can
+be sub-mas. We adopt a default of 0.005" (5 mas), which is representative of HST point-source astrometry
+in the strong-lensing literature (CASTLES, TDCOSMO/H0LiCOW). Setting the precision close to the imaging
+pixel scale (~0.05") would inflate lens-model parameter uncertainties well beyond what real data deliver.
+
+Centroid uncertainties from PSF fitting are well-approximated as Gaussian via Laplace's approximation
+around the fitted likelihood maximum, so a Gaussian noise model is appropriate here.
 """
+position_noise = 0.005
+
 positions_with_noise = positions + np.random.normal(
-    loc=0.0, scale=grid.pixel_scale, size=positions.shape
+    loc=0.0, scale=position_noise, size=positions.shape
 )
 
 positions_with_noise = al.Grid2DIrregular(
@@ -172,10 +182,9 @@ This dataset is labeled with the `name` `point_0`, identifying it as correspondi
 `point_0`. The name is essential for associating the dataset with the correct point source in the lens model during 
 fitting.
 
-The dataset contains the image-plane coordinates of the multiple images and their corresponding noise-map values. 
-Typically, the noise value for each position is set to the pixel scale of the CCD image, representing the area the 
-point source occupies. Although sub-pixel accuracy can be achieved with more detailed analysis, this example does not 
-cover those techniques.
+The dataset contains the image-plane coordinates of the multiple images and their corresponding noise-map values.
+The `positions_noise_map` is set to the same `position_noise` defined above (0.005", i.e. 5 mas), reflecting
+realistic PSF-centroiding precision rather than the imaging pixel scale.
 
 Note also that this dataset does not contain fluxes or time delays, which are often included in point source datasets
 and are included in a separate simulation below.
@@ -183,7 +192,7 @@ and are included in a separate simulation below.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
 )
 
 """"
@@ -321,21 +330,25 @@ fluxes = [flux * np.abs(magnification) for magnification in magnifications]
 fluxes = al.ArrayIrregular(values=fluxes)
 
 """
-We now add noise to the fluxes to simulate observational measurement errors.
+We now add Gaussian noise to the fluxes to simulate observational measurement errors.
+
+For lensed quasars and supernovae, photometric measurements of multiple-image fluxes are not generally
+photon-noise-limited — the dominant uncertainty is microlensing, in which stars in the lens galaxy
+distort the apparent flux of each image by amounts that depend on the source size, the macro-magnification,
+and where each image lies in the lens-plane stellar field. Lens models that explicitly *exclude*
+microlensing therefore typically assume a few-percent flux uncertainty per image rather than a Poisson
+floor. We adopt a 5% relative flux error here, which is consistent with this practice and produces
+realistic flux-ratio constraints on the mass model.
 """
+flux_rel_noise = 0.05
+
 fluxes_with_noise = fluxes + np.random.normal(
-    loc=0.0, scale=np.sqrt(fluxes), size=len(fluxes)
+    loc=0.0, scale=flux_rel_noise * np.asarray(fluxes), size=len(fluxes)
 )
 
 fluxes_with_noise = al.ArrayIrregular(values=fluxes_with_noise)
 
-"""
-The noise values of the fluxes are set to the square root of the flux, which is a common given that Poisson noise
-is expected to dominate the noise of the fluxes.
-"""
-fluxes_noise_map = al.ArrayIrregular(
-    values=[np.sqrt(flux) for _ in range(len(fluxes_with_noise))]
-)
+fluxes_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes))
 
 """
 __Point Dataset__
@@ -349,7 +362,7 @@ of a single point-source.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes_with_noise,
     fluxes_noise_map=fluxes_noise_map,
 )
@@ -387,14 +400,20 @@ light to travel through the gravitational potential of the lens galaxy).
 time_delays = tracer.time_delays_from(grid=positions)
 
 """
-In real observations, times delays are measured by taking photometric measurements of the multiple images over time,
-aligning the light curves, and measuring the time delays between the images.
+In real observations, time delays are measured by photometrically monitoring the multiple images over months
+to years and cross-correlating their light curves to align the variable signals. State-of-the-art monitoring
+campaigns (e.g. COSMOGRAIL, TDCOSMO) routinely achieve ~1–3% relative precision on the longest time delays
+in well-sampled quad systems — absolute uncertainties of ~0.5–1.5 days on 30–100 day delays.
 
-This processes estimates with it uncertainties, which are often represented as noise-map values in the dataset.
-For simplicity, in this simulation we assume the time delays have a noise value which is a quarter of their
-measurement value, however it is not typical that the noise value is directly proportional to the time delay.
+For simplicity we adopt a 5% relative uncertainty here. Real-world uncertainties are not strictly
+proportional to the delay magnitude (they depend on the cadence and total length of the photometric
+monitoring, on microlensing variability that distorts the light curves, and on the lens configuration),
+but a constant fractional error is a reasonable simulator default and produces realistic relative weights
+between the multiple images.
 """
-time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * 0.25)
+time_delay_rel_noise = 0.05
+
+time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * time_delay_rel_noise)
 
 """
 We now add noise to the time delays to simulate observational measurement errors.
@@ -417,7 +436,7 @@ of a single point-source.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     time_delays=time_delays_with_noise,
     time_delays_noise_map=time_delays_noise_map,
 )
@@ -441,7 +460,7 @@ to perform lens modeling of all measurements simultaneously.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions_with_noise,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes_with_noise,
     fluxes_noise_map=fluxes_noise_map,
     time_delays=time_delays_with_noise,

--- a/scripts/point_source/simulator_sample.py
+++ b/scripts/point_source/simulator_sample.py
@@ -166,16 +166,23 @@ for sample_index in range(total_datasets):
     """
     __Positions__
 
-    We now pass the `Tracer` to the solver to find the multiple image positions and add noise to simulate observed
-    data.
+    We now pass the `Tracer` to the solver to find the multiple image positions and add Gaussian noise to
+    simulate observational measurement errors.
+
+    The position uncertainty is set to 0.005" (5 mas), reflecting the centroid precision achievable by PSF
+    fitting on HST or adaptive-optics imaging — *not* the imaging pixel scale, which is the detector's
+    sampling rather than its centroiding precision. This value is representative of HST point-source
+    astrometry in the strong-lensing literature (CASTLES, TDCOSMO/H0LiCOW). See `simulator.py` for a
+    fuller discussion.
     """
+    position_noise = 0.005
+
     positions = solver.solve(
         tracer=tracer, source_plane_coordinate=source_galaxy.point_0.centre
     )
-    positions_noise_map = grid.pixel_scale
 
     positions_with_noise = positions + np.random.normal(
-        loc=0.0, scale=grid.pixel_scale, size=positions.shape
+        loc=0.0, scale=position_noise, size=positions.shape
     )
 
     positions_with_noise = al.Grid2DIrregular(
@@ -185,11 +192,17 @@ for sample_index in range(total_datasets):
     """
     __Time Delays__
 
-    We next compute the time delays of the multiple images, with noise added to the data, which are used to 
-    constrain the Hubble constant.
+    We next compute the time delays of the multiple images, with Gaussian noise added to simulate
+    observational measurement errors, which are used to constrain the Hubble constant.
+
+    State-of-the-art photometric monitoring campaigns (e.g. COSMOGRAIL, TDCOSMO) routinely achieve ~1–3%
+    relative precision on the longest time delays in well-sampled quad systems. We adopt a 5% relative
+    uncertainty here as a conservative simulator default. See `simulator.py` for a fuller discussion.
     """
+    time_delay_rel_noise = 0.05
+
     time_delays = tracer.time_delays_from(grid=positions)
-    time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * 0.25)
+    time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * time_delay_rel_noise)
 
     time_delays_with_noise = time_delays + np.random.normal(
         loc=0.0, scale=time_delays_noise_map, size=len(time_delays)
@@ -208,7 +221,7 @@ for sample_index in range(total_datasets):
     dataset = al.PointDataset(
         name="point_0",
         positions=positions_with_noise,
-        positions_noise_map=grid.pixel_scale,
+        positions_noise_map=position_noise,
         time_delays=time_delays_with_noise,
         time_delays_noise_map=time_delays_noise_map,
     )

--- a/scripts/point_source/start_here.py
+++ b/scripts/point_source/start_here.py
@@ -110,7 +110,7 @@ this will be import later when we perform lens modeling.
 positions = al.Grid2DIrregular(
     [(-1.039, -1.038), (0.442, 1.608), (1.609, 0.442), (1.179, 1.179)]
 )
-noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
+noise_map = al.ArrayIrregular([0.005, 0.005, 0.005, 0.005])
 
 dataset = al.PointDataset(
     name="point_0", positions=positions, positions_noise_map=noise_map
@@ -327,7 +327,7 @@ A few things to note, with full details on data preparation provided in the main
 positions = al.Grid2DIrregular(
     [(-1.039, -1.038), (0.442, 1.608), (1.609, 0.442), (1.179, 1.179)]
 )
-noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
+noise_map = al.ArrayIrregular([0.005, 0.005, 0.005, 0.005])
 
 dataset = al.PointDataset(
     name="point_0", positions=positions, positions_noise_map=noise_map
@@ -348,9 +348,13 @@ positions = al.Grid2DIrregular(
 fluxes = al.ArrayIrregular(values=[6.82, 55.16, 53.63, 100.62])
 time_delays = al.ArrayIrregular(values=[-136.99, -176.85, -177.02, -176.74])
 
-positions_noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
-fluxes_noise_map = al.ArrayIrregular(values=[1.0, 1.0, 1.0, 1.0])
-time_delays_noise_map = al.ArrayIrregular(values=[-34.25, -44.21, -44.26, -44.19])
+# Position noise = 5 mas (PSF-centroiding precision on HST imaging).
+# Flux noise = 5% relative (microlensing-dominated regime).
+# Time delay noise = 5% relative magnitude (COSMOGRAIL/TDCOSMO regime).
+# See `simulator.py` for a full discussion of these values.
+positions_noise_map = al.ArrayIrregular([0.005, 0.005, 0.005, 0.005])
+fluxes_noise_map = al.ArrayIrregular(values=[0.34, 2.76, 2.68, 5.03])
+time_delays_noise_map = al.ArrayIrregular(values=[6.85, 8.84, 8.85, 8.84])
 
 dataset = al.PointDataset(
     name="point_0",
@@ -495,14 +499,21 @@ al.output_to_fits(
 """
 __Simulator__
 
-We now compute: 
+We now compute:
 
  - The point source positions, reusing the `PointSolver` above.
- - The RMS noise map of the positions, which uses the `pixel_scale` of the CCD imaging data the quasar is observed on.
- - The point source fluxes, by computing the magnificaiton from the tracer and applying it to an input source flux.
- - The RMS noise map of the fluxes, which is the square root of the observed counts of each image.
- - The time delays, which comes from the tracer's mass model.
- - The RMS noise of the time delays, which is assumed to be 0.25 * their values but in real data uses the time delay estimate process.
+ - The RMS noise map of the positions, set to the centroid precision of PSF fitting on HST imaging
+   (~5 mas) — *not* the imaging pixel scale, which is the detector's sampling rather than its
+   centroiding precision.
+ - The point source fluxes, by computing the magnification from the tracer and applying it to an
+   input source flux.
+ - The RMS noise map of the fluxes, set to 5% relative — for lensed quasars and supernovae,
+   photometric flux uncertainties are dominated by microlensing systematics rather than photon noise.
+ - The time delays, which come from the tracer's mass model.
+ - The RMS noise of the time delays, set to 5% relative — matching COSMOGRAIL/TDCOSMO precision on
+   well-sampled photometric monitoring of multiply-imaged quasars.
+
+See `simulator.py` for a full discussion of these values.
 """
 positions = solver.solve(
     tracer=tracer, source_plane_coordinate=source_galaxy.point_0.centre
@@ -518,11 +529,15 @@ flux = 1.0
 fluxes = [flux * np.abs(magnification) for magnification in magnifications]
 fluxes = al.ArrayIrregular(values=fluxes)
 
-positions_noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
+position_noise = 0.005
+flux_rel_noise = 0.05
+time_delay_rel_noise = 0.05
 
-fluxes_noise_map = al.ArrayIrregular(values=[np.sqrt(flux) for _ in range(len(fluxes))])
+positions_noise_map = al.ArrayIrregular([position_noise] * len(positions))
 
-time_delays_noise_map = al.ArrayIrregular(values=time_delays * 0.25)
+fluxes_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes))
+
+time_delays_noise_map = al.ArrayIrregular(values=np.abs(time_delays) * time_delay_rel_noise)
 
 """
 We can pass these to a `PointDataset` and output to hard disk as a .json file.
@@ -530,7 +545,7 @@ We can pass these to a `PointDataset` and output to hard disk as a .json file.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=positions_noise_map,
     fluxes=fluxes,
     fluxes_noise_map=fluxes_noise_map,
     time_delays=time_delays,
@@ -593,11 +608,11 @@ for sample_index in range(total_datasets):
     fluxes = [flux * np.abs(magnification) for magnification in magnifications]
     fluxes = al.ArrayIrregular(values=fluxes)
 
-    positions_noise_map = al.ArrayIrregular([0.05, 0.05, 0.05, 0.05])
-    fluxes_noise_map = al.ArrayIrregular(
-        values=[np.sqrt(flux) for _ in range(len(fluxes))]
+    positions_noise_map = al.ArrayIrregular([position_noise] * len(positions))
+    fluxes_noise_map = al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes))
+    time_delays_noise_map = al.ArrayIrregular(
+        values=np.abs(time_delays) * time_delay_rel_noise
     )
-    time_delays_noise_map = al.ArrayIrregular(values=time_delays * 0.25)
 
     dataset = al.PointDataset(
         name=f"point_0",


### PR DESCRIPTION
## Summary

Realistic measurement errors in the point-source simulators. Position
uncertainty is now 0.005" (5 mas, HST PSF-centroiding precision) rather
than the imaging pixel scale; time-delay relative noise is 5% (matching
COSMOGRAIL/TDCOSMO regime) rather than 25%; flux relative noise is 5%
(microlensing-dominated regime) rather than √flux. Docstrings now cite
the relevant literature and explain the rationale.

## Scripts Changed

- `scripts/point_source/simulator.py` — canonical simulator: full position/flux/time-delay docstring rewrites with literature citations (CASTLES, TDCOSMO, COSMOGRAIL)
- `scripts/point_source/simulator_sample.py` — sample-mode variant with the same constants and condensed docstrings referring back to the canonical
- `scripts/point_source/start_here.py` — multiple sections updated (manual dataset, fluxes-and-time-delays example, simulator section, sample loop), plus fixed a latent bug where `positions_noise_map` was defined but unused (the dataset constructor used `grid.pixel_scale` instead)
- `scripts/point_source/fit.py` — hardcoded `[0.05]*4` → `[0.005]*4`, plus updated flux and time-delay noise sections with rewritten docstrings
- `scripts/point_source/features/deblending/simulator.py` — positions and fluxes
- `scripts/point_source/features/multiple_sources/simulator.py` — positions and fluxes for both lensed sources in a double Einstein cross
- `scripts/cluster/simulator.py` — position fix plus rewrite of the misleading "positional uncertainty (typically the pixel scale of the imaging used to measure it)" docstring in the manual-CSV-editing section

Constants applied consistently across all scripts:

- `position_noise = 0.005`         — 5 mas, HST PSF-centroiding precision
- `flux_rel_noise = 0.05`          — 5%, microlensing-dominated regime
- `time_delay_rel_noise = 0.05`    — 5%, COSMOGRAIL/TDCOSMO regime

Closes #125.

## Test Plan

- [ ] Smoke tests pass for autolens_workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)