### PR TITLE
fix: derive point_source/fit.py positions data from solver output (Cluster E)

### DIFF
--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -239,24 +239,19 @@ localised by fitting the instrumental PSF to the image, and the resulting centro
 fraction of a pixel: ~0.005" (5 mas) for HST or adaptive-optics imaging of lensed quasars in the strong-lensing
 literature (CASTLES, TDCOSMO/H0LiCOW). See `scripts/point_source/simulator.py` for a full discussion.
 
-We manually specify the positions of the multiple images below, which correspond to the multiple images of the
-isothermal mass model used above.
+We construct a `PointDataset` from the multiple-image positions we just solved for, with a small (5 mas) noise
+value per position. In a real analysis the positions would come from your data reduction pipeline (e.g. a
+centroid fit to each multiple image in the calibrated image), but for this demo we reuse the solver's output
+so the script adapts to whatever number of multiple images the mass model produces.
 
-The demagnified central image is not included in the dataset, as it is not observed in the image-plane. This is
-standard practice in point-source modeling.
+The demagnified central image is excluded by the solver's `magnification_threshold=0.1` setting, so it does not
+appear in the dataset either — standard practice in point-source modeling.
 
-It also contains the name `point_0`, which is an important label, as explained in more detail below.
+The dataset's name `point_0` is an important label, as explained in more detail below.
 """
-positions_data = al.Grid2DIrregular(
-    [
-        [-1.03884121e00, -1.03906250e00],
-        [4.41972024e-01, 1.60859375e00],
-        [1.17899573e00, 1.17890625e00],
-        [1.60930210e00, 4.41406250e-01],
-    ]
-)
+positions_data = al.Grid2DIrregular(positions)
 
-positions_noise_map = al.ArrayIrregular([0.005, 0.005, 0.005, 0.005])
+positions_noise_map = al.ArrayIrregular([0.005] * len(positions))
 
 dataset = al.PointDataset(
     name="point_0", positions=positions_data, positions_noise_map=positions_noise_map


### PR DESCRIPTION
## Summary
`scripts/point_source/fit.py` crashed with `ValueError: operands could not be broadcast together with shapes (2,) (4,)` at `autoarray/abstract_ndarray.py:326` under `PYAUTO_SMALL_DATASETS=1`. `PointSolver.solve()` short-circuits to a fixed 2-position pair in that mode (`PyAutoLens/autolens/point/solver/point_solver.py:90-91`), but the script hardcoded a 4-element `positions_data` and a 4-element `positions_noise_map`. `FitPositionsImagePairRepeat` then divided a 2-element residual vector by the 4-element noise_map and broadcasts failed.

This was Cluster E of the recent release-prep triage. Same family as the issues PR #119 ("Cluster E: fix deblending simulator + add auto-simulate snippets to 3 guides", merged 2026-05-03) cleared in `point_source/features/deblending/simulator.py` — that PR didn't touch `point_source/fit.py`, so this script kept the latent bug.

## Scripts Changed
- `scripts/point_source/fit.py` — replace the hardcoded 4-element `positions_data` and `positions_noise_map` lists with `al.Grid2DIrregular(positions)` and `al.ArrayIrregular([0.005] * len(positions))`. Same shape of fix as PR #119's `range(len(positions))` dict comprehension. Prose updated from "we manually specify" framing to a description of deriving the data from the solver's output, matching the new code.

## Test Plan
- [ ] Smoke tests pass for autolens_workspace
- [x] Verified locally under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` — script exits 0 with 2-element `residual_map`. Pre-fix: exits 1 with the documented `(2,) (4,)` broadcast error.
- [x] Verified locally with all PYAUTO_* env vars unset — script exits 0 with 4-element `residual_map`. The two modes share the same `len(positions)`-driven construction now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)