### PR TITLE
chore: park double_einstein_ring/slam as NEEDS_FIX (Cluster H)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -48,5 +48,6 @@
 - imaging/data_preparation/manual/mask_irregular # NEEDS_FIX 2026-04-10 - silent failure, needs investigation
 - imaging/features/pixelization/delaunay # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in Delaunay pixelization fit
 - imaging/features/pixelization/slam # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in SLaM pixelization pipeline
+- imaging/features/advanced/double_einstein_ring/slam # NEEDS_FIX 2026-05-07 - autofit.exc.FitException in SLaM bypass mode (same family as imaging/features/pixelization/slam — Adapt regularization needs adapt_data which the synthetic samples_summary doesn't carry; cascade goes deep, fixing in one PR isn't tractable)
 - interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-04-10 - broadcast shape mismatch (2,2) vs (1032,1032) in Delaunay interferometer
 - multi/features/wavelength_dependence/modeling # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in multi-wavelength modeling


### PR DESCRIPTION
## Summary
`scripts/imaging/features/advanced/double_einstein_ring/slam.py` crashes under `PYAUTO_TEST_MODE=2` with `autofit.exc.FitException` at `analysis.py:84`. Investigation traced the failure to a structural incompatibility between bypass mode and `Adapt` regularization:

- `Adapt.regularization_weights_from` → `Mapper.pixel_signals_from` does `self.adapt_data.array`, which is `None` under bypass.
- The same `None`-deref is reachable from multiple inversion entry points (likelihood evaluation, post-fit `result.subtracted_signal_to_noise_map_galaxy_dict`, etc.), so patching one site only unblocks the next.
- Even after a defensive FitException-tolerance patch in `_fit_bypass_test_mode` (which I drafted and then rolled back), the script fails downstream when the next SLaM phase derives `adapt_images` from the synthetic samples_summary.
- A real end-to-end fix requires either (a) defensively pretending `Adapt` works without `adapt_data` (silent semantic change — unsafe) or (b) restructuring the SLaM bypass to construct valid `adapt_data` (large refactor).

This was Cluster H of the recent release-prep triage. Parking alongside `imaging/features/pixelization/slam # NEEDS_FIX 2026-04-10` which has the same root cause and has been parked for ~26 days.

## Files Changed
- `config/build/no_run.yaml` — one new `# NEEDS_FIX 2026-05-07` entry for `imaging/features/advanced/double_einstein_ring/slam`. Sibling of the existing `imaging/features/pixelization/slam` entry.

## Test Plan
- [x] Visual diff inspection — one line added, format matches existing NEEDS_FIX entries.
- [ ] Confirmed by next mega-run: the script no longer appears in the failure list and instead surfaces in the NEEDS_FIX-warning banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)