### PR TITLE
fix: pathlib-refactor leftovers in HPC example_cpu.py

### DIFF
--- a/scripts/guides/hpc/example_cpu.py
+++ b/scripts/guides/hpc/example_cpu.py
@@ -55,7 +55,7 @@ You will need to update `hpc_username` to your hpc username below.
 """
 from pathlib import Path
 
-hpc_output_path = Path(path.sep) / "hpc" / "data" / "hpc_username" / "output"
+hpc_output_path = Path("/") / "hpc" / "data" / "hpc_username" / "output"
 
 """
 __HPC Dataset Path__
@@ -73,7 +73,7 @@ dataset_folder = "example"
 dataset_name = "simple__no_lens_light"
 
 hpc_dataset_path = (
-    Path(path.sep)
+    Path("/")
     / "hpc"
     / "data"
     / "hpc_username"
@@ -91,7 +91,7 @@ The home path often has signficant storage restrictions, so is not a good locati
 But may be where you store the python lens modeling scripts you run on the HPC, the config files, batch scripts
 and other files you use to set up lens modeling on the hpc.
 """
-home_path = Path(path.sep, "hpc", "home", "hpc_username")
+home_path = Path("/", "hpc", "home", "hpc_username")
 
 """
 On the HPC, most likely in your home directory, you should have a config folder which contains the config files used by 
@@ -288,7 +288,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_Path().exists():
+if not dataset_path.exists():
     import subprocess
     import sys
 


### PR DESCRIPTION
## Summary
Mirror of PyAutoLabs/autogalaxy_workspace's Cluster H fix. The autolens HPC tutorial `scripts/guides/hpc/example_cpu.py` carries the exact same two classes of leftover typos from #128 (the `os.path` → `pathlib` refactor):

1. **`Path(path.sep…)`** at lines 58, 76, 94 — `path` was the old `os.path` import, removed by #128. Replaced with `Path("/" …)`; `pathlib` normalises `/` correctly on both POSIX and Windows, and the HPC scripts target SLURM-style absolute paths like `/hpc/data/...`.
2. **`dataset_Path()`** at line 291 — the case-insensitive substitution corrupted the variable name `dataset_path` (a `Path` instance) into `dataset_Path` and re-styled it as a callable. Replaced with `dataset_path`.

The bug did not appear in the latest workspace test run because this script is listed in `config/build/no_run.yaml` ("HPC paths dont exist locally."), which pre-dates the typo. Verified post-fix that the script no longer raises `NameError` and instead reaches the expected pre-existing `ConfigException: /hpc/home/hpc_username/hpc/config does not exist` at line 110 — i.e. exactly the failure mode `no_run.yaml` documents. The skip entry is therefore left as-is.

## Scripts Changed
- `scripts/guides/hpc/example_cpu.py` — three `Path(path.sep …)` → `Path("/" …)` at lines 58, 76, 94; one `dataset_Path()` → `dataset_path` at line 291.

## Test Plan
- [x] `PYAUTO_TEST_MODE=1 python scripts/guides/hpc/example_cpu.py` no longer raises `NameError`; reaches the documented `ConfigException` for missing HPC paths (line 110), the very reason it remains skipped in `no_run.yaml`.
- [x] `grep -n "path\.sep\|dataset_Path" scripts/guides/hpc/` returns no matches in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)