### PR TITLE
fix: correct HDU indices for dataset.fits reload in results/start_here.py

### DIFF
--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -246,9 +246,9 @@ if (image_path / "dataset.fits").exists():
         data_path=image_path / "dataset.fits",
         noise_map_path=image_path / "dataset.fits",
         psf_path=image_path / "dataset.fits",
-        data_hdu=0,
-        noise_map_hdu=1,
-        psf_hdu=2,
+        data_hdu=1,
+        noise_map_hdu=2,
+        psf_hdu=3,
         pixel_scales=0.1,
     )
 


### PR DESCRIPTION
## Summary
Fix HDU indices in the `dataset.fits` reload block of `scripts/guides/results/start_here.py`. The Simple-Loading section was passing `data_hdu=0, noise_map_hdu=1, psf_hdu=2`, but the visualizer writes `dataset.fits` with MASK at HDU 0 and the data / noise_map / psf triplet at HDUs 1 / 2 / 3. The off-by-one made `noise_map_hdu=1` pull the data array (whose lens-residual pixels are negative), tripping the `check_noise_map` validation in `Imaging.__init__` with `DatasetException: A value in the noise-map of the dataset is -0.0367 ... less than or equal to zero`. (At native image sizes the same off-by-one also routes the noise map into the PSF slot and crashes the `Convolver` with the same `KernelException` reported in autogalaxy_workspace#61.)

This is the autolens_workspace counterpart to the already-merged PyAutoLabs/autogalaxy_workspace#61 and applies the same three-line fix.

## Scripts Changed
- `scripts/guides/results/start_here.py` — bumped `data_hdu` 0→1, `noise_map_hdu` 1→2, `psf_hdu` 2→3 in the FITS-reload block (lines 249–251) so the kwargs match the visualizer's actual HDU layout: `MASK, DATA, NOISE_MAP, PSF, OVER_SAMPLE_SIZE_LP, OVER_SAMPLE_SIZE_PIXELIZATION`.

## Test Plan
- [x] `python scripts/guides/results/start_here.py` runs to completion (exit 0) under `PYAUTO_SMALL_DATASETS=1` from a clean output folder.
- [x] Same script re-run against the cached fit also runs to completion (resume case — exercises the patched `from_fits`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)