### PR TITLE
fix: clamp einstein_radius prior in two more group SLaM scripts

### DIFF
--- a/scripts/group/features/linear_light_profiles/slam.py
+++ b/scripts/group/features/linear_light_profiles/slam.py
@@ -701,9 +701,11 @@ def mass_total(
             abs(galaxy_with_intensity.bulge.luminosity_within_circle_from(radius=10.0))
             / pixel_scale**2
         )
+        luminosity_cap = 5 * 0.5 * total_luminosity**0.6
+        upper_limit = min(luminosity_cap, 5.0) if luminosity_cap > 0 else 5.0
         mass.einstein_radius = af.UniformPrior(
             lower_limit=0.0,
-            upper_limit=min(5 * 0.5 * total_luminosity**0.6, 5.0),
+            upper_limit=upper_limit,
         )
 
         extra_mass_models.append(

--- a/scripts/group/features/pixelization/slam.py
+++ b/scripts/group/features/pixelization/slam.py
@@ -231,9 +231,11 @@ def source_lp_1(
             for g in tracer.galaxies[n_main + i].bulge.profile_list
         ]
         total_luminosity = np.sum(luminosity_per_gaussian_list) / pixel_scale**2
+        luminosity_cap = 5 * 0.5 * total_luminosity**0.6
+        upper_limit = min(luminosity_cap, 5.0) if luminosity_cap > 0 else 5.0
         mass.einstein_radius = af.UniformPrior(
             lower_limit=0.0,
-            upper_limit=min(5 * 0.5 * total_luminosity**0.6, 5.0),
+            upper_limit=upper_limit,
         )
 
         extra_mass_models.append(


### PR DESCRIPTION
## Summary
Two group SLaM scripts in `scripts/group/features/` crashed with `PriorException: upper limit of a prior must be greater than its lower limit` under fast smoke mode. The root cause is the same one PR #117 fixed in `linear_light_profiles/slam.py`'s `source_lp_1` — when `PYAUTO_TEST_MODE=2` produces zero linear-light intensities, `total_luminosity == 0`, so `min(5 * 0.5 * 0**0.6, 5.0) == 0` and the resulting `af.UniformPrior(lower_limit=0.0, upper_limit=0)` is rejected.

PR #117's clamp didn't cover every site of the same pattern. This PR ports the identical fix to the two missed siblings — Cluster C of the recent release-prep triage.

## Scripts Changed
- `scripts/group/features/linear_light_profiles/slam.py` — function `mass_total` (the second SLaM phase). Adds the `luminosity_cap` / `upper_limit` clamp prefix before `mass.einstein_radius = af.UniformPrior(...)`. PR #117 already fixed `source_lp_1` in the same file; the SLaM pipeline was crashing at the next phase down.
- `scripts/group/features/pixelization/slam.py` — function `source_lp_1`. Same clamp pattern; the only difference vs the linear_light_profiles version is that this one computes `total_luminosity` via `np.sum(luminosity_per_gaussian_list)` (MGE basis) rather than `bulge.luminosity_within_circle_from(...)` — failure mode is identical.

Verbatim mechanical port of the patch accepted in PR #117.

## Test Plan
- [ ] Smoke tests pass for autolens_workspace
- [x] Verified locally: both scripts exit 0 under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1`. The `linear_light_profiles/slam.py` run now reaches `mass_total[1]` (the previously-buggy site) and completes; pre-fix it crashed at the `mass_total` PriorException.

🤖 Generated with [Claude Code](https://claude.com/claude-code)