### PR TITLE
fix: restore missing source assignment in subhalo_refine (Cluster F)

### DIFF
--- a/scripts/group/features/advanced/subhalo/detect/start_here.py
+++ b/scripts/group/features/advanced/subhalo/detect/start_here.py
@@ -623,6 +623,8 @@ def subhalo_refine(
     subhalo.redshift = subhalo_grid_search_result.model.galaxies.subhalo.redshift
     subhalo.mass.redshift_object = subhalo.redshift
 
+    source = subhalo_grid_search_result.model.galaxies.source
+
     lens_dict = {
         "lens_0": subhalo_grid_search_result.model.galaxies.lens_0,
         "subhalo": subhalo,


### PR DESCRIPTION
## Summary
`scripts/group/features/advanced/subhalo/detect/start_here.py` crashed with `NameError: name 'source' is not defined. Did you mean: 'source_lp'?` at line 634 (the `source=source` kwarg in the `af.Collection(...)` call inside `subhalo_refine`).

This was Cluster F of the recent release-prep triage — fallout from PR #117 ("Cluster F triage: 4 script fixes", merged 2026-05-02). PR #117 removed the redundant `"source": ...` key from five `lens_dict` literals in this file (they collided with the explicit `source=source` kwarg, causing `TypeError: got multiple values`). For four functions, a local `source = ...` assignment already existed earlier in the function body, so the explicit kwarg remained resolvable. `subhalo_refine` was the exception — PR #117 dropped `"source": subhalo_grid_search_result.model.galaxies.source` from its lens_dict without lifting that expression into a standalone assignment, leaving the explicit kwarg pointing at an undefined name.

Note: Python's `Did you mean: 'source_lp'?` hint is a lexical-proximity suggestion only. `source_lp` (line 72) is a function in this file, not a Galaxy/Model — passing it as a Galaxy kwarg would have type-errored at fit time. The right fix is to restore the value PR #117 actually dropped.

## Scripts Changed
- `scripts/group/features/advanced/subhalo/detect/start_here.py` — function `subhalo_refine`. Add a single line `source = subhalo_grid_search_result.model.galaxies.source` between the existing `subhalo.mass.redshift_object = subhalo.redshift` (line 624) and the `lens_dict = {` literal (line 626). Restores exactly the value PR #117 dropped, matches the standalone-assignment style every other function in this file uses for `source`, and produces a model identical to the pre-PR-#117 behavior.

## Test Plan
- [ ] Smoke tests pass for autolens_workspace
- [x] Verified locally under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` — script exits 0 and `subhalo[3]_[single_plane_refine]` (the previously-failing phase) completes successfully. Pre-fix: exits 1 with the documented `NameError` at line 634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)