### PR TITLE
fix: align aggregator queries with MGE source bulge in autolens tutorials

### DIFF
--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -111,14 +111,14 @@ agg_query = agg.query(lens.mass == al.mp.Isothermal)
 print("Total Samples Objects via `Isothermal` model query = ", len(agg_query), "\n")
 
 """
-Queries using the results of model-fitting are also supported. Below, we query the database to find all fits where the 
-inferred value of `sersic_index` for the `Sersic` of the source's bulge is less than 3.0 (which returns only 
+Queries using the results of model-fitting are also supported. Below, we query the database to find all fits where the
+inferred value of `einstein_radius` for the `Isothermal` mass of the lens is less than 1.5 (which returns only
 the first of the three model-fits).
 """
-bulge = agg.model.galaxies.source.bulge
-agg_query = agg.query(bulge.sersic_index < 3.0)
+mass = agg.model.galaxies.lens.mass
+agg_query = agg.query(mass.einstein_radius < 1.5)
 print(
-    "Total Samples Objects In Query `source.bulge.sersic_index < 3.0` = ",
+    "Total Samples Objects In Query `lens.mass.einstein_radius < 1.5` = ",
     len(agg_query),
     "\n",
 )

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -476,19 +476,19 @@ print(samples.parameter_lists[0])
 samples = samples.with_paths(
     [
         ("galaxies", "lens", "mass", "einstein_radius"),
-        ("galaxies", "source", "bulge", "sersic_index"),
+        ("galaxies", "lens", "mass", "centre", "centre_0"),
     ]
 )
 
 print(
     "All parameters of the very first sample (containing only the lens mass's einstein radius and "
-    "source bulge's sersic index)."
+    "centre y-coordinate)."
 )
 print(samples.parameter_lists[0])
 
 print(
     "Maximum Log Likelihood Model Instances (containing only the lens mass's einstein radius and "
-    "source bulge's sersic index):\n"
+    "centre y-coordinate):\n"
 )
 print(samples.max_log_likelihood(as_instance=False))
 
@@ -503,12 +503,12 @@ We can alternatively use the following API:
 samples = list(agg.values("samples"))[0]
 
 samples = samples.with_paths(
-    ["galaxies.lens.mass.einstein_radius", "galaxies.source.bulge.sersic_index"]
+    ["galaxies.lens.mass.einstein_radius", "galaxies.lens.mass.centre.centre_0"]
 )
 
 print(
     "All parameters of the very first sample (containing only the lens mass's einstein radius and "
-    "source bulge's sersic index)."
+    "centre y-coordinate)."
 )
 
 """


### PR DESCRIPTION
## Summary
Two aggregator tutorial scripts in `scripts/guides/results/aggregator/` (`queries.py`, `samples_via_aggregator.py`) crashed with `AttributeError: 'Model' object has no attribute 'sersic_index'` because the recent `_quick_fit.py` refactor (PR #118) switched the source bulge from `Sersic` to MGE (`al.model_util.mge_model_from`). The MGE model exposes only the basis's shared `centre` and `ell_comps` — there is no `sersic_index` field.

This was Cluster B of the recent release-prep triage. Cluster A's fix (`_quick_fit.py` smoke-mode env var pop) is already on `main` and is the prerequisite that exposes these failures end-to-end.

## Scripts Changed
- `scripts/guides/results/aggregator/queries.py` — Model Queries section now demos `agg.query(lens.mass.einstein_radius < 1.5)` instead of `bulge.sersic_index < 3.0`. The Logic section already uses `mass.einstein_radius` with a `& mass == al.mp.Isothermal` composite, so the two sections continue to demonstrate distinct query API features (single comparison vs `&` composition).
- `scripts/guides/results/aggregator/samples_via_aggregator.py` — Samples Filtering section's two `with_paths` calls (tuple form and string form) now use `("galaxies", "lens", "mass", "centre", "centre_0")` / `"galaxies.lens.mass.centre.centre_0"` as the second path instead of `sersic_index`. Surrounding description strings updated to "lens mass's einstein radius and centre y-coordinate". `centre.centre_0` is already referenced verbatim later in the same script (line 533), so the path is known valid.

## Test Plan
- [ ] Smoke tests pass for autolens_workspace
- [x] Verified locally: both scripts exit 0 under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` (pre-fix: both exit 1 with the documented `AttributeError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)