### PR TITLE
docs: render __Contents__ blocks as Markdown lists

### DIFF
--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -12,30 +12,30 @@ pixel level).
 
 __Contents__
 
-**Scaling Relations:** This example models the mass of the cluster galaxies by putting them on a scaling relation which.
-**Example:** This script fits a `PointDataset` dataset of a 'cluster-scale' strong lens where.
-**Simulation:** Overview of how the simulated dataset was generated.
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**Dataset:** Load and plot the strong lens dataset.
-**Centres:** The centre of every extra lens galaxy is used to compose the lens model, fixing their mass.
-**Luminosities:** We also need the luminosity of each galaxy, which in this example is the measured property we.
-**Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
-**Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
-**Main Galaxies and Extra Galaxies:** For a cluster-scale lens, we designate there to be the following lensing objects in the system.
-**Redshifts:** In this example all galaxies are at the same redshift in the image-plane, meaning multi-plane.
-**Model:** Compose the lens model fitted to the data.
-**Name Pairing:** Every point-source dataset in the `PointDataset` has a name, (e.g.
-**Search:** Configure the non-linear search used to fit the model.
-**Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-**Iterations Per Update:** Every N iterations, the non-linear search outputs the maximum likelihood model and its best fit.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs each analysis it with the model.
-**Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Overview of the results of the model-fit.
-**HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
+- **Scaling Relations:** This example models the mass of the cluster galaxies by putting them on a scaling relation which.
+- **Example:** This script fits a `PointDataset` dataset of a 'cluster-scale' strong lens where.
+- **Simulation:** Overview of how the simulated dataset was generated.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Centres:** The centre of every extra lens galaxy is used to compose the lens model, fixing their mass.
+- **Luminosities:** We also need the luminosity of each galaxy, which in this example is the measured property we.
+- **Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
+- **Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
+- **Main Galaxies and Extra Galaxies:** For a cluster-scale lens, we designate there to be the following lensing objects in the system.
+- **Redshifts:** In this example all galaxies are at the same redshift in the image-plane, meaning multi-plane.
+- **Model:** Compose the lens model fitted to the data.
+- **Name Pairing:** Every point-source dataset in the `PointDataset` has a name, (e.g.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
+- **Iterations Per Update:** Every N iterations, the non-linear search outputs the maximum likelihood model and its best fit.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs each analysis it with the model.
+- **Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Overview of the results of the model-fit.
+- **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
 
 __Scaling Relations__
 

--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -20,25 +20,25 @@ image. This script simulates that point-source data alongside CCD imaging — th
 
 __Contents__
 
-**Multi-Plane Setup:** Why the two sources sit at different redshifts and what that buys the example.
-**Main Lens Galaxies vs Host Halo vs Source Galaxies:** Galaxies are organized into three categories.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a name.
-**Imaging and Visualization Grids:** Define the high-res rendering grid and a coarse viz grid.
-**Galaxy Centres:** Define the centres of the main lens galaxies and sources; used for over-sampling and JSON output.
-**Over Sampling:** Adaptive over-sampling grid for accurate light profile evaluation near galaxy centres.
-**Main Lens Galaxies:** The 2 cluster member galaxies — each has a `SersicSph` light profile and a `dPIEMassSph` mass.
-**Host Dark Matter Halo:** A standalone `NFWMCRLudlowSph` halo with `mass_at_200 = 10^15.3` at z=0.5.
-**Source Galaxies:** The 2 multi-plane background sources, each a `SersicCore` light + a `Point` model.
-**Ray Tracing:** Combine all galaxies into a single `Tracer` capable of multi-plane ray tracing.
-**JAX JIT:** Register the tracer's underlying classes as JAX pytrees and compile the point solver.
-**Point Solver:** Solve for image-plane multiple-image positions of each source.
-**Point Datasets:** Collect per-source image positions (with noise) into `PointDataset` objects, one per source.
-**Combined CSV:** Write *all* datasets to a single CSV so a user can hand-edit positions and noise in a spreadsheet.
-**Manual CSV Editing:** Instructions for editing the combined CSV by hand, which is the preferred cluster workflow.
-**Tracer JSON:** Save the true `Tracer` for future inspection.
-**Centre JSON Files:** Save the main lens and source centres as JSON.
-**Imaging:** Simulate CCD imaging of the cluster (used to measure positions in real datasets and for visualization).
-**Visualize:** Plot the point-source dataset, tracer, and imaging.
+- **Multi-Plane Setup:** Why the two sources sit at different redshifts and what that buys the example.
+- **Main Lens Galaxies vs Host Halo vs Source Galaxies:** Galaxies are organized into three categories.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a name.
+- **Imaging and Visualization Grids:** Define the high-res rendering grid and a coarse viz grid.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and sources; used for over-sampling and JSON output.
+- **Over Sampling:** Adaptive over-sampling grid for accurate light profile evaluation near galaxy centres.
+- **Main Lens Galaxies:** The 2 cluster member galaxies — each has a `SersicSph` light profile and a `dPIEMassSph` mass.
+- **Host Dark Matter Halo:** A standalone `NFWMCRLudlowSph` halo with `mass_at_200 = 10^15.3` at z=0.5.
+- **Source Galaxies:** The 2 multi-plane background sources, each a `SersicCore` light + a `Point` model.
+- **Ray Tracing:** Combine all galaxies into a single `Tracer` capable of multi-plane ray tracing.
+- **JAX JIT:** Register the tracer's underlying classes as JAX pytrees and compile the point solver.
+- **Point Solver:** Solve for image-plane multiple-image positions of each source.
+- **Point Datasets:** Collect per-source image positions (with noise) into `PointDataset` objects, one per source.
+- **Combined CSV:** Write *all* datasets to a single CSV so a user can hand-edit positions and noise in a spreadsheet.
+- **Manual CSV Editing:** Instructions for editing the combined CSV by hand, which is the preferred cluster workflow.
+- **Tracer JSON:** Save the true `Tracer` for future inspection.
+- **Centre JSON Files:** Save the main lens and source centres as JSON.
+- **Imaging:** Simulate CCD imaging of the cluster (used to measure positions in real datasets and for visualization).
+- **Visualize:** Plot the point-source dataset, tracer, and imaging.
 
 __Multi-Plane Setup__
 

--- a/scripts/cluster/start_here.py
+++ b/scripts/cluster/start_here.py
@@ -18,22 +18,22 @@ most th lensing, lensing a single source, you should instead checlout the `start
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Beta Feature:** Modeling strong lens clusters with PyAutoLens is a feature in beta testing, and there are many.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Main Galaxies and Extra Galaxies:** For a group-scale lens, we designate there to be two types of lens galaxies in the system.
-**Centres:** For group-scale lenses we must manually specify the centres of the extra galaxies, which are fixed.
-**Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
-**Model:** Compose the lens model fitted to the data.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Result:** Overview of the results of the model-fit.
-**Centre Input GUI:** __Model Your Own Lens__.
-**Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
-**Simulator:** In the galaxy-scale examples (`start_here_imaging.ipynb`, `start_here_interferometer.ipynb`.
-**Scaling Relations:** This example models the mass of each galaxy individually, which means the number of dimensions of.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Beta Feature:** Modeling strong lens clusters with PyAutoLens is a feature in beta testing, and there are many.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Main Galaxies and Extra Galaxies:** For a group-scale lens, we designate there to be two types of lens galaxies in the system.
+- **Centres:** For group-scale lenses we must manually specify the centres of the extra galaxies, which are fixed.
+- **Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
+- **Model:** Compose the lens model fitted to the data.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Result:** Overview of the results of the model-fit.
+- **Centre Input GUI:** __Model Your Own Lens__.
+- **Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
+- **Simulator:** In the galaxy-scale examples (`start_here_imaging.ipynb`, `start_here_interferometer.ipynb`.
+- **Scaling Relations:** This example models the mass of each galaxy individually, which means the number of dimensions of.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/group/data_preparation/start_here.py
+++ b/scripts/group/data_preparation/start_here.py
@@ -13,11 +13,11 @@ galaxy centres.
 
 __Contents__
 
-**Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
-**Image:** The image is the image of your group-scale strong lens, which comes from a telescope like the.
-**Noise Map:** The noise-map defines the uncertainty in every pixel of your strong lens image, where values are.
-**PSF:** The Point Spread Function (PSF) describes blurring due the optics of your dataset`s telescope.
-**Data Processing Complete:** If your image, noise-map and PSF conform the standards above, you are ready to analyse your dataset!
+- **Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
+- **Image:** The image is the image of your group-scale strong lens, which comes from a telescope like the.
+- **Noise Map:** The noise-map defines the uncertainty in every pixel of your strong lens image, where values are.
+- **PSF:** The Point Spread Function (PSF) describes blurring due the optics of your dataset`s telescope.
+- **Data Processing Complete:** If your image, noise-map and PSF conform the standards above, you are ready to analyse your dataset!
 
 __Pixel Scale__
 

--- a/scripts/group/features/advanced/operated_light_profile/modeling.py
+++ b/scripts/group/features/advanced/operated_light_profile/modeling.py
@@ -15,13 +15,13 @@ galaxy may have a compact nuclear component that is best represented as an opera
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Result:** Overview of the results of the model-fit.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Result:** Overview of the results of the model-fit.
 
 __Model__
 

--- a/scripts/group/features/advanced/operated_light_profile/simulator.py
+++ b/scripts/group/features/advanced/operated_light_profile/simulator.py
@@ -11,16 +11,16 @@ was performed using PSF-convolved models and the residual light retains that con
 
 __Contents__
 
-**Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
-**Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Main Lens Galaxies:** The main lens galaxy with an operated ``Sersic`` light profile.
-**Extra Galaxies:** The extra galaxies with operated ``Sersic`` light profiles.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to set up a tracer.
-**Dataset:** Simulate and output the dataset.
-**Centre JSON Files:** Save the centres as JSON files.
+- **Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
+- **Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Main Lens Galaxies:** The main lens galaxy with an operated ``Sersic`` light profile.
+- **Extra Galaxies:** The extra galaxies with operated ``Sersic`` light profiles.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to set up a tracer.
+- **Dataset:** Simulate and output the dataset.
+- **Centre JSON Files:** Save the centres as JSON files.
 
 __Model__
 

--- a/scripts/group/features/advanced/shapelets/fit.py
+++ b/scripts/group/features/advanced/shapelets/fit.py
@@ -12,12 +12,12 @@ from the simulation.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** Load galaxy centres from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Basis:** Build a ``Basis`` of multiple linear shapelet light profiles.
-**Fit:** Fit the lens model to the dataset using the shapelet basis.
-**Intensities:** Extract the solved-for intensity values from the fit.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** Load galaxy centres from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Basis:** Build a ``Basis`` of multiple linear shapelet light profiles.
+- **Fit:** Fit the lens model to the dataset using the shapelet basis.
+- **Intensities:** Extract the solved-for intensity values from the fit.
 
 __Model__
 

--- a/scripts/group/features/advanced/shapelets/modeling.py
+++ b/scripts/group/features/advanced/shapelets/modeling.py
@@ -19,13 +19,13 @@ flexibility of shapelets to capture complex morphology.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Result:** Overview of the results of the model-fit.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Result:** Overview of the results of the model-fit.
 
 __Model__
 

--- a/scripts/group/features/advanced/sky_background/fit.py
+++ b/scripts/group/features/advanced/sky_background/fit.py
@@ -11,10 +11,10 @@ This illustrates the ``DatasetModel`` API for sky background subtraction using s
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** Load galaxy centres from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fit:** Demonstrate fitting with a ``DatasetModel`` that includes sky background.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** Load galaxy centres from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fit:** Demonstrate fitting with a ``DatasetModel`` that includes sky background.
 
 __Model__
 

--- a/scripts/group/features/advanced/sky_background/modeling.py
+++ b/scripts/group/features/advanced/sky_background/modeling.py
@@ -17,13 +17,13 @@ dataset as a non-linear free parameter.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Result:** Overview of the results of the model-fit.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Result:** Overview of the results of the model-fit.
 
 __Model__
 

--- a/scripts/group/features/advanced/sky_background/simulator.py
+++ b/scripts/group/features/advanced/sky_background/simulator.py
@@ -10,16 +10,16 @@ This is used to demonstrate sky background modeling in the
 
 __Contents__
 
-**Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
-**Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up the adaptive over-sampling grid.
-**Main Lens Galaxies:** The main lens galaxy at the origin.
-**Extra Galaxies:** Two companion galaxies near the lens system.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to set up a tracer.
-**Dataset:** Simulate and output the dataset.
-**Centre JSON Files:** Save the centres as JSON files.
+- **Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
+- **Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up the adaptive over-sampling grid.
+- **Main Lens Galaxies:** The main lens galaxy at the origin.
+- **Extra Galaxies:** Two companion galaxies near the lens system.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to set up a tracer.
+- **Dataset:** Simulate and output the dataset.
+- **Centre JSON Files:** Save the centres as JSON files.
 
 __Model__
 

--- a/scripts/group/features/advanced/subhalo/detect/start_here.py
+++ b/scripts/group/features/advanced/subhalo/detect/start_here.py
@@ -12,15 +12,15 @@ the dark matter subhalo.
 
 __Contents__
 
-**SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines.
-**Grid Search:** The second stage uses a grid-search of non-linear searches.
-**Group Adaptation:** The lens model includes all group galaxies.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** Load galaxy centres from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid.
-**SLaM Pipeline Functions:** The pipeline functions adapted for group-scale lenses.
-**Bayesian Evidence:** Determine if a DM subhalo was detected.
-**Grid Search Result:** Inspect the grid search results.
+- **SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines.
+- **Grid Search:** The second stage uses a grid-search of non-linear searches.
+- **Group Adaptation:** The lens model includes all group galaxies.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** Load galaxy centres from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid.
+- **SLaM Pipeline Functions:** The pipeline functions adapted for group-scale lenses.
+- **Bayesian Evidence:** Determine if a DM subhalo was detected.
+- **Grid Search Result:** Inspect the grid search results.
 
 __SLaM Pipelines__
 

--- a/scripts/group/features/advanced/subhalo/simulator.py
+++ b/scripts/group/features/advanced/subhalo/simulator.py
@@ -10,17 +10,17 @@ careful lens modeling.
 
 __Contents__
 
-**Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
-**Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up the adaptive over-sampling grid.
-**Main Lens Galaxies:** The main lens galaxy, which includes a dark matter subhalo.
-**Extra Galaxies:** Two companion galaxies near the lens system.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to set up a tracer.
-**Dataset:** Simulate and output the dataset.
-**Centre JSON Files:** Save the centres as JSON files.
-**Subhalo Difference Image:** Visualize the effect of the subhalo.
+- **Dataset Paths:** The ``dataset_type`` describes the type of data being simulated.
+- **Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up the adaptive over-sampling grid.
+- **Main Lens Galaxies:** The main lens galaxy, which includes a dark matter subhalo.
+- **Extra Galaxies:** Two companion galaxies near the lens system.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to set up a tracer.
+- **Dataset:** Simulate and output the dataset.
+- **Centre JSON Files:** Save the centres as JSON files.
+- **Subhalo Difference Image:** Visualize the effect of the subhalo.
 
 __Model__
 

--- a/scripts/group/features/linear_light_profiles/fit.py
+++ b/scripts/group/features/linear_light_profiles/fit.py
@@ -16,12 +16,12 @@ object is created.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Galaxy Centres:** Load the centres of the main lens galaxies and extra galaxies from JSON.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fitting:** Fit the lens model to the dataset using linear light profiles.
-**Intensities:** Extract the solved-for intensity values.
-**Visualization:** Convert linear light profiles to ordinary profiles for visualization.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Galaxy Centres:** Load the centres of the main lens galaxies and extra galaxies from JSON.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fitting:** Fit the lens model to the dataset using linear light profiles.
+- **Intensities:** Extract the solved-for intensity values.
+- **Visualization:** Convert linear light profiles to ordinary profiles for visualization.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/group/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/group/features/linear_light_profiles/likelihood_function.py
@@ -19,14 +19,14 @@ This script has the following aims:
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Linear Light Profiles:** Define the lens, extra galaxies and source using ``lp_linear`` profiles.
-**Lens Galaxy Mass:** Compute deflection angles from all mass profiles.
-**Ray Tracing:** Trace image-plane coordinates to the source plane.
-**Linear Inversion:** Explain how intensities are solved via the linear algebra system.
-**Fit:** Use the ``FitImaging`` object which handles all steps automatically.
-**Likelihood Function:** Compute the log likelihood step by step.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Linear Light Profiles:** Define the lens, extra galaxies and source using ``lp_linear`` profiles.
+- **Lens Galaxy Mass:** Compute deflection angles from all mass profiles.
+- **Ray Tracing:** Trace image-plane coordinates to the source plane.
+- **Linear Inversion:** Explain how intensities are solved via the linear algebra system.
+- **Fit:** Use the ``FitImaging`` object which handles all steps automatically.
+- **Likelihood Function:** Compute the log likelihood step by step.
 
 __Prerequisites__
 

--- a/scripts/group/features/linear_light_profiles/modeling.py
+++ b/scripts/group/features/linear_light_profiles/modeling.py
@@ -13,15 +13,15 @@ and improving sampling efficiency.
 
 __Contents__
 
-**Advantages:** Linear light profiles remove `intensity` from the non-linear parameter space.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Result:** Overview of the results of the model-fit.
-**Intensities:** How to extract the solved-for intensity values from the result.
+- **Advantages:** Linear light profiles remove `intensity` from the non-linear parameter space.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** The centres of the main lens galaxies and extra galaxies are loaded from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Result:** Overview of the results of the model-fit.
+- **Intensities:** How to extract the solved-for intensity values from the result.
 
 __Advantages__
 

--- a/scripts/group/features/linear_light_profiles/slam.py
+++ b/scripts/group/features/linear_light_profiles/slam.py
@@ -18,18 +18,18 @@ composition with fewer basis functions, while still benefiting from the intensit
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**SOURCE LP PIPELINE 0:** Light-only fit using linear Sersic profiles for all galaxies.
-**SOURCE LP PIPELINE 1:** Introduces mass and source with light fixed from stage 0.
-**SOURCE PIX PIPELINE 1:** Pixelized source fitting (identical to group/slam.py).
-**SOURCE PIX PIPELINE 2:** Refined pixelized source (identical to group/slam.py).
-**LIGHT LP PIPELINE:** Refits light using linear Sersic profiles.
-**MASS TOTAL PIPELINE:** Final mass fit with PowerLaw (identical to group/slam.py).
-**Dataset:** Load and plot the strong lens dataset.
-**Galaxy Centres:** Load centres from JSON files.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Settings AutoFit:** The settings of autofit.
-**SLaM Pipeline:** Run the full pipeline.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **SOURCE LP PIPELINE 0:** Light-only fit using linear Sersic profiles for all galaxies.
+- **SOURCE LP PIPELINE 1:** Introduces mass and source with light fixed from stage 0.
+- **SOURCE PIX PIPELINE 1:** Pixelized source fitting (identical to group/slam.py).
+- **SOURCE PIX PIPELINE 2:** Refined pixelized source (identical to group/slam.py).
+- **LIGHT LP PIPELINE:** Refits light using linear Sersic profiles.
+- **MASS TOTAL PIPELINE:** Final mass fit with PowerLaw (identical to group/slam.py).
+- **Dataset:** Load and plot the strong lens dataset.
+- **Galaxy Centres:** Load centres from JSON files.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Settings AutoFit:** The settings of autofit.
+- **SLaM Pipeline:** Run the full pipeline.
 
 __Prerequisites__
 

--- a/scripts/group/features/multi_gaussian_expansion/fit.py
+++ b/scripts/group/features/multi_gaussian_expansion/fit.py
@@ -16,15 +16,15 @@ where the intensities are determined automatically via linear algebra.
 
 __Contents__
 
-**Loading Data:** Load the group-scale strong lens dataset.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Galaxy Centres:** Load centres of main lens galaxies and extra galaxies from JSON files.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fitting:** Fit the lens model to the dataset and inspect the results.
-**Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
-**Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
-**Figures of Merit:** There are single valued floats which quantify the goodness of fit.
-**MGE In Practice:** How MGE would be used in a real fit via modeling.
+- **Loading Data:** Load the group-scale strong lens dataset.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Galaxy Centres:** Load centres of main lens galaxies and extra galaxies from JSON files.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fitting:** Fit the lens model to the dataset and inspect the results.
+- **Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
+- **Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
+- **Figures of Merit:** There are single valued floats which quantify the goodness of fit.
+- **MGE In Practice:** How MGE would be used in a real fit via modeling.
 
 """
 

--- a/scripts/group/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/group/features/multi_gaussian_expansion/likelihood_function.py
@@ -14,19 +14,19 @@ concrete MGE instances requires many parameters), but explains how the MGE likel
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Disable over sampling for simplicity.
-**Main Lens Galaxy:** The main lens galaxy at the centre of the group.
-**Extra Galaxies:** The two extra galaxies are companion galaxies near the main lens.
-**Source Galaxy:** The source galaxy light profile.
-**Lens Light:** Compute a 2D image of each lens galaxy's light and sum them together.
-**Lens Galaxy Mass:** Compute deflection angles from all mass profiles.
-**Ray Tracing:** Ray-trace the image-plane grid to the source plane.
-**Source Image:** Evaluate the source galaxy light on the traced grid.
-**Convolution:** Convolve the total image with the PSF.
-**Likelihood Function:** Compute the log likelihood.
-**MGE Likelihood:** How the likelihood changes when using MGE light profiles.
-**Fit:** Verify using the FitImaging object.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Disable over sampling for simplicity.
+- **Main Lens Galaxy:** The main lens galaxy at the centre of the group.
+- **Extra Galaxies:** The two extra galaxies are companion galaxies near the main lens.
+- **Source Galaxy:** The source galaxy light profile.
+- **Lens Light:** Compute a 2D image of each lens galaxy's light and sum them together.
+- **Lens Galaxy Mass:** Compute deflection angles from all mass profiles.
+- **Ray Tracing:** Ray-trace the image-plane grid to the source plane.
+- **Source Image:** Evaluate the source galaxy light on the traced grid.
+- **Convolution:** Convolve the total image with the PSF.
+- **Likelihood Function:** Compute the log likelihood.
+- **MGE Likelihood:** How the likelihood changes when using MGE light profiles.
+- **Fit:** Verify using the FitImaging object.
 
 """
 

--- a/scripts/group/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/group/features/multi_gaussian_expansion/modeling.py
@@ -13,14 +13,14 @@ with appropriate sigma ranges and linked parameters.
 
 __Contents__
 
-**MGE Advantages for Group Lenses:** The MGE is especially important for group-scale lenses because adding an extra.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
+- **MGE Advantages for Group Lenses:** The MGE is especially important for group-scale lenses because adding an extra.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
 
 __MGE Advantages for Group Lenses__
 

--- a/scripts/group/features/multi_gaussian_expansion/simulator.py
+++ b/scripts/group/features/multi_gaussian_expansion/simulator.py
@@ -15,15 +15,15 @@ will not re-simulate it.
 
 __Contents__
 
-**Dataset Paths:** Output path for the simulated dataset.
-**Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up the adaptive over-sampling grid.
-**Main Lens Galaxies:** The main lens galaxy at the origin.
-**Extra Galaxies:** The two extra companion galaxies.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to setup a tracer and simulate.
-**Output:** Output the simulated dataset and metadata.
+- **Dataset Paths:** Output path for the simulated dataset.
+- **Grid:** Define the 2d grid of (y,x) coordinates for the simulation.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up the adaptive over-sampling grid.
+- **Main Lens Galaxies:** The main lens galaxy at the origin.
+- **Extra Galaxies:** The two extra companion galaxies.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to setup a tracer and simulate.
+- **Output:** Output the simulated dataset and metadata.
 
 """
 

--- a/scripts/group/features/multi_gaussian_expansion/slam.py
+++ b/scripts/group/features/multi_gaussian_expansion/slam.py
@@ -14,14 +14,14 @@ guide before working through this example.
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**This Script:** Using a SOURCE LP PIPELINE, LIGHT LP PIPELINE and MASS TOTAL PIPELINE.
-**SOURCE LP PIPELINE:** Fits lens light and source light using MGE, with Isothermal mass and ExternalShear.
-**LIGHT LP PIPELINE:** Refits lens light with a fresh MGE, mass and source fixed from SOURCE LP.
-**MASS TOTAL PIPELINE:** Refits the mass using a PowerLaw, light and source fixed from previous stages.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **This Script:** Using a SOURCE LP PIPELINE, LIGHT LP PIPELINE and MASS TOTAL PIPELINE.
+- **SOURCE LP PIPELINE:** Fits lens light and source light using MGE, with Isothermal mass and ExternalShear.
+- **LIGHT LP PIPELINE:** Refits lens light with a fresh MGE, mass and source fixed from SOURCE LP.
+- **MASS TOTAL PIPELINE:** Refits the mass using a PowerLaw, light and source fixed from previous stages.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/group/features/multi_gaussian_expansion/source_science.py
+++ b/scripts/group/features/multi_gaussian_expansion/source_science.py
@@ -18,14 +18,14 @@ differences from the standard group source science example are:
 
 __Contents__
 
-**Simulated Dataset:** Load the group dataset.
-**Mask:** Define the 2D mask.
-**Source Values:** Set up the lens and source galaxies.
-**MGE Source:** Create an MGE source and fit it to the data to obtain intensities.
-**Source Flux:** Compute the total source flux.
-**Source Magnification:** Compute the source magnification using all group galaxies.
-**Impact of Extra Galaxies:** Show that omitting extra galaxies gives incorrect magnification.
-**Tracer:** Using the tracer from lens modeling results.
+- **Simulated Dataset:** Load the group dataset.
+- **Mask:** Define the 2D mask.
+- **Source Values:** Set up the lens and source galaxies.
+- **MGE Source:** Create an MGE source and fit it to the data to obtain intensities.
+- **Source Flux:** Compute the total source flux.
+- **Source Magnification:** Compute the source magnification using all group galaxies.
+- **Impact of Extra Galaxies:** Show that omitting extra galaxies gives incorrect magnification.
+- **Tracer:** Using the tracer from lens modeling results.
 
 """
 

--- a/scripts/group/features/no_lens_light/modeling.py
+++ b/scripts/group/features/no_lens_light/modeling.py
@@ -14,14 +14,14 @@ removes all light-related non-linear parameters from the lens side of the model.
 
 __Contents__
 
-**Advantages:** The main advantage of fitting group data without lens light is the dramatic reduction in model.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Centres:** The centres of both the main lens galaxies and the extra galaxies are loaded from JSON files.
-**Model:** Compose the lens model fitted to the data — all galaxies have mass only.
-**Over Sampling:** Not needed for lens light when there is none.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Result:** Overview of the results of the model-fit.
+- **Advantages:** The main advantage of fitting group data without lens light is the dramatic reduction in model.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Centres:** The centres of both the main lens galaxies and the extra galaxies are loaded from JSON files.
+- **Model:** Compose the lens model fitted to the data — all galaxies have mass only.
+- **Over Sampling:** Not needed for lens light when there is none.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Result:** Overview of the results of the model-fit.
 
 __Advantages__
 

--- a/scripts/group/features/no_lens_light/simulator.py
+++ b/scripts/group/features/no_lens_light/simulator.py
@@ -16,19 +16,19 @@ This script simulates `Imaging` of a 'group-scale' strong lens where:
 
 __Contents__
 
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up over-sampling at the source centre for accurate light profile evaluation.
-**Main Lens Galaxies:** The main lens galaxy at the origin, mass only, no light.
-**Extra Galaxies:** The two extra galaxies, mass only, no light.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to setup a tracer, which will generate the image for the simulated `Imaging`.
-**Dataset:** Load and plot the strong lens dataset.
-**Visualize:** Output a subplot of the simulated dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file.
-**Centre JSON Files:** Save the centres of the main lens galaxies and extra galaxies as JSON files.
-**Positions:** Solve for the lensed positions of the source galaxy.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up over-sampling at the source centre for accurate light profile evaluation.
+- **Main Lens Galaxies:** The main lens galaxy at the origin, mass only, no light.
+- **Extra Galaxies:** The two extra galaxies, mass only, no light.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to setup a tracer, which will generate the image for the simulated `Imaging`.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Visualize:** Output a subplot of the simulated dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file.
+- **Centre JSON Files:** Save the centres of the main lens galaxies and extra galaxies as JSON files.
+- **Positions:** Solve for the lensed positions of the source galaxy.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/group/features/no_lens_light/slam.py
+++ b/scripts/group/features/no_lens_light/slam.py
@@ -15,17 +15,17 @@ simplified compared to the standard group SLaM (`group/slam.py`) because:
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**This Script:** Using a SOURCE LP PIPELINE (one search), SOURCE PIX PIPELINE (two searches), and.
-**SOURCE LP PIPELINE:** Fits mass + source directly. No lens light for any galaxy.
-**SOURCE PIX PIPELINE 1:** Pixelized source, mass carried forward. No lens light.
-**SOURCE PIX PIPELINE 2:** Refined pixelized source. No lens light.
-**MASS TOTAL PIPELINE:** Final mass fit with PowerLaw. No lens light.
-**Dataset:** Load and plot the strong lens dataset.
-**Galaxy Centres:** Load centres from JSON files.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **This Script:** Using a SOURCE LP PIPELINE (one search), SOURCE PIX PIPELINE (two searches), and.
+- **SOURCE LP PIPELINE:** Fits mass + source directly. No lens light for any galaxy.
+- **SOURCE PIX PIPELINE 1:** Pixelized source, mass carried forward. No lens light.
+- **SOURCE PIX PIPELINE 2:** Refined pixelized source. No lens light.
+- **MASS TOTAL PIPELINE:** Final mass fit with PowerLaw. No lens light.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Galaxy Centres:** Load centres from JSON files.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Prerequisites__
 

--- a/scripts/group/features/pixelization/adaptive.py
+++ b/scripts/group/features/pixelization/adaptive.py
@@ -17,12 +17,12 @@ morphology, then subsequent searches use adaptive pixelization features.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Search 1:** Fit a parametric model to establish the lens model and source morphology.
-**Search 2:** Introduce a pixelization with constant regularization.
-**Search 3:** Use adaptive mesh and regularization driven by adapt_data from search 2.
-**Adapt Images:** How adapt_data is constructed from the lens-subtracted source image.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Search 1:** Fit a parametric model to establish the lens model and source morphology.
+- **Search 2:** Introduce a pixelization with constant regularization.
+- **Search 3:** Use adaptive mesh and regularization driven by adapt_data from search 2.
+- **Adapt Images:** How adapt_data is constructed from the lens-subtracted source image.
 
 __Adaptive Features__
 

--- a/scripts/group/features/pixelization/cpu_fast_modeling.py
+++ b/scripts/group/features/pixelization/cpu_fast_modeling.py
@@ -23,11 +23,11 @@ is not currently optimized in JAX.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Sparse Operators:** Pre-compute sparse matrices for CPU-accelerated pixelization.
-**Fit:** Fit the group lens with a pixelized source on CPU.
-**Model:** Full model-fit with CPU parallelization.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Sparse Operators:** Pre-compute sparse matrices for CPU-accelerated pixelization.
+- **Fit:** Fit the group lens with a pixelized source on CPU.
+- **Model:** Full model-fit with CPU parallelization.
 
 """
 

--- a/scripts/group/features/pixelization/delaunay.py
+++ b/scripts/group/features/pixelization/delaunay.py
@@ -24,11 +24,11 @@ triangles naturally adapt to follow the source morphology in this environment.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Fit:** Create a FitImaging with a Delaunay pixelized source for a group lens.
-**Model:** Compose a group lens model with a Delaunay pixelized source for modeling.
-**Advantages for Group Lenses:** Why Delaunay meshes are well-suited for group-scale lensing.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Fit:** Create a FitImaging with a Delaunay pixelized source for a group lens.
+- **Model:** Compose a group lens model with a Delaunay pixelized source for modeling.
+- **Advantages for Group Lenses:** Why Delaunay meshes are well-suited for group-scale lensing.
 
 """
 

--- a/scripts/group/features/pixelization/fit.py
+++ b/scripts/group/features/pixelization/fit.py
@@ -14,11 +14,11 @@ full model-fit.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies from JSON files.
-**Fitting:** Create a FitImaging with a pixelized source for a group lens.
-**Inversion:** Inspect the pixelized source reconstruction via the inversion object.
-**Over Sampling:** Adaptive over-sampling at all galaxy centres.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies from JSON files.
+- **Fitting:** Create a FitImaging with a pixelized source for a group lens.
+- **Inversion:** Inspect the pixelized source reconstruction via the inversion object.
+- **Over Sampling:** Adaptive over-sampling at all galaxy centres.
 
 """
 

--- a/scripts/group/features/pixelization/likelihood_function.py
+++ b/scripts/group/features/pixelization/likelihood_function.py
@@ -15,16 +15,16 @@ This script has the following aims:
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Lens Galaxies:** Define the main lens and extra galaxies with light and mass profiles.
-**Source Galaxy Pixelization:** The source uses a Delaunay mesh with constant regularization.
-**Lens Light:** Compute the total lens light from all galaxies.
-**Deflection Angles:** Compute deflection angles from all mass profiles.
-**Ray Tracing:** Ray-trace image pixels to the source plane using combined deflections.
-**Pixelized Source Reconstruction:** The linear algebra inversion step.
-**Likelihood Function:** Compute the log likelihood including regularization evidence terms.
-**Fit:** Confirm the step-by-step calculation matches the FitImaging object.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Lens Galaxies:** Define the main lens and extra galaxies with light and mass profiles.
+- **Source Galaxy Pixelization:** The source uses a Delaunay mesh with constant regularization.
+- **Lens Light:** Compute the total lens light from all galaxies.
+- **Deflection Angles:** Compute deflection angles from all mass profiles.
+- **Ray Tracing:** Ray-trace image pixels to the source plane using combined deflections.
+- **Pixelized Source Reconstruction:** The linear algebra inversion step.
+- **Likelihood Function:** Compute the log likelihood including regularization evidence terms.
+- **Fit:** Confirm the step-by-step calculation matches the FitImaging object.
 
 __Prerequisites__
 

--- a/scripts/group/features/pixelization/modeling.py
+++ b/scripts/group/features/pixelization/modeling.py
@@ -17,13 +17,13 @@ prior search and is wired up later by the SLaM pipeline — see `scripts/group/s
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies from JSON files.
-**Model:** Compose the group lens model with a pixelized source.
-**Over Sampling:** Adaptive over-sampling at all galaxy centres.
-**Search:** Configure the non-linear search.
-**Analysis:** Create the Analysis object with pixelization settings.
-**Result:** Overview of the results of the model-fit.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies from JSON files.
+- **Model:** Compose the group lens model with a pixelized source.
+- **Over Sampling:** Adaptive over-sampling at all galaxy centres.
+- **Search:** Configure the non-linear search.
+- **Analysis:** Create the Analysis object with pixelization settings.
+- **Result:** Overview of the results of the model-fit.
 
 __Example__
 

--- a/scripts/group/features/pixelization/slam.py
+++ b/scripts/group/features/pixelization/slam.py
@@ -34,12 +34,12 @@ The SLaM pipeline makes the following pixelization-specific decisions:
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with group/slam.py and the
-pixelization feature scripts.
-**Dataset:** Load and plot the strong lens dataset.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Mask:** Define the 2D mask applied to the dataset.
-**SLaM Pipeline:** The full SLaM pipeline with pixelization-specific documentation.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with group/slam.py and the
+  pixelization feature scripts.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Mask:** Define the 2D mask applied to the dataset.
+- **SLaM Pipeline:** The full SLaM pipeline with pixelization-specific documentation.
 
 __Prerequisites__
 

--- a/scripts/group/features/pixelization/source_science.py
+++ b/scripts/group/features/pixelization/source_science.py
@@ -18,14 +18,14 @@ pixelized reconstruction can recover source properties that parametric models ma
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
-**Galaxy Centres:** Load centres for main lens and extra galaxies.
-**Model Fit:** Create a FitImaging with a pixelized source.
-**Source Flux:** Compute the total flux from the pixelized source reconstruction.
-**Source Magnification:** Compute the magnification using all group mass profiles.
-**Impact of Extra Galaxies:** Demonstrate how omitting extra galaxies affects magnification.
-**Interpolated Source:** Interpolate the pixelized source to a uniform grid.
-**Parametric Comparison:** Compare pixelized source flux to a parametric estimate.
+- **Dataset & Mask:** Standard set up of the group dataset and 7.5" mask.
+- **Galaxy Centres:** Load centres for main lens and extra galaxies.
+- **Model Fit:** Create a FitImaging with a pixelized source.
+- **Source Flux:** Compute the total flux from the pixelized source reconstruction.
+- **Source Magnification:** Compute the magnification using all group mass profiles.
+- **Impact of Extra Galaxies:** Demonstrate how omitting extra galaxies affects magnification.
+- **Interpolated Source:** Interpolate the pixelized source to a uniform grid.
+- **Parametric Comparison:** Compare pixelized source flux to a parametric estimate.
 
 """
 

--- a/scripts/group/fit.py
+++ b/scripts/group/fit.py
@@ -20,18 +20,18 @@ This example uses functionality described fully in other examples in the `guides
 
 __Contents__
 
-**Loading Data:** We begin by loading the group-scale strong lens dataset `simple` from .fits files, which is the.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Galaxy Centres:** For group-scale lenses we load the centres of the main lens galaxies and extra galaxies from JSON.
-**Fitting:** Fit the lens model to the dataset and inspect the results.
-**Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
-**Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
-**Figures of Merit:** There are single valued floats which quantify the goodness of fit.
-**Plane Quantities:** The `FitImaging` object has specific quantities which break down each image of each plane.
-**Unmasked Quantities:** All of the quantities above are computed using the mask which was used to fit the data.
-**Pixel Counting:** An alternative way to quantify residuals like the lens light residuals is pixel counting.
-**Outputting Results:** You may wish to output certain results to .fits files for later inspection.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Loading Data:** We begin by loading the group-scale strong lens dataset `simple` from .fits files, which is the.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Galaxy Centres:** For group-scale lenses we load the centres of the main lens galaxies and extra galaxies from JSON.
+- **Fitting:** Fit the lens model to the dataset and inspect the results.
+- **Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
+- **Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
+- **Figures of Merit:** There are single valued floats which quantify the goodness of fit.
+- **Plane Quantities:** The `FitImaging` object has specific quantities which break down each image of each plane.
+- **Unmasked Quantities:** All of the quantities above are computed using the mask which was used to fit the data.
+- **Pixel Counting:** An alternative way to quantify residuals like the lens light residuals is pixel counting.
+- **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
 
 """
 

--- a/scripts/group/likelihood_function.py
+++ b/scripts/group/likelihood_function.py
@@ -20,24 +20,24 @@ for a single lens galaxy. This script extends that to the group scale.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
-**Main Lens Galaxy:** The main lens galaxy is at the centre of the group.
-**Extra Galaxies:** The two extra galaxies are companion galaxies near the main lens.
-**Source Galaxy Light Profile:** The source galaxy is fitted using an analytic light profile, in this example a cored elliptical.
-**Lens Light:** Compute a 2D image of each lens galaxy's light and sum them together.
-**Lens Galaxy Mass:** We next consider the mass profiles of all galaxies in the group.
-**Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\\theta$ from the.
-**Source Image:** We pass the traced grid and blurring grid of coordinates to the source galaxy to evaluate its 2D.
-**Convolution:** Convolve the 2D image of the lens galaxies and source above with the PSF in real-space (as opposed.
-**Likelihood Function:** We now quantify the goodness-of-fit of our group-scale lens model.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the two terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
+- **Main Lens Galaxy:** The main lens galaxy is at the centre of the group.
+- **Extra Galaxies:** The two extra galaxies are companion galaxies near the main lens.
+- **Source Galaxy Light Profile:** The source galaxy is fitted using an analytic light profile, in this example a cored elliptical.
+- **Lens Light:** Compute a 2D image of each lens galaxy's light and sum them together.
+- **Lens Galaxy Mass:** We next consider the mass profiles of all galaxies in the group.
+- **Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\\theta$ from the.
+- **Source Image:** We pass the traced grid and blurring grid of coordinates to the source galaxy to evaluate its 2D.
+- **Convolution:** Convolve the 2D image of the lens galaxies and source above with the PSF in real-space (as opposed.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our group-scale lens model.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the two terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/group/modeling.py
+++ b/scripts/group/modeling.py
@@ -21,31 +21,31 @@ than being hardcoded, so the same script works for different datasets without co
 
 __Contents__
 
-**Scaling Relations:** This example models the mass of each galaxy individually, which means the number of dimensions of.
-**Example:** This script fits an `Imaging` dataset of a 'group-scale' strong lens where.
-**Simulation:** Overview of how the simulated dataset was generated.
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Main Galaxies and Extra Galaxies:** For a group-scale lens, we designate there to be two types of lens galaxies in the system.
-**Centres:** The centres of both the main lens galaxies and the extra galaxies are loaded from JSON files in the.
-**Redshifts:** In this example all line of sight galaxies are at the same redshift as the lens galaxy, meaning.
-**Model:** Compose the lens model fitted to the data.
-**Coordinates:** Coordinate system assumptions for the model-fit.
-**Improved Lens Model:** The previous model used Sersic light profiles for the lens, source and extra galaxies.
-**Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge and disk via the ``lp_linear``.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Search:** Configure the non-linear search used to fit the model.
-**Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-**Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU's available VRAM.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Overview of the results of the model-fit.
-**Features:** The examples in the `autolens_workspace/*/imaging/features` package illustrate other lens modeling.
-**HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
-**Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
+- **Scaling Relations:** This example models the mass of each galaxy individually, which means the number of dimensions of.
+- **Example:** This script fits an `Imaging` dataset of a 'group-scale' strong lens where.
+- **Simulation:** Overview of how the simulated dataset was generated.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Main Galaxies and Extra Galaxies:** For a group-scale lens, we designate there to be two types of lens galaxies in the system.
+- **Centres:** The centres of both the main lens galaxies and the extra galaxies are loaded from JSON files in the.
+- **Redshifts:** In this example all line of sight galaxies are at the same redshift as the lens galaxy, meaning.
+- **Model:** Compose the lens model fitted to the data.
+- **Coordinates:** Coordinate system assumptions for the model-fit.
+- **Improved Lens Model:** The previous model used Sersic light profiles for the lens, source and extra galaxies.
+- **Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge and disk via the ``lp_linear``.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
+- **Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU's available VRAM.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Overview of the results of the model-fit.
+- **Features:** The examples in the `autolens_workspace/*/imaging/features` package illustrate other lens modeling.
+- **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
+- **Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
 
 __Scaling Relations__
 

--- a/scripts/group/simulator.py
+++ b/scripts/group/simulator.py
@@ -14,19 +14,19 @@ This script simulates `Imaging` of a 'group-scale' strong lens where:
 
 __Contents__
 
-**Main Lens Galaxies vs Extra Galaxies:** For group-scale lens modeling, galaxies are organized into two categories.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
-**Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Main Lens Galaxies:** The main lens galaxy is at the origin (0.0, 0.0).
-**Extra Galaxies:** The two extra galaxies are companion galaxies near the lens system.
-**Source Galaxy:** The source galaxy whose lensed images we simulate.
-**Ray Tracing:** Use all galaxies to setup a tracer, which will generate the image for the simulated `Imaging`.
-**Dataset:** Load and plot the strong lens dataset.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Centre JSON Files:** Save the centres of the main lens galaxies and extra galaxies as JSON files.
+- **Main Lens Galaxies vs Extra Galaxies:** For group-scale lens modeling, galaxies are organized into two categories.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
+- **Galaxy Centres:** Define the centres of the main lens galaxies and extra galaxies.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Main Lens Galaxies:** The main lens galaxy is at the origin (0.0, 0.0).
+- **Extra Galaxies:** The two extra galaxies are companion galaxies near the lens system.
+- **Source Galaxy:** The source galaxy whose lensed images we simulate.
+- **Ray Tracing:** Use all galaxies to setup a tracer, which will generate the image for the simulated `Imaging`.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Centre JSON Files:** Save the centres of the main lens galaxies and extra galaxies as JSON files.
 
 __Main Lens Galaxies vs Extra Galaxies__
 

--- a/scripts/group/slam.py
+++ b/scripts/group/slam.py
@@ -7,20 +7,20 @@ scaling galaxies surrounding the main lens whose light and mass are both modeled
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Extra Galaxies and Scaling Galaxies:** This group-scale SLaM pipeline handles two distinct categories of companion galaxy, which differ in.
-**This Script:** Using a SOURCE LP PIPELINE (two searches), SOURCE PIX PIPELINE (two searches), LIGHT LP PIPELINE.
-**SOURCE LP PIPELINE 0:** Not present in `slam_start_here.py`.
-**SOURCE LP PIPELINE 1:** Equivalent to `source_lp` in `slam_start_here.py`, except lens light is fixed from `source_lp[0]`.
-**SOURCE PIX PIPELINE 1:** Equivalent to `source_pix_1` in `slam_start_here.py`, except a Hilbert image mesh is used instead.
-**SOURCE PIX PIPELINE 2:** Identical to `source_pix_1` above, except the adapt data for the Hilbert image mesh is capped at a.
-**LIGHT LP PIPELINE:** Identical to `light_lp` in `slam_start_here.py`, except extra galaxies receive a fresh free MGE.
-**MASS TOTAL PIPELINE:** Identical to `mass_total` in `slam_start_here.py`, except extra galaxies receive a new.
-**Dataset:** Load and plot the strong lens dataset.
-**Galaxy Centres:** main_lens_centres.json — required; determines the number of main lenses.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Extra Galaxies and Scaling Galaxies:** This group-scale SLaM pipeline handles two distinct categories of companion galaxy, which differ in.
+- **This Script:** Using a SOURCE LP PIPELINE (two searches), SOURCE PIX PIPELINE (two searches), LIGHT LP PIPELINE.
+- **SOURCE LP PIPELINE 0:** Not present in `slam_start_here.py`.
+- **SOURCE LP PIPELINE 1:** Equivalent to `source_lp` in `slam_start_here.py`, except lens light is fixed from `source_lp[0]`.
+- **SOURCE PIX PIPELINE 1:** Equivalent to `source_pix_1` in `slam_start_here.py`, except a Hilbert image mesh is used instead.
+- **SOURCE PIX PIPELINE 2:** Identical to `source_pix_1` above, except the adapt data for the Hilbert image mesh is capped at a.
+- **LIGHT LP PIPELINE:** Identical to `light_lp` in `slam_start_here.py`, except extra galaxies receive a fresh free MGE.
+- **MASS TOTAL PIPELINE:** Identical to `mass_total` in `slam_start_here.py`, except extra galaxies receive a new.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Galaxy Centres:** main_lens_centres.json — required; determines the number of main lenses.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Prerequisites__
 

--- a/scripts/group/source_science.py
+++ b/scripts/group/source_science.py
@@ -13,14 +13,14 @@ mass profiles in the group must be included when computing ray-tracing and magni
 
 __Contents__
 
-**Simulated Dataset:** We load and plot the `simple` group example dataset, which is simulated imaging of a group-scale.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Impact of Extra Galaxies:** For group-scale lenses, the magnification is determined by ALL mass profiles in the group: the main.
-**Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
-**Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
+- **Simulated Dataset:** We load and plot the `simple` group example dataset, which is simulated imaging of a group-scale.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Impact of Extra Galaxies:** For group-scale lenses, the magnification is determined by ALL mass profiles in the group: the main.
+- **Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
+- **Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
 
 """
 

--- a/scripts/group/start_here.py
+++ b/scripts/group/start_here.py
@@ -20,18 +20,18 @@ PyAutoLens can efficiently scale to these more complex systems.
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Main Lens Galaxies:** For a group-scale lens, we have multiple lens galaxies whose light and mass all contribute.
-**Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
-**Model:** Compose the lens model fitted to the data.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Result:** Overview of the results of the model-fit.
-**Centre Input GUI:** The centres of the main lens galaxies above were loaded from a .json file, which was created using.
-**Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Main Lens Galaxies:** For a group-scale lens, we have multiple lens galaxies whose light and mass all contribute.
+- **Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
+- **Model:** Compose the lens model fitted to the data.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Result:** Overview of the results of the model-fit.
+- **Centre Input GUI:** The centres of the main lens galaxies above were loaded from a .json file, which was created using.
+- **Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/guides/advanced/add_a_profile.py
+++ b/scripts/guides/advanced/add_a_profile.py
@@ -16,17 +16,17 @@ are then applied to show how custom _light profiles_ can be implemented.
 
 __Contents__
 
-**Source Code:** This example includes direct links to the source code of the classes used to define mass and light.
-**Example Mass Profile:** The mass profiles available in **PyAutoLens** are located in its parent package, **PyAutoGalaxy**.
-**Inheritance Structure:** Let us next consider the inheritance structure of the ``Isothermal`` profile, defined by the class.
-**Data Structure Decorators:** Different grids can be input into each mass profile function (e.g.
-**Transform Decorator:** Overview of transform decorator for this example.
-**Lens Modeling:** **PyAutoLens** assumes that all input parameters of a mass profile (for example, those listed in.
-**Lens Modeling Configs:** In most **PyAutoLens** examples, you will notice we compose models without manually specifying.
-**Deflections:** We are therefore ready to implement a mass profile, and the best place to start is the.
-**Spherical Template:** radial_grid removal of ell_comps.
-**Physical Profiles:** Show how to wrap existing profiles with physical units?
-**Light Profiles:** Pretty much the same but need to add text.
+- **Source Code:** This example includes direct links to the source code of the classes used to define mass and light.
+- **Example Mass Profile:** The mass profiles available in **PyAutoLens** are located in its parent package, **PyAutoGalaxy**.
+- **Inheritance Structure:** Let us next consider the inheritance structure of the ``Isothermal`` profile, defined by the class.
+- **Data Structure Decorators:** Different grids can be input into each mass profile function (e.g.
+- **Transform Decorator:** Overview of transform decorator for this example.
+- **Lens Modeling:** **PyAutoLens** assumes that all input parameters of a mass profile (for example, those listed in.
+- **Lens Modeling Configs:** In most **PyAutoLens** examples, you will notice we compose models without manually specifying.
+- **Deflections:** We are therefore ready to implement a mass profile, and the best place to start is the.
+- **Spherical Template:** radial_grid removal of ell_comps.
+- **Physical Profiles:** Show how to wrap existing profiles with physical units?
+- **Light Profiles:** Pretty much the same but need to add text.
 
 __Source Code__
 

--- a/scripts/guides/advanced/custom_analysis.py
+++ b/scripts/guides/advanced/custom_analysis.py
@@ -17,17 +17,17 @@ This example demonstrates how you can write your own `Analysis` class to fit a d
 
 __Contents__
 
-**PyAutoFit:** The `Analysis` class is the interface between the data and model, whereby a.
-**Source Code:** This example contains URLs to the locations of the source code of the classes used when creating.
-**Example Analysis Class:** The `Analysis` classes available in **PyAutoLens** are actually located in both **PyAutoLens** and.
-**Lens Model:** To illustrate how to write a custom `Analysis` class, we require an example lens model that we will.
-**Instances:** Instances of the model above can be created, where an input `vector` of parameters is mapped to.
-**Simple Analysis Example:** For simplicity, a shortened version of an `AnalysisImaging` class is shown below where certain.
-**Analysis Class Considerations:** Lets quickly think about the design of an `Analysis` class and how this can help us to set up any.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Weak Lensing Example:** Now lets consider how to write our own custom `Analysis` class, for the example of performing a.
-**Result:** Overview of the results of the model-fit.
-**To Do List:** The following `Analysis` cookbook from the **PyAutoFit** readthedocs should help you get started.
+- **PyAutoFit:** The `Analysis` class is the interface between the data and model, whereby a.
+- **Source Code:** This example contains URLs to the locations of the source code of the classes used when creating.
+- **Example Analysis Class:** The `Analysis` classes available in **PyAutoLens** are actually located in both **PyAutoLens** and.
+- **Lens Model:** To illustrate how to write a custom `Analysis` class, we require an example lens model that we will.
+- **Instances:** Instances of the model above can be created, where an input `vector` of parameters is mapped to.
+- **Simple Analysis Example:** For simplicity, a shortened version of an `AnalysisImaging` class is shown below where certain.
+- **Analysis Class Considerations:** Lets quickly think about the design of an `Analysis` class and how this can help us to set up any.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Weak Lensing Example:** Now lets consider how to write our own custom `Analysis` class, for the example of performing a.
+- **Result:** Overview of the results of the model-fit.
+- **To Do List:** The following `Analysis` cookbook from the **PyAutoFit** readthedocs should help you get started.
 
 __PyAutoFit__
 

--- a/scripts/guides/advanced/multi_plane.py
+++ b/scripts/guides/advanced/multi_plane.py
@@ -22,10 +22,10 @@ Examples of multi-plane lensing systems include:
 
 __Contents__
 
-**Example:** To illustrate multi-plane ray-tracing, we first set up a simple lens system, using a `Tracer`.
-**Ray Tracing:** Multi-plane ray tracing is implemented in the `tracer_util.py` module of the following package.
-**Profiles With Physical Units:** The above ray-tracing used dimensionless angular units (e.g.
-**SLACK:** This script was written after discussion on the PyAutoLens Slack channel, where some users modeling.
+- **Example:** To illustrate multi-plane ray-tracing, we first set up a simple lens system, using a `Tracer`.
+- **Ray Tracing:** Multi-plane ray tracing is implemented in the `tracer_util.py` module of the following package.
+- **Profiles With Physical Units:** The above ray-tracing used dimensionless angular units (e.g.
+- **SLACK:** This script was written after discussion on the PyAutoLens Slack channel, where some users modeling.
 
 __Example__
 

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -32,15 +32,15 @@ This guide will explain why these choices were made for the default over-samplin
 
 __Contents__
 
-**Illustration:** To illustrate over sampling, lets first create a uniform grid which does not over sample the.
-**Numerics:** Lets quickly check how the sub-grid is defined and stored numerically.
-**Images:** We now use over-sampling to compute the image of a Sersic light profile, which has a steep.
-**Adaptive Over Sampling:** We have shown that over-sampling is important for accurate image evaluation.
-**Multiple Lens Galaxies:** The analysis may contain multiple lens galaxies, each of which must be over-sampled accurately.
-**Ray Tracing:** So far, we have evaluated the image of a light profile using over-sampling on an unlensed uniform.
-**Default Ray Tracing:** By assuming the lens galaxy is near (0.0", 0.0"), it was simple to set up an adaptive over sampling.
-**Dataset & Modeling:** Throughout this guide, grid objects have been used to compute the image of light and mass profiles.
-**Pixelization:** Source galaxies can be reconstructed using pixelizations, which discretize the source's light onto.
+- **Illustration:** To illustrate over sampling, lets first create a uniform grid which does not over sample the.
+- **Numerics:** Lets quickly check how the sub-grid is defined and stored numerically.
+- **Images:** We now use over-sampling to compute the image of a Sersic light profile, which has a steep.
+- **Adaptive Over Sampling:** We have shown that over-sampling is important for accurate image evaluation.
+- **Multiple Lens Galaxies:** The analysis may contain multiple lens galaxies, each of which must be over-sampled accurately.
+- **Ray Tracing:** So far, we have evaluated the image of a light profile using over-sampling on an unlensed uniform.
+- **Default Ray Tracing:** By assuming the lens galaxy is near (0.0", 0.0"), it was simple to set up an adaptive over sampling.
+- **Dataset & Modeling:** Throughout this guide, grid objects have been used to compute the image of light and mass profiles.
+- **Pixelization:** Source galaxies can be reconstructed using pixelizations, which discretize the source's light onto.
 
 """
 

--- a/scripts/guides/advanced/over_sampling_chaining.py
+++ b/scripts/guides/advanced/over_sampling_chaining.py
@@ -24,14 +24,14 @@ This example shows how to combine lensed source adaptive over sampling with sear
 
 __Contents__
 
-**Start Here Notebook:** If any code in this script is unclear, refer to the `guides/modeling/chaining.ipynb` notebook.
-**Dataset + Masking:** Load, plot and mask the `Imaging` data.
-**Paths:** The path the results of all chained searches are output.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` with `ExternalShear` and the source galaxy's light is an MGE.
-**Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
-**Over Sampling (Search 2):** We update the over sampling grid between searches using the results of search 1.
+- **Start Here Notebook:** If any code in this script is unclear, refer to the `guides/modeling/chaining.ipynb` notebook.
+- **Dataset + Masking:** Load, plot and mask the `Imaging` data.
+- **Paths:** The path the results of all chained searches are output.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` with `ExternalShear` and the source galaxy's light is an MGE.
+- **Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
+- **Over Sampling (Search 2):** We update the over sampling grid between searches using the results of search 1.
 
 __Start Here Notebook__
 

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -15,16 +15,16 @@ These data structures use the `slim` and `native` data representations API to ma
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**API:** We discuss in detail why these data structures and illustrate their functionality below.
-**Grids:** We now illustrate data structures using a `Grid2D` object, which is a set of two-dimensional.
-**Native:** This plot shows the grid in its `native` format, that is in 2D dimensions where the y and x.
-**Slim:** Every `Grid2D` object is accessible via two attributes, `native` and `slim`, which store the grid.
-**Masked Data Structures:** When a mask is applied to a grid or other data structure, this changes the `slim` and `native`.
-**Data:** Two dimensional arrays of data are stored using the `Array2D` object, which has `slim` and `native`.
-**Tracer:** The `Tracer` produces many lensing quantities all of which use the `slim` and `native` data.
-**Irregular Structures:** We may want to perform calculations at specific (y,x) coordinates which are not tied to a uniform.
-**Vector Quantities:** Many lensing quantities are vectors.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **API:** We discuss in detail why these data structures and illustrate their functionality below.
+- **Grids:** We now illustrate data structures using a `Grid2D` object, which is a set of two-dimensional.
+- **Native:** This plot shows the grid in its `native` format, that is in 2D dimensions where the y and x.
+- **Slim:** Every `Grid2D` object is accessible via two attributes, `native` and `slim`, which store the grid.
+- **Masked Data Structures:** When a mask is applied to a grid or other data structure, this changes the `slim` and `native`.
+- **Data:** Two dimensional arrays of data are stored using the `Array2D` object, which has `slim` and `native`.
+- **Tracer:** The `Tracer` produces many lensing quantities all of which use the `slim` and `native` data.
+- **Irregular Structures:** We may want to perform calculations at specific (y,x) coordinates which are not tied to a uniform.
+- **Vector Quantities:** Many lensing quantities are vectors.
 
 __Units__
 

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -14,12 +14,12 @@ comprises two galaxies.
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
-**Grids:** To describe the luminous emission of galaxies, **PyAutoGalaxy** uses `Grid2D` data structures.
-**Tracer:** We first set up a tracer with a lens galaxy and two source galaxies, which we will use to.
-**Individual Lens Galaxy Components:** We are able to create an image of the lens galaxy as follows, which includes the emission of both.
-**Log10:** The light distributions of galaxies are closer to a log10 distribution than a linear one.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
+- **Grids:** To describe the luminous emission of galaxies, **PyAutoGalaxy** uses `Grid2D` data structures.
+- **Tracer:** We first set up a tracer with a lens galaxy and two source galaxies, which we will use to.
+- **Individual Lens Galaxy Components:** We are able to create an image of the lens galaxy as follows, which includes the emission of both.
+- **Log10:** The light distributions of galaxies are closer to a log10 distribution than a linear one.
 
 __Units__
 

--- a/scripts/guides/hpc/example_cpu.py
+++ b/scripts/guides/hpc/example_cpu.py
@@ -25,16 +25,16 @@ illustrate the general principles of how to set up lens modeling on an HPC.
 
 __Contents__
 
-**HPC Output Path:** We first set the `hpc_output_path`, where the results of lens modeling are output on your HPC.
-**HPC Dataset Path:** We next set the `hpc_dataset_path`, which is the path where datasets are stored on the hpc.
-**HPC Home Path:** The `home_path` is in your the hpc home directory, which again may be different from your output.
-**Batch Script Many Lenses:** HPC submissions require a batch script, which tells the HPC the CPU hardware you want the job to.
-**Batch Script One Lenses:** Lets now look at the second example batch script, `example_cpu_one_dataset_parallel`, which fits a.
-**Dataset:** Load and plot the strong lens dataset.
-**Nautilus CPUs:** The final change we need to make is to set the number of CPUs Nautilus uses in the model-fit.
-**Lens Modeling:** Define a 3.0" circular mask, which includes the emission of the lens and source galaxies.
-**Model:** Compose the lens model fitted to the data.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **HPC Output Path:** We first set the `hpc_output_path`, where the results of lens modeling are output on your HPC.
+- **HPC Dataset Path:** We next set the `hpc_dataset_path`, which is the path where datasets are stored on the hpc.
+- **HPC Home Path:** The `home_path` is in your the hpc home directory, which again may be different from your output.
+- **Batch Script Many Lenses:** HPC submissions require a batch script, which tells the HPC the CPU hardware you want the job to.
+- **Batch Script One Lenses:** Lets now look at the second example batch script, `example_cpu_one_dataset_parallel`, which fits a.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Nautilus CPUs:** The final change we need to make is to set the number of CPUs Nautilus uses in the model-fit.
+- **Lens Modeling:** Define a 3.0" circular mask, which includes the emission of the lens and source galaxies.
+- **Model:** Compose the lens model fitted to the data.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
 
 """
 

--- a/scripts/guides/lens_calc.py
+++ b/scripts/guides/lens_calc.py
@@ -20,22 +20,22 @@ guide walks through each quantity from first principles, with equations and code
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
-**Grids:** To describe the deflection of light, **PyAutoLens** uses `Grid2D` data structures.
-**Mass Profile and Galaxy:** We create a simple elliptical isothermal mass profile and wrap it in a Galaxy.
-**Tracer:** We create a two-plane Tracer from a lens and source galaxy.
-**LensCalc:** We introduce the ``LensCalc`` object and how to construct one from a Tracer.
-**The Lens Equation:** The fundamental equation of gravitational lensing.
-**Deflection Angles:** The deflection angles are the input to every other lensing quantity.
-**Hessian:** The matrix of second derivatives of the lensing potential.
-**Convergence:** The projected surface mass density normalised by the critical density.
-**Shear:** The tidal distortion field that stretches lensed images.
-**Magnification:** How much a lensed image is brightened (or dimmed) relative to the unlensed source.
-**Critical Curves and Caustics:** Where magnification formally diverges and how this maps to the source plane.
-**Einstein Radius:** The characteristic angular size of a lens.
-**Fermat Potential:** The time-delay surface whose extrema locate lensed images.
-**Wrap Up:** Summary and pointers to further reading.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
+- **Grids:** To describe the deflection of light, **PyAutoLens** uses `Grid2D` data structures.
+- **Mass Profile and Galaxy:** We create a simple elliptical isothermal mass profile and wrap it in a Galaxy.
+- **Tracer:** We create a two-plane Tracer from a lens and source galaxy.
+- **LensCalc:** We introduce the ``LensCalc`` object and how to construct one from a Tracer.
+- **The Lens Equation:** The fundamental equation of gravitational lensing.
+- **Deflection Angles:** The deflection angles are the input to every other lensing quantity.
+- **Hessian:** The matrix of second derivatives of the lensing potential.
+- **Convergence:** The projected surface mass density normalised by the critical density.
+- **Shear:** The tidal distortion field that stretches lensed images.
+- **Magnification:** How much a lensed image is brightened (or dimmed) relative to the unlensed source.
+- **Critical Curves and Caustics:** Where magnification formally diverges and how this maps to the source plane.
+- **Einstein Radius:** The characteristic angular size of a lens.
+- **Fermat Potential:** The time-delay surface whose extrema locate lensed images.
+- **Wrap Up:** Summary and pointers to further reading.
 
 __Units__
 

--- a/scripts/guides/modeling/advanced/expectation_propagation.py
+++ b/scripts/guides/modeling/advanced/expectation_propagation.py
@@ -17,19 +17,19 @@ fit every dataset simultaneously.
 
 __Contents__
 
-**Sample Simulation:** The dataset fitted in this example script is simulated imaging data of a sample of 3 galaxies.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Model Individual Factors:** We first set up a model for each lens, with an `PowerLawSph` mass and `ExponentialSph` bulge, which.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model:** Compose the lens model fitted to the data.
-**Paths:** Overview of paths for this example.
-**Analysis Factors:** Now we have our `Analysis` classes and graphical model, we can compose our `AnalysisFactor`'s.
-**Factor Graph:** We combine our `AnalysisFactors` into one, to compose the factor graph.
-**Expectation Propagation:** In the previous tutorials, we used the `global_prior_model` of the `factor_graph` to fit the global.
-**Cyclic Fitting:** After every `AnalysisFactor` has been fitted (e.g.
-**Result:** Overview of the results of the model-fit.
-**Output:** The results of the factor graph, using the EP framework and message passing, are contained in the.
-**Results:** The `MeanField` object represent the posterior of the entire factor graph and is used to infer.
+- **Sample Simulation:** The dataset fitted in this example script is simulated imaging data of a sample of 3 galaxies.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Model Individual Factors:** We first set up a model for each lens, with an `PowerLawSph` mass and `ExponentialSph` bulge, which.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model:** Compose the lens model fitted to the data.
+- **Paths:** Overview of paths for this example.
+- **Analysis Factors:** Now we have our `Analysis` classes and graphical model, we can compose our `AnalysisFactor`'s.
+- **Factor Graph:** We combine our `AnalysisFactors` into one, to compose the factor graph.
+- **Expectation Propagation:** In the previous tutorials, we used the `global_prior_model` of the `factor_graph` to fit the global.
+- **Cyclic Fitting:** After every `AnalysisFactor` has been fitted (e.g.
+- **Result:** Overview of the results of the model-fit.
+- **Output:** The results of the factor graph, using the EP framework and message passing, are contained in the.
+- **Results:** The `MeanField` object represent the posterior of the entire factor graph and is used to infer.
 
 __Sample Simulation__
 

--- a/scripts/guides/modeling/advanced/graphical.py
+++ b/scripts/guides/modeling/advanced/graphical.py
@@ -33,15 +33,15 @@ be composed and fitted using the same framework.
 
 __Contents__
 
-**Initialization:** Load 3 simulated time-delay lens datasets which are all simulated with different mass models but.
-**Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
-**Model:** Compose the lens model fitted to the data.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Analysis Factors:** Above, we created a `model_list` containing three lens models, each sharing the same prior on `H0`.
-**Factor Graph:** We now combine our `AnalysisFactor` objects to form a **factor graph**.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Initialization:** Load 3 simulated time-delay lens datasets which are all simulated with different mass models but.
+- **Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
+- **Model:** Compose the lens model fitted to the data.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Analysis Factors:** Above, we created a `model_list` containing three lens models, each sharing the same prior on `H0`.
+- **Factor Graph:** We now combine our `AnalysisFactor` objects to form a **factor graph**.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/guides/modeling/advanced/hierarchical.py
+++ b/scripts/guides/modeling/advanced/hierarchical.py
@@ -24,16 +24,16 @@ no such example is included in the current workspace, the structure shown here c
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model Individual Factors:** We first set up a model for each lens, with an `PowerLawSph` mass and `ExponentialSph` bulge, which.
-**Analysis Factors:** Now we have our `Analysis` classes and model components, we can compose our `AnalysisFactor`'s.
-**Model:** Compose the lens model fitted to the data.
-**Factor Graph:** We now create the factor graph for this model, using the list of `AnalysisFactor`'s and the.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
-**Concept:** A hierarchical model yields more precise and accurate estimates of the parent distribution’s.
-**Wrap Up:** Summary of the script and next steps.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model Individual Factors:** We first set up a model for each lens, with an `PowerLawSph` mass and `ExponentialSph` bulge, which.
+- **Analysis Factors:** Now we have our `Analysis` classes and model components, we can compose our `AnalysisFactor`'s.
+- **Model:** Compose the lens model fitted to the data.
+- **Factor Graph:** We now create the factor graph for this model, using the list of `AnalysisFactor`'s and the.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
+- **Concept:** A hierarchical model yields more precise and accurate estimates of the parent distribution’s.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -13,8 +13,8 @@ Comments have therefore been removed to avoid repetition and make the script mor
 
 __Contents__
 
-**The Fix:** The fix which makes parallelization work is at the end of the script, where we use the following.
-**Trouble Shooting:** If you still cannot get parallelization to work, please ask to be added to the SLACK channel (by.
+- **The Fix:** The fix which makes parallelization work is at the end of the script, where we use the following.
+- **Trouble Shooting:** If you still cannot get parallelization to work, please ask to be added to the SLACK channel (by.
 
 __The Fix__
 

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -21,20 +21,20 @@ The benefits of non-linear search chaining are:
 
 __Contents__
 
-**Concise Model Composition API:** Chaining uses the concise `Model` API to compose lens models, which is nearly identical to the standard API but avoids the need to use `Model` objects to compose the lens model when a light or mass profile is passed to a `Collection` object.
-**This Example:** This script gives an overview of the API for search chaining, a description of how the priors on parameters are used to pass information between searches as well as tools for customizing prior passing.
-**Dataset + Masking:** Load, plot and mask the `Imaging` data.
-**Paths:** The path the results of all chained searches are output.
-**Model (Search 1):** We compose our lens model using `Model` objects, which represent the galaxies we fit to our data.
-**Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
-**Model Chaining:** We use the results of search 1 to create the `Model` components that we fit in search 2.
-**Model Centred Chaining:** We use the results of search 1 to create the `Model` components that we fit in search 2, using `model_centred` to pass priors centered on the maximum likelihood parameter values.
-**Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using the chained model.
-**Result (Search 2):** The final results of the chained model-fit.
-**How is Search Chaining Used?:** Overview of how search chaining is used in practice for automated lens modeling and SLaM pipelines.
-**Detailed Explanation Of Prior Passing:** Detailed overview of how prior passing works and tools to customize its behaviour.
-**EXAMPLE:** Lets go through an example using a real parameter.
+- **Concise Model Composition API:** Chaining uses the concise `Model` API to compose lens models, which is nearly identical to the standard API but avoids the need to use `Model` objects to compose the lens model when a light or mass profile is passed to a `Collection` object.
+- **This Example:** This script gives an overview of the API for search chaining, a description of how the priors on parameters are used to pass information between searches as well as tools for customizing prior passing.
+- **Dataset + Masking:** Load, plot and mask the `Imaging` data.
+- **Paths:** The path the results of all chained searches are output.
+- **Model (Search 1):** We compose our lens model using `Model` objects, which represent the galaxies we fit to our data.
+- **Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
+- **Model Chaining:** We use the results of search 1 to create the `Model` components that we fit in search 2.
+- **Model Centred Chaining:** We use the results of search 1 to create the `Model` components that we fit in search 2, using `model_centred` to pass priors centered on the maximum likelihood parameter values.
+- **Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using the chained model.
+- **Result (Search 2):** The final results of the chained model-fit.
+- **How is Search Chaining Used?:** Overview of how search chaining is used in practice for automated lens modeling and SLaM pipelines.
+- **Detailed Explanation Of Prior Passing:** Detailed overview of how prior passing works and tools to customize its behaviour.
+- **EXAMPLE:** Lets go through an example using a real parameter.
 
 __Concise Model Composition API__
 

--- a/scripts/guides/modeling/cookbook.py
+++ b/scripts/guides/modeling/cookbook.py
@@ -10,13 +10,13 @@ readable code for different use-cases.
 
 __Contents__
 
-**Simple Lens Model:** Compose a simple lens model with a lens galaxy and source galaxy.
-**More Complex Lens Models:** Extend the simple model to have multiple light or mass profiles and multiple galaxies.
-**Concise API:** Compose a lens model using the concise API, which is more readable and concise.
-**Prior Customization:** Customize the priors of individual lens model parameters using uniform, log-uniform and Gaussian priors.
-**Model Customization:** Customize the lens model parameters, including parameter pairing, fixing and offsets.
-**Redshift Free:** Make the redshift of a galaxy a free parameter in the model-fit.
-**Available Model Components:** List the available light profiles, mass profiles and other components that can be used for lens modeling.
+- **Simple Lens Model:** Compose a simple lens model with a lens galaxy and source galaxy.
+- **More Complex Lens Models:** Extend the simple model to have multiple light or mass profiles and multiple galaxies.
+- **Concise API:** Compose a lens model using the concise API, which is more readable and concise.
+- **Prior Customization:** Customize the priors of individual lens model parameters using uniform, log-uniform and Gaussian priors.
+- **Model Customization:** Customize the lens model parameters, including parameter pairing, fixing and offsets.
+- **Redshift Free:** Make the redshift of a galaxy a free parameter in the model-fit.
+- **Available Model Components:** List the available light profiles, mass profiles and other components that can be used for lens modeling.
 
 Advanced Features:
 

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -7,9 +7,9 @@ reasons explaining why each customization is useful.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Positions:** Before fitting a strong lens, we can manually specify a grid of image-plane coordinates.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Positions:** Before fitting a strong lens, we can manually specify a grid of image-plane coordinates.
 
 __Start Here Notebook__
 

--- a/scripts/guides/modeling/searches.py
+++ b/scripts/guides/modeling/searches.py
@@ -23,12 +23,12 @@ object and pass these to the search to perform the fit. We skip these steps for 
 
 __Contents__
 
-**Dynesty:** Dynesty (https://github.com/joshspeagle/dynesty) is a nested sampling algorithm.
-**Emcee:** Emcee (https://github.com/dfm/emcee) is an ensemble MCMC sampler that is commonly used in Astronomy.
-**Zeus:** Zeus (https://zeus-mcmc.readthedocs.io/en/latest/) is an ensemble MCMC slice sampler.
-**LBFGS:** LBFGS is a quasi-Newton optimization algorithm from scipy.
-**Start Point:** For maximum likelihood estimator (MLE) and Markov Chain Monte Carlo (MCMC) non-linear searches.
-**Search Cookbook:** There are a number of other searches supported by **PyAutoFit** and therefore which can be used.
+- **Dynesty:** Dynesty (https://github.com/joshspeagle/dynesty) is a nested sampling algorithm.
+- **Emcee:** Emcee (https://github.com/dfm/emcee) is an ensemble MCMC sampler that is commonly used in Astronomy.
+- **Zeus:** Zeus (https://zeus-mcmc.readthedocs.io/en/latest/) is an ensemble MCMC slice sampler.
+- **LBFGS:** LBFGS is a quasi-Newton optimization algorithm from scipy.
+- **Start Point:** For maximum likelihood estimator (MLE) and Markov Chain Monte Carlo (MCMC) non-linear searches.
+- **Search Cookbook:** There are a number of other searches supported by **PyAutoFit** and therefore which can be used.
 
 __Start Here Notebook__
 

--- a/scripts/guides/modeling/slam_start_here.py
+++ b/scripts/guides/modeling/slam_start_here.py
@@ -7,22 +7,22 @@ pipelines which use many aspects of core PyAutoLens functionality to automate th
 
 __Contents__
 
-**Preqrequisites:** Before using SLaM, you should understand.
-**Overview:** SLaM chains together four or more sequential modeling searches, with each stage passing its results.
-**Design Choices:** The structure of the SLaM pipelines is driven by the requirements of **adaptive pixelized source.
-**This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
-**SOURCE LP PIPELINE:** The SOURCE LP PIPELINE uses one search to initialize a robust model for the source galaxy's light.
-**SOURCE PIX PIPELINE 1:** The SOURCE PIX PIPELINE uses two searches to initialize a robust pixelized model of the source.
-**Positions:** Image positions are used to prevent unphysical source reconstructions (see `features/pixelization`.
-**Adapt Images:** An adapt image is computed from the SOURCE LP result and passed to the analysis.
-**SOURCE PIX PIPELINE 2:** The second search of the SOURCE PIX PIPELINE fits the final pixelized source model using the.
-**LIGHT LP PIPELINE:** The LIGHT LP PIPELINE uses one search to fit a complex lens light model to a high level of.
-**MASS TOTAL PIPELINE:** The MASS TOTAL PIPELINE uses one search to fit a complex lens mass model to a high level of.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Preqrequisites:** Before using SLaM, you should understand.
+- **Overview:** SLaM chains together four or more sequential modeling searches, with each stage passing its results.
+- **Design Choices:** The structure of the SLaM pipelines is driven by the requirements of **adaptive pixelized source.
+- **This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
+- **SOURCE LP PIPELINE:** The SOURCE LP PIPELINE uses one search to initialize a robust model for the source galaxy's light.
+- **SOURCE PIX PIPELINE 1:** The SOURCE PIX PIPELINE uses two searches to initialize a robust pixelized model of the source.
+- **Positions:** Image positions are used to prevent unphysical source reconstructions (see `features/pixelization`.
+- **Adapt Images:** An adapt image is computed from the SOURCE LP result and passed to the analysis.
+- **SOURCE PIX PIPELINE 2:** The second search of the SOURCE PIX PIPELINE fits the final pixelized source model using the.
+- **LIGHT LP PIPELINE:** The LIGHT LP PIPELINE uses one search to fit a complex lens light model to a high level of.
+- **MASS TOTAL PIPELINE:** The MASS TOTAL PIPELINE uses one search to fit a complex lens mass model to a high level of.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Preqrequisites__
 

--- a/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
+++ b/scripts/guides/plot/advanced/plotters_double_einstein_ring.py
@@ -19,11 +19,11 @@ Refer to `plots/start_here.ipynb` for an introduction to the new plotting API.
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Fit Imaging:** Plot individual fit attributes with `aplt.plot_array()`.
-**Full Subplot:** A multi-panel subplot overview is produced with `aplt.subplot_fit_imaging()`.
-**Pixelized Source Reconstruction:** Now set up a double Einstein ring fit using pixelized source reconstructions.
-**Inversion:** The inversion is computed directly from a `Tracer` using `TracerToInversion`.
+- **Setup:** General setup for the analysis.
+- **Fit Imaging:** Plot individual fit attributes with `aplt.plot_array()`.
+- **Full Subplot:** A multi-panel subplot overview is produced with `aplt.subplot_fit_imaging()`.
+- **Pixelized Source Reconstruction:** Now set up a double Einstein ring fit using pixelized source reconstructions.
+- **Inversion:** The inversion is computed directly from a `Tracer` using `TracerToInversion`.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -19,12 +19,12 @@ Refer to `plots/start_here.ipynb` for an introduction to the new plotting API.
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Fit Imaging:** Plot the multi-panel fit overview with `aplt.subplot_fit_imaging()`.
-**Inversion:** The `inversion` property contains the linear algebra, mesh calculations and other key quantities.
-**Mapper Grids:** The mapper maps pixels from the image-plane to the source-plane pixelization.
-**Mapper Galaxy Dict:** The mapper galaxy dict maps each mapper to its corresponding galaxy.
-**Fit Interferometer:** A fit to an interferometer dataset with a pixelized source is plotted with.
+- **Setup:** General setup for the analysis.
+- **Fit Imaging:** Plot the multi-panel fit overview with `aplt.subplot_fit_imaging()`.
+- **Inversion:** The `inversion` property contains the linear algebra, mesh calculations and other key quantities.
+- **Mapper Grids:** The mapper maps pixels from the image-plane to the source-plane pixelization.
+- **Mapper Galaxy Dict:** The mapper galaxy dict maps each mapper to its corresponding galaxy.
+- **Fit Interferometer:** A fit to an interferometer dataset with a pixelized source is plotted with.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/guides/plot/examples/mat_plot.py
+++ b/scripts/guides/plot/examples/mat_plot.py
@@ -24,12 +24,12 @@ Refer to `plots/start_here.ipynb` for a general introduction to the new plotting
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Output:** To save a figure to disk, pass `output_path` (a directory) and `output_format`.
-**Title:** The figure title is set with the `title=` kwarg.
-**Colormap:** The colormap is set with the `colormap=` kwarg.
-**Log10:** Many lensing quantities (images, convergence, potential) span many orders of magnitude and are.
-**Config Defaults:** All default values (colormaps, tick sizes, label fonts, etc.) are configured via the config files.
+- **Setup:** General setup for the analysis.
+- **Output:** To save a figure to disk, pass `output_path` (a directory) and `output_format`.
+- **Title:** The figure title is set with the `title=` kwarg.
+- **Colormap:** The colormap is set with the `colormap=` kwarg.
+- **Log10:** Many lensing quantities (images, convergence, potential) span many orders of magnitude and are.
+- **Config Defaults:** All default values (colormaps, tick sizes, label fonts, etc.) are configured via the config files.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -25,16 +25,16 @@ Refer to `plots/start_here.ipynb` for an introduction to the new plotting API.
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Array2D:** Any `Array2D` — images, convergence, noise-maps, etc.
-**Grid2D:** A `Grid2D` of (y,x) coordinates is plotted with `aplt.plot_grid()`.
-**Tracer:** Tracer quantities (image, convergence, potential, deflections, magnification) are computed via.
-**Imaging Dataset:** An `Imaging` dataset's data, noise-map and PSF are plotted individually with `aplt.plot_array()`.
-**Fit Imaging:** A fit's residuals, chi-squared, model image, etc.
-**Light Profile:** A light profile image is computed via `image_2d_from()` and plotted with `aplt.plot_array()`.
-**Mass Profile:** Mass profile quantities are computed and plotted individually.
-**Galaxy:** A galaxy's image and mass quantities are computed and plotted with `aplt.plot_array()`.
-**Interferometer:** Interferometer datasets and fits are plotted using their dedicated subplot functions.
+- **Setup:** General setup for the analysis.
+- **Array2D:** Any `Array2D` — images, convergence, noise-maps, etc.
+- **Grid2D:** A `Grid2D` of (y,x) coordinates is plotted with `aplt.plot_grid()`.
+- **Tracer:** Tracer quantities (image, convergence, potential, deflections, magnification) are computed via.
+- **Imaging Dataset:** An `Imaging` dataset's data, noise-map and PSF are plotted individually with `aplt.plot_array()`.
+- **Fit Imaging:** A fit's residuals, chi-squared, model image, etc.
+- **Light Profile:** A light profile image is computed via `image_2d_from()` and plotted with `aplt.plot_array()`.
+- **Mass Profile:** Mass profile quantities are computed and plotted individually.
+- **Galaxy:** A galaxy's image and mass quantities are computed and plotted with `aplt.plot_array()`.
+- **Interferometer:** Interferometer datasets and fits are plotted using their dedicated subplot functions.
 
 __Setup__
 

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -11,21 +11,21 @@ behaviour of plotting visuals.
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Notation:** Plot are labeled with short hand parameter names (e.g.
-**DynestyPlotter:** We set up the Dynesty non-linear search and perform the fit to get the samples we will plot below.
-**Plots:** All plots use dynesty's inbuilt plotting library and the model.
-**EmceePlotter:** We now use the MCMC plotting functions to visualize emcee's results.
-**Search Specific Visualization:** The internal sampler can be used to plot the results of the non-linear search.
-**ZeusPlotter:** We now use the MCMC plotting functions to visualize Zeus's results.
-**GetDist:** This example illustrates how to plot visualization summarizing the results of model-fit using any.
-**Parameter Names:** Note that in order to customize the figure, we will use the `samples.model.parameter_names` list.
-**GetDist Plotter:** To make plots we use a GetDist plotter object, which can be customized to change the appearance of.
-**GetDist Subplots:** Using the plotter we can make different plots, for example a triangle plot showing the 1D and 2D.
-**GetDist Single Plots:** We can make plots of specific 1D or 2D PDFs, using the single plotter object.
-**Output:** A figure can be output using standard matplotlib functionality.
-**GetDist Other Plots:** There are many more ways to visualize PDFs possible with GetDist, checkout the official.
-**Plotting Multiple Samples:** Finally, we can plot the results of multiple different non-linear searches on the same plot, using.
+- **Setup:** General setup for the analysis.
+- **Notation:** Plot are labeled with short hand parameter names (e.g.
+- **DynestyPlotter:** We set up the Dynesty non-linear search and perform the fit to get the samples we will plot below.
+- **Plots:** All plots use dynesty's inbuilt plotting library and the model.
+- **EmceePlotter:** We now use the MCMC plotting functions to visualize emcee's results.
+- **Search Specific Visualization:** The internal sampler can be used to plot the results of the non-linear search.
+- **ZeusPlotter:** We now use the MCMC plotting functions to visualize Zeus's results.
+- **GetDist:** This example illustrates how to plot visualization summarizing the results of model-fit using any.
+- **Parameter Names:** Note that in order to customize the figure, we will use the `samples.model.parameter_names` list.
+- **GetDist Plotter:** To make plots we use a GetDist plotter object, which can be customized to change the appearance of.
+- **GetDist Subplots:** Using the plotter we can make different plots, for example a triangle plot showing the 1D and 2D.
+- **GetDist Single Plots:** We can make plots of specific 1D or 2D PDFs, using the single plotter object.
+- **Output:** A figure can be output using standard matplotlib functionality.
+- **GetDist Other Plots:** There are many more ways to visualize PDFs possible with GetDist, checkout the official.
+- **Plotting Multiple Samples:** Finally, we can plot the results of multiple different non-linear searches on the same plot, using.
 
 __Setup__
 

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -17,14 +17,14 @@ Refer to `plots/start_here.ipynb` for a general introduction to the new plotting
 
 __Contents__
 
-**Setup:** General setup for the analysis.
-**Critical Curves:** Critical curves are plotted as lines over the image using the `lines=` keyword argument.
-**Multiple Critical Curves:** If a `Tracer` has multiple lens galaxies it may have multiple tangential and radial critical curves.
-**Caustics:** Caustics are the critical curves mapped to the source plane.
-**Image Positions:** The multiple image positions of a lensed source can be plotted using `positions=`.
-**Light Profile Centres:** The centres of light profiles can be extracted and plotted as positions over an image.
-**Mass Profile Centres:** Mass profile centres can be extracted and overlaid in the same way.
-**Combined Overlays:** `lines=` and `positions=` can be used together on the same plot.
+- **Setup:** General setup for the analysis.
+- **Critical Curves:** Critical curves are plotted as lines over the image using the `lines=` keyword argument.
+- **Multiple Critical Curves:** If a `Tracer` has multiple lens galaxies it may have multiple tangential and radial critical curves.
+- **Caustics:** Caustics are the critical curves mapped to the source plane.
+- **Image Positions:** The multiple image positions of a lensed source can be plotted using `positions=`.
+- **Light Profile Centres:** The centres of light profiles can be extracted and plotted as positions over an image.
+- **Mass Profile Centres:** Mass profile centres can be extracted and overlaid in the same way.
+- **Combined Overlays:** `lines=` and `positions=` can be used together on the same plot.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -15,10 +15,10 @@ The new API uses standalone functions:
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Customization:** Each plotting function accepts direct keyword arguments for customization.
-**Config Defaults:** All default plotting values are configured via config files in.
-**Overlays:** Overlays are added to plots using the `lines=` and `positions=` keyword arguments.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Customization:** Each plotting function accepts direct keyword arguments for customization.
+- **Config Defaults:** All default plotting values are configured via config files in.
+- **Overlays:** Overlays are added to plots using the `lines=` and `positions=` keyword arguments.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -10,11 +10,11 @@ like its visualization and also inspect fits randomly drawm from the PDF.
 
 __Contents__
 
-**Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
-**Aggregator:** First, set up the aggregator as shown in `start_here.py`.
-**Fits via Aggregator:** Having performed a model-fit, we now want to interpret and visualize the results.
-**Modification:** The `FitImagingAgg` allow us to modify the fit settings.
-**Visualization Customization:** The benefit of inspecting fits using the aggregator, rather than the files outputs to the.
+- **Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
+- **Aggregator:** First, set up the aggregator as shown in `start_here.py`.
+- **Fits via Aggregator:** Having performed a model-fit, we now want to interpret and visualize the results.
+- **Modification:** The `FitImagingAgg` allow us to modify the fit settings.
+- **Visualization Customization:** The benefit of inspecting fits using the aggregator, rather than the files outputs to the.
 
 __Interferometer__
 

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -16,14 +16,14 @@ and therefore you should read these guides in detail first.
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Max Likelihood Tracer:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_tracer` which we can.
-**Refitting:** Using the API introduced in the first tutorial, we can also refit the data locally.
-**Samples API:** In the first results tutorial, we used `Samples` objects to inspect the results of a model.
-**Max Likelihood Fit:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_fit` which we can.
-**Wrap Up:** Summary of the script and next steps.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Max Likelihood Tracer:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_tracer` which we can.
+- **Refitting:** Using the API introduced in the first tutorial, we can also refit the data locally.
+- **Samples API:** In the first results tutorial, we used `Samples` objects to inspect the results of a model.
+- **Max Likelihood Fit:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_fit` which we can.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Units__
 

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -11,9 +11,9 @@ by the non-linear search.
 
 __Contents__
 
-**Aggregator:** First, set up the aggregator as shown in `start_here.py`.
-**Tracer via Aggregator:** Having performed a model-fit, we now want to interpret and visualize the results.
-**Einstein Mass Example:** Each tracer has the information we need to compute the Einstein mass of a model.
+- **Aggregator:** First, set up the aggregator as shown in `start_here.py`.
+- **Tracer via Aggregator:** Having performed a model-fit, we now want to interpret and visualize the results.
+- **Einstein Mass Example:** Each tracer has the information we need to compute the Einstein mass of a model.
 
 """
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -11,11 +11,11 @@ can be loaded.
 
 __Contents__
 
-**Aggregator:** First, set up the aggregator as shown in `start_here.py`.
-**Unique Tag:** We can use the `Aggregator` to query the database and return only specific fits that we are.
-**Search Name:** We can also use the `name` of the search used to fit to the model as a query.
-**Model Queries:** We can also query based on the model fitted.
-**Logic:** Advanced queries can be constructed using logic, for example we below we combine the two queries.
+- **Aggregator:** First, set up the aggregator as shown in `start_here.py`.
+- **Unique Tag:** We can use the `Aggregator` to query the database and return only specific fits that we are.
+- **Search Name:** We can also use the `name` of the search used to fit to the model as a query.
+- **Model Queries:** We can also query based on the model fitted.
+- **Logic:** Advanced queries can be constructed using logic, for example we below we combine the two queries.
 
 """
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -10,21 +10,21 @@ This script illustrates how to use the result to inspect the non-linear search s
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Info:** As seen throughout the workspace, the `info` attribute shows the result in a readable format.
-**Plot:** We now have the `Result` object we will cover in this script.
-**Samples:** The result contains a `Samples` object, which contains all samples of the non-linear search.
-**Parameters:** The parameters are stored as a list of lists, where.
-**Figures of Merit:** The `Samples` class contains the log likelihood, log prior, log posterior and weight_list of every.
-**Instances:** Many results can be returned as an instance of the model, using the Python class structure of the.
-**Errors:** Methods for computing error estimates on all parameters are provided.
-**Sample Instance:** A non-linear search retains every model that is accepted during the model-fit.
-**Search Plots:** The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search.
-**Maximum Likelihood:** The maximum log likelihood value of the model-fit can be estimated by simple taking the maximum of.
-**Bayesian Evidence:** Nested sampling algorithms like Nautilus also estimate the Bayesian evidence (estimated via the.
-**Lists:** All results can alternatively be returned as a 1D list of values, by passing `as_instance=False`.
-**Latex:** If you are writing modeling results up in a paper, you can use inbuilt latex tools to create latex.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Info:** As seen throughout the workspace, the `info` attribute shows the result in a readable format.
+- **Plot:** We now have the `Result` object we will cover in this script.
+- **Samples:** The result contains a `Samples` object, which contains all samples of the non-linear search.
+- **Parameters:** The parameters are stored as a list of lists, where.
+- **Figures of Merit:** The `Samples` class contains the log likelihood, log prior, log posterior and weight_list of every.
+- **Instances:** Many results can be returned as an instance of the model, using the Python class structure of the.
+- **Errors:** Methods for computing error estimates on all parameters are provided.
+- **Sample Instance:** A non-linear search retains every model that is accepted during the model-fit.
+- **Search Plots:** The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search.
+- **Maximum Likelihood:** The maximum log likelihood value of the model-fit can be estimated by simple taking the maximum of.
+- **Bayesian Evidence:** Nested sampling algorithms like Nautilus also estimate the Bayesian evidence (estimated via the.
+- **Lists:** All results can alternatively be returned as a 1D list of values, by passing `as_instance=False`.
+- **Latex:** If you are writing modeling results up in a paper, you can use inbuilt latex tools to create latex.
 
 __Units__
 

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -16,27 +16,27 @@ can copy and paste the code to use in your own scripts!
 
 __Contents__
 
-**Samples via Result:** A fraction of this example repeats the API for manipulating samples given in the.
-**Files:** In the `start_here.py` script, we discussed the `files` that are output by the non-linear search.
-**Aggregator:** First, set up the aggregator as shown in `start_here.py`.
-**Generators:** The `start_here.py` database example gives an explanation of what Python generators are and why and.
-**Samples:** The result contains a `Samples` object, which contains all samples of the non-linear search, which.
-**Parameters:** The parameters are stored as a list of lists, where.
-**Samples Info:** The samples info contains additional information on the samples, which depends on the non-linear.
-**Figures of Merit:** The `Samples` class contains the log likelihood, log prior, log posterior and weight_list of every.
-**Samples Summary:** The samples summary contains a subset of results access via the `Samples`, for example the maximum.
-**Maximum Likelihood Model:** We can use the outputs to create a list of the maximum log likelihood model of each fit to our.
-**Parameter Names:** Vectors return a lists of all model parameters, but do not tell us which values correspond to which.
-**Instances:** We can use the `Aggregator` to create a list of instances of the model, using the Python class.
-**Errors:** Methods for computing error estimates on all parameters are provided.
-**Sample Instance:** A non-linear search retains every model that is accepted during the model-fit.
-**Search Plots:** The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search.
-**Maximum Likelihood:** The maximum log likelihood value of the model-fit can be estimated by simple taking the maximum of.
-**Bayesian Evidence:** Nested sampling algorithms like Nautilus also estimate the Bayesian evidence (estimated via the.
-**Lists:** All results can alternatively be returned as a 1D list of values, by passing `as_instance=False`.
-**Latex:** If you are writing modeling results up in a paper, you can use inbuilt latex tools to create latex.
-**Ordering:** The default ordering of the results can be a bit random, as it depends on how the sqlite database.
-**Samples Filtering:** The samples object has the results for all model parameter.
+- **Samples via Result:** A fraction of this example repeats the API for manipulating samples given in the.
+- **Files:** In the `start_here.py` script, we discussed the `files` that are output by the non-linear search.
+- **Aggregator:** First, set up the aggregator as shown in `start_here.py`.
+- **Generators:** The `start_here.py` database example gives an explanation of what Python generators are and why and.
+- **Samples:** The result contains a `Samples` object, which contains all samples of the non-linear search, which.
+- **Parameters:** The parameters are stored as a list of lists, where.
+- **Samples Info:** The samples info contains additional information on the samples, which depends on the non-linear.
+- **Figures of Merit:** The `Samples` class contains the log likelihood, log prior, log posterior and weight_list of every.
+- **Samples Summary:** The samples summary contains a subset of results access via the `Samples`, for example the maximum.
+- **Maximum Likelihood Model:** We can use the outputs to create a list of the maximum log likelihood model of each fit to our.
+- **Parameter Names:** Vectors return a lists of all model parameters, but do not tell us which values correspond to which.
+- **Instances:** We can use the `Aggregator` to create a list of instances of the model, using the Python class.
+- **Errors:** Methods for computing error estimates on all parameters are provided.
+- **Sample Instance:** A non-linear search retains every model that is accepted during the model-fit.
+- **Search Plots:** The Probability Density Functions (PDF's) of the results can be plotted using the non-linear search.
+- **Maximum Likelihood:** The maximum log likelihood value of the model-fit can be estimated by simple taking the maximum of.
+- **Bayesian Evidence:** Nested sampling algorithms like Nautilus also estimate the Bayesian evidence (estimated via the.
+- **Lists:** All results can alternatively be returned as a 1D list of values, by passing `as_instance=False`.
+- **Latex:** If you are writing modeling results up in a paper, you can use inbuilt latex tools to create latex.
+- **Ordering:** The default ordering of the results can be a bit random, as it depends on how the sqlite database.
+- **Samples Filtering:** The samples object has the results for all model parameter.
 
 __Samples via Result__
 

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -18,17 +18,17 @@ to illustrate the database in the database tutorials that follow.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Unique Identifiers:** Results output to hard-disk are contained in a folder named via a unique identifier (a random.
-**Dataset:** Load and plot the strong lens dataset.
-**Results From Hard Disk:** In this example, results will be first be written to hard-disk using the standard output directory.
-**Building a Database File From an Output Folder:** The fits above wrote the results to hard-disk in folders, not as an .sqlite database file.
-**Writing Directly To Database:** Results can be written directly to the .sqlite database file, skipping output to hard-disk.
-**Files:** When performing fits which output results to hard-disc, a `files` folder is created containing.
-**Generators:** Before using the aggregator to inspect results, lets discuss Python generators.
-**Search:** Configure the non-linear search used to fit the model.
-**Samples:** The `Samples` class contains all information on the non-linear search samples, for example the.
-**Wrap Up:** Summary of the script and next steps.
+- **Model:** Compose the lens model fitted to the data.
+- **Unique Identifiers:** Results output to hard-disk are contained in a folder named via a unique identifier (a random.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Results From Hard Disk:** In this example, results will be first be written to hard-disk using the standard output directory.
+- **Building a Database File From an Output Folder:** The fits above wrote the results to hard-disk in folders, not as an .sqlite database file.
+- **Writing Directly To Database:** Results can be written directly to the .sqlite database file, skipping output to hard-disk.
+- **Files:** When performing fits which output results to hard-disc, a `files` folder is created containing.
+- **Generators:** Before using the aggregator to inspect results, lets discuss Python generators.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Samples:** The `Samples` class contains all information on the non-linear search samples, for example the.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Model__
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -53,8 +53,8 @@ Each completed fit lives at a path like::
 
 __Contents__
 
-**Model Fit:** Run a quick fit once so both halves of this guide have a real result on disk to read from.
-**Info:** Print the result in a readable format.
+- **Model Fit:** Run a quick fit once so both halves of this guide have a real result on disk to read from.
+- **Info:** Print the result in a readable format.
 
 **Simple Loading (one fit at a time):**
 

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -19,21 +19,21 @@ The same initial fit creating results in a folder called `results_folder_csv_png
 
 __Contents__
 
-**Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
-**Database File:** The aggregator can also load results from a `.sqlite` database file.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
-**Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
-**Aggregator:** Set up the aggregator as shown in `start_here.py`.
-**Model Paths:** The paths are the tuples which define how model parameters are accessed from the model.
-**Adding CSV Columns:** We first make a simple .csv which contains two columns, corresponding to the inferred median PDF.
-**Saving the CSV:** We can now output the results of all our model-fits to the .csv file, using the `save` method.
-**Customizing CSV Headers:** The headers of the .csv file are by default the argument input above based on the model.
-**Maximum Likelihood Values:** We can also output the maximum likelihood values of each parameter to the .csv file, using the.
-**Errors:** We can also output PDF values at a given sigma confidence of each parameter to the .csv file, using.
-**Column Label List:** We can add a list of values to the .csv file, provided the list is the same length as the number of.
-**Latent Variables:** Latent variables are not free model parameters but can be derived from the model, and they are.
-**Computed Columns:** We can also add columns to the .csv file that are computed from the non-linear search samples (e.g.
+- **Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
+- **Database File:** The aggregator can also load results from a `.sqlite` database file.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
+- **Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
+- **Aggregator:** Set up the aggregator as shown in `start_here.py`.
+- **Model Paths:** The paths are the tuples which define how model parameters are accessed from the model.
+- **Adding CSV Columns:** We first make a simple .csv which contains two columns, corresponding to the inferred median PDF.
+- **Saving the CSV:** We can now output the results of all our model-fits to the .csv file, using the `save` method.
+- **Customizing CSV Headers:** The headers of the .csv file are by default the argument input above based on the model.
+- **Maximum Likelihood Values:** We can also output the maximum likelihood values of each parameter to the .csv file, using the.
+- **Errors:** We can also output PDF values at a given sigma confidence of each parameter to the .csv file, using.
+- **Column Label List:** We can add a list of values to the .csv file, provided the list is the same length as the number of.
+- **Latent Variables:** Latent variables are not free model parameters but can be derived from the model, and they are.
+- **Computed Columns:** We can also add columns to the .csv file that are computed from the non-linear search samples (e.g.
 
 __Interferometer__
 

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -31,20 +31,20 @@ The same initial fit creating results in a folder called `results_folder_csv_png
 
 __Contents__
 
-**Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
-**Database File:** The aggregator can also load results from a `.sqlite` database file.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
-**Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
-**Aggregator:** Set up the aggregator as shown in `start_here.py`.
-**Extract Images:** We now extract 2 images from the `fit.fits` file and combine them together into a single .fits file.
-**Output Single Fits:** The `image` object which has been extracted is an `astropy` `Fits` object, which we use to save the.
-**Output to Folder:** An alternative way to output the .fits files is to output them as single .fits files for each.
-**Naming Convention:** We require a naming convention for the output files.
-**CSV Files:** In the results `image` folder .csv files containing the information to visualize aspects of a.
-**Add Extra Fits:** We can also add an extra .fits image to the extracted .fits file, for example an RGB image of the.
-**Custom Fits Files in Analysis:** Describe how a user can extend the `Analysis` class to compute custom images that are output to the.
-**Path Navigation:** Example combinig `fit.fits` from `source_lp[1]` and `mass_total[0]`.
+- **Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
+- **Database File:** The aggregator can also load results from a `.sqlite` database file.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
+- **Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
+- **Aggregator:** Set up the aggregator as shown in `start_here.py`.
+- **Extract Images:** We now extract 2 images from the `fit.fits` file and combine them together into a single .fits file.
+- **Output Single Fits:** The `image` object which has been extracted is an `astropy` `Fits` object, which we use to save the.
+- **Output to Folder:** An alternative way to output the .fits files is to output them as single .fits files for each.
+- **Naming Convention:** We require a naming convention for the output files.
+- **CSV Files:** In the results `image` folder .csv files containing the information to visualize aspects of a.
+- **Add Extra Fits:** We can also add an extra .fits image to the extracted .fits file, for example an RGB image of the.
+- **Custom Fits Files in Analysis:** Describe how a user can extend the `Analysis` class to compute custom images that are output to the.
+- **Path Navigation:** Example combinig `fit.fits` from `source_lp[1]` and `mass_total[0]`.
 
 __Interferometer__
 

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -33,19 +33,19 @@ The same initial fit creating results in a folder called `results_folder_csv_png
 
 __Contents__
 
-**Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
-**Database File:** The aggregator can also load results from a `.sqlite` database file.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
-**Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
-**Aggregator:** Set up the aggregator as shown in `start_here.py`.
-**Extract Images:** We now extract 3 images from the `subplot_fit.png` file and make them together into a single image.
-**Output Single Png:** The `image` object which has been extracted is a `Image` object from the Python package `PIL`.
-**Output to Folder:** An alternative way to output the image is to output them as single .png files for each model-fit in.
-**Naming Convention:** We require a naming convention for the output files.
-**Combine Images From Subplots:** We now combine images from two different subplots into a single image, which we will save to the.
-**Custom Subplots in Analysis:** Describe how a user can extend the `Analysis` class to compute custom images that are output to the.
-**Path Navigation:** Example combinng `subplot_fit.png` from `source_lp[1]` and `mass_total[0]`.
+- **Interferometer:** This script can easily be adapted to analyse the results of charge injection imaging model-fits.
+- **Database File:** The aggregator can also load results from a `.sqlite` database file.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Unique Tag:** One thing to note is that the `unique_tag` of the search is given the name of the dataset with an.
+- **Workflow Paths:** The workflow examples are designed to take large libraries of results and distill them down to the.
+- **Aggregator:** Set up the aggregator as shown in `start_here.py`.
+- **Extract Images:** We now extract 3 images from the `subplot_fit.png` file and make them together into a single image.
+- **Output Single Png:** The `image` object which has been extracted is a `Image` object from the Python package `PIL`.
+- **Output to Folder:** An alternative way to output the image is to output them as single .png files for each model-fit in.
+- **Naming Convention:** We require a naming convention for the output files.
+- **Combine Images From Subplots:** We now combine images from two different subplots into a single image, which we will save to the.
+- **Custom Subplots in Analysis:** Describe how a user can extend the `Analysis` class to compute custom images that are output to the.
+- **Path Navigation:** Example combinng `subplot_fit.png` from `source_lp[1]` and `mass_total[0]`.
 
 __Interferometer__
 

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -13,25 +13,25 @@ briefly discusses visualization.
 
 __Contents__
 
-**Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
-**Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
-**Other Models:** This tutorial does not use a pixelized source reconstruction or linear light profiles, which have.
-**Grids:** To describe the deflection of light, **PyAutoLens** uses `Grid2D` data structures, which are.
-**Light Profiles:** We will ray-trace this `Grid2D`'s coordinates to calculate how the lens galaxy's mass deflects the.
-**Mass Profiles:** **PyAutoLens** uses `MassProfile` objects to represent a galaxy's mass distribution and perform.
-**Galaxies:** A `Galaxy` object is a collection of `LightProfile` and `MassProfile` objects at a given redshift.
-**Ray Tracing:** We can now create the image of the strong lens system!
-**Log10:** The light and masss distributions of galaxies are closer to a log10 distribution than a linear one.
-**Extending Objects:** The API has been designed such that all of the objects introduced above are extensible.
-**Attributes:** Printing individual attributes of the max log likelihood tracer gives us access to the inferred.
-**Lensing Quantities:** The maximum log likelihood tracer contains a lot of information about the inferred model.
-**Grid Choices:** We can input a different grid, which is not masked, to evaluate the image everywhere of interest.
-**Sub Gridding:** A grid can also have a sub-grid, defined via its `sub_size`, which defines how each pixel on the 2D.
-**Positions Grid:** We may want the image at specific (y,x) coordinates.
-**Scalar Lensing Quantities:** The tracer has many scalar lensing quantities, which are all returned using an `Array2D` and.
-**Vector Quantities:** Many lensing quantities are vectors.
-**Other Vector Lensing Quantities:** The tracer has other vector lensing quantities, which use the same interface described above.
-**Other Quantities:** Many more quantities are shown below.
+- **Units:** In this example, all quantities use the source code's internal unit coordinates, with spatial.
+- **Data Structures:** Arrays inspected in this example use bespoke data structures for storing arrays, grids, vectors and.
+- **Other Models:** This tutorial does not use a pixelized source reconstruction or linear light profiles, which have.
+- **Grids:** To describe the deflection of light, **PyAutoLens** uses `Grid2D` data structures, which are.
+- **Light Profiles:** We will ray-trace this `Grid2D`'s coordinates to calculate how the lens galaxy's mass deflects the.
+- **Mass Profiles:** **PyAutoLens** uses `MassProfile` objects to represent a galaxy's mass distribution and perform.
+- **Galaxies:** A `Galaxy` object is a collection of `LightProfile` and `MassProfile` objects at a given redshift.
+- **Ray Tracing:** We can now create the image of the strong lens system!
+- **Log10:** The light and masss distributions of galaxies are closer to a log10 distribution than a linear one.
+- **Extending Objects:** The API has been designed such that all of the objects introduced above are extensible.
+- **Attributes:** Printing individual attributes of the max log likelihood tracer gives us access to the inferred.
+- **Lensing Quantities:** The maximum log likelihood tracer contains a lot of information about the inferred model.
+- **Grid Choices:** We can input a different grid, which is not masked, to evaluate the image everywhere of interest.
+- **Sub Gridding:** A grid can also have a sub-grid, defined via its `sub_size`, which defines how each pixel on the 2D.
+- **Positions Grid:** We may want the image at specific (y,x) coordinates.
+- **Scalar Lensing Quantities:** The tracer has many scalar lensing quantities, which are all returned using an `Array2D` and.
+- **Vector Quantities:** Many lensing quantities are vectors.
+- **Other Vector Lensing Quantities:** The tracer has other vector lensing quantities, which use the same interface described above.
+- **Other Quantities:** Many more quantities are shown below.
 
 __Units__
 

--- a/scripts/guides/units/cosmology.py
+++ b/scripts/guides/units/cosmology.py
@@ -10,12 +10,12 @@ Mass or the effective radii of the galaxies in the lens model.
 
 __Contents__
 
-**Errors:** To produce errors on unit converted quantities, you`ll may need to perform marginalization over.
-**Tracer:** We set up a simple strong lens tracer and grid which will illustrate the unit conversion.
-**Arcsec to Kiloparsec:** The majority of distance quantities in **PyAutoLens** are in arcseconds, because this means that.
-**Einstein Radius:** Given a tracer, galaxy or mass profile we can compute its Einstein Radius, which is defined as the.
-**Einstein Mass:** The Einstein mass can also be computed from a tracer, galaxy or mass profile.
-**Convergence:** The `colorbar_convert_factor` and `colorbar_label` inputs above can also be used to convert the.
+- **Errors:** To produce errors on unit converted quantities, you`ll may need to perform marginalization over.
+- **Tracer:** We set up a simple strong lens tracer and grid which will illustrate the unit conversion.
+- **Arcsec to Kiloparsec:** The majority of distance quantities in **PyAutoLens** are in arcseconds, because this means that.
+- **Einstein Radius:** Given a tracer, galaxy or mass profile we can compute its Einstein Radius, which is defined as the.
+- **Einstein Mass:** The Einstein mass can also be computed from a tracer, galaxy or mass profile.
+- **Convergence:** The `colorbar_convert_factor` and `colorbar_label` inputs above can also be used to convert the.
 
 __Errors__
 

--- a/scripts/guides/units/flux.py
+++ b/scripts/guides/units/flux.py
@@ -23,8 +23,8 @@ unit, like a solar luminosity or AB magnitude, it becomes a lot more straightfor
 
 __Contents__
 
-**Zero Point:** In astronomy, a zero point refers to a reference value used in photometry and spectroscopy to.
-**Total Flux:** A key quantity for computing the magnitudes of galaxies is the total flux of a light profile.
+- **Zero Point:** In astronomy, a zero point refers to a reference value used in photometry and spectroscopy to.
+- **Total Flux:** A key quantity for computing the magnitudes of galaxies is the total flux of a light profile.
 
 __Zero Point__
 

--- a/scripts/imaging/data_preparation/examples/data.py
+++ b/scripts/imaging/data_preparation/examples/data.py
@@ -8,11 +8,11 @@ This tutorial describes preprocessing your dataset`s image to adhere to the unit
 
 __Contents__
 
-**Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
-**Loading Data From Individual Fits Files:** Loading an image from FITS files and inspecting its standards.
-**Converting Data To Electrons Per Second:** Converting image flux units between electrons per second, counts and ADUs.
-**Resizing Data:** Trimming or padding a large postage stamp to an appropriate size.
-**Background Subtraction:** Overview of background sky subtraction tools and modeling approaches.
+- **Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
+- **Loading Data From Individual Fits Files:** Loading an image from FITS files and inspecting its standards.
+- **Converting Data To Electrons Per Second:** Converting image flux units between electrons per second, counts and ADUs.
+- **Resizing Data:** Trimming or padding a large postage stamp to an appropriate size.
+- **Background Subtraction:** Overview of background sky subtraction tools and modeling approaches.
 
 __Pixel Scale__
 

--- a/scripts/imaging/data_preparation/examples/noise_map.py
+++ b/scripts/imaging/data_preparation/examples/noise_map.py
@@ -12,10 +12,10 @@ by **PyAutoLens**.
 
 __Contents__
 
-**Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
-**Loading Data From Individual Fits Files:** Loading a noise-map from FITS files and inspecting its standards.
-**1) Tools Illustrated In Image:** Overview of unit conversion and resizing tools from the image preparation script.
-**Noise Conversions:** Functions for computing noise-maps from various input formats.
+- **Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
+- **Loading Data From Individual Fits Files:** Loading a noise-map from FITS files and inspecting its standards.
+- **1) Tools Illustrated In Image:** Overview of unit conversion and resizing tools from the image preparation script.
+- **Noise Conversions:** Functions for computing noise-maps from various input formats.
 
 __Pixel Scale__
 

--- a/scripts/imaging/data_preparation/examples/optional/extra_galaxies_centres.py
+++ b/scripts/imaging/data_preparation/examples/optional/extra_galaxies_centres.py
@@ -17,8 +17,8 @@ centres of every object we'll model as an extra galaxy. A GUI is also available 
 
 __Contents__
 
-**Masking Extra Galaxies:** The example `mask_extra_galaxies.py` masks the regions of an image where extra galaxies are present.
-**Output:** Save this as a .png image in the dataset folder for easy inspection later.
+- **Masking Extra Galaxies:** The example `mask_extra_galaxies.py` masks the regions of an image where extra galaxies are present.
+- **Output:** Save this as a .png image in the dataset folder for easy inspection later.
 
 __Masking Extra Galaxies__
 

--- a/scripts/imaging/data_preparation/examples/optional/mask_extra_galaxies.py
+++ b/scripts/imaging/data_preparation/examples/optional/mask_extra_galaxies.py
@@ -31,7 +31,7 @@ the extra galaxies mask.
 
 __Contents__
 
-**Output:** Output to a .png file for easy inspection.
+- **Output:** Output to a .png file for easy inspection.
 
 __Start Here Notebook__
 

--- a/scripts/imaging/data_preparation/examples/psf.py
+++ b/scripts/imaging/data_preparation/examples/psf.py
@@ -12,10 +12,10 @@ This tutorial describes preprocessing your dataset`s psf to adhere to the units 
 
 __Contents__
 
-**Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
-**Loading Data From Individual Fits Files:** Load a PSF from .fits files (a format commonly used by Astronomers) via the `Array2D` object.
-**PSF Dimensions:** The PSF dimensions must be odd x odd (e.g.
-**PSF Normalization:** The PSF should also be normalized to unity.
+- **Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
+- **Loading Data From Individual Fits Files:** Load a PSF from .fits files (a format commonly used by Astronomers) via the `Array2D` object.
+- **PSF Dimensions:** The PSF dimensions must be odd x odd (e.g.
+- **PSF Normalization:** The PSF should also be normalized to unity.
 
 __Pixel Scale__
 

--- a/scripts/imaging/data_preparation/gui/extra_galaxies_centres.py
+++ b/scripts/imaging/data_preparation/gui/extra_galaxies_centres.py
@@ -14,10 +14,10 @@ above which requires you to input these values manually.
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
-**Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
-**Output:** Now lets plot the image and extra galaxy centres, so we can check that the centre overlaps the.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
+- **Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
+- **Output:** Now lets plot the image and extra galaxy centres, so we can check that the centre overlaps the.
 
 """
 

--- a/scripts/imaging/data_preparation/gui/lens_light_centre.py
+++ b/scripts/imaging/data_preparation/gui/lens_light_centre.py
@@ -7,10 +7,10 @@ value in pipelines.
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
-**Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
-**Output:** Now lets plot the image and lens light centres, so we can check that the centre overlaps the.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
+- **Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
+- **Output:** Now lets plot the image and lens light centres, so we can check that the centre overlaps the.
 
 """
 

--- a/scripts/imaging/data_preparation/gui/mask.py
+++ b/scripts/imaging/data_preparation/gui/mask.py
@@ -10,9 +10,9 @@ This GUI is adapted from the following code: https://gist.github.com/brikeats/4f
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Scribbler:** Load the Scribbler GUI for drawing the mask.
-**Output:** Now lets plot the image and mask, so we can check that the mask includes the regions of the image.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Scribbler:** Load the Scribbler GUI for drawing the mask.
+- **Output:** Now lets plot the image and mask, so we can check that the mask includes the regions of the image.
 
 """
 

--- a/scripts/imaging/data_preparation/gui/mask_extra_galaxies.py
+++ b/scripts/imaging/data_preparation/gui/mask_extra_galaxies.py
@@ -15,9 +15,9 @@ example above which requires you to input these values manually.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Scribbler:** Load the Scribbler GUI for spray painting the scaled regions of the dataset.
-**Output:** The new image is plotted for inspection.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Scribbler:** Load the Scribbler GUI for spray painting the scaled regions of the dataset.
+- **Output:** The new image is plotted for inspection.
 
 """
 

--- a/scripts/imaging/data_preparation/gui/positions.py
+++ b/scripts/imaging/data_preparation/gui/positions.py
@@ -9,10 +9,10 @@ This GUI is adapted from the following code: https://gist.github.com/brikeats/4f
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
-**Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
-**Output:** Now lets plot the image and positions,, so we can check that the positions overlap the brightest.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Search Box:** When you click on a pixel to mark a position, the search box looks around this click and finds the.
+- **Clicker:** Set up the `Clicker` object from the `clicker.py` module, which monitors your mouse clicks in order.
+- **Output:** Now lets plot the image and positions,, so we can check that the positions overlap the brightest.
 
 """
 

--- a/scripts/imaging/data_preparation/start_here.py
+++ b/scripts/imaging/data_preparation/start_here.py
@@ -8,11 +8,11 @@ you prepare your dataset to adhere to them if it does not already.
 
 __Contents__
 
-**Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
-**Image:** The image is the image of your strong lens, which comes from a telescope like the Hubble Space.
-**Noise Map:** The noise-map defines the uncertainty in every pixel of your strong lens image, where values are.
-**PSF:** The Point Spread Function (PSF) describes blurring due the optics of your dataset`s telescope.
-**Data Processing Complete:** If your image, noise-map and PSF conform the standards above, you are ready to analyse your dataset!
+- **Pixel Scale:** The "pixel_scale" of the image (and the data in general) is pixel-units to arcsecond-units.
+- **Image:** The image is the image of your strong lens, which comes from a telescope like the Hubble Space.
+- **Noise Map:** The noise-map defines the uncertainty in every pixel of your strong lens image, where values are.
+- **PSF:** The Point Spread Function (PSF) describes blurring due the optics of your dataset`s telescope.
+- **Data Processing Complete:** If your image, noise-map and PSF conform the standards above, you are ready to analyse your dataset!
 
 __Pixel Scale__
 

--- a/scripts/imaging/features/advanced/double_einstein_ring/chaining.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/chaining.py
@@ -33,18 +33,18 @@ of the second source from the model-fit. A larger mask included both sources is 
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens `Imaging` dataset.
-**Paths:** The path the results of all chained searches are output.
-**Masking (Search 1):** We apply a smaller circular mask, the radius of which is chosen to remove the light of the second source galaxy.
-**Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` and the first source galaxy's light is an MGE.
-**Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
-**Masking (Search 2):** We apply a larger circular mask which includes the light of both source galaxies.
-**Model (Search 2):** Search 2 fits the lens, first and second source galaxies, where the first source's mass is an `IsothermalSph` and the second source is an MGE.
-**Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 2):** The final results of the chained model-fit.
-**Wrap Up:** Summary of the script and next steps.
-**Pipelines:** Advanced search chaining uses `pipelines` that chain together multiple searches to perform complex lens modeling in a robust and efficient way.
+- **Dataset:** Load and plot the strong lens `Imaging` dataset.
+- **Paths:** The path the results of all chained searches are output.
+- **Masking (Search 1):** We apply a smaller circular mask, the radius of which is chosen to remove the light of the second source galaxy.
+- **Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` and the first source galaxy's light is an MGE.
+- **Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
+- **Masking (Search 2):** We apply a larger circular mask which includes the light of both source galaxies.
+- **Model (Search 2):** Search 2 fits the lens, first and second source galaxies, where the first source's mass is an `IsothermalSph` and the second source is an MGE.
+- **Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 2):** The final results of the chained model-fit.
+- **Wrap Up:** Summary of the script and next steps.
+- **Pipelines:** Advanced search chaining uses `pipelines` that chain together multiple searches to perform complex lens modeling in a robust and efficient way.
 
 __Start Here Notebook__
 

--- a/scripts/imaging/features/advanced/double_einstein_ring/modeling.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/modeling.py
@@ -13,18 +13,18 @@ This script illustrates the PyAutoLens API for modeling a double Einstein ring l
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Cheating:** Initializing a double Einstein ring lens model is difficult, due to the complexity of parameter.
-**Cosmology:** Double Einstein rings allow cosmological parameters to be constrained, because they provide.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Cheating:** Initializing a double Einstein ring lens model is difficult, due to the complexity of parameter.
+- **Cosmology:** Double Einstein rings allow cosmological parameters to be constrained, because they provide.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/double_einstein_ring/simulator.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/simulator.py
@@ -11,13 +11,13 @@ and other script to illustrate how to model these systems correctly.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/los_halos/simulator.py
+++ b/scripts/imaging/features/advanced/los_halos/simulator.py
@@ -16,19 +16,19 @@ all halos, so that only the *fluctuations* above the mean affect the lensing.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The simulated dataset is output to the ``dataset/imaging/los_halos`` folder.
-**Grid:** Define the 2D grid on which the image is evaluated and simulated.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**PSF:** A Gaussian PSF models the telescope optics.
-**Simulator:** The simulator defines the exposure time, PSF, background sky level, and noise properties.
-**LOS Configuration:** Parameters controlling the line-of-sight halo population.
-**Sample LOS Halos:** The ``LOSSampler`` handles the full pipeline.
-**Ray Tracing:** Define the main lens galaxy and source galaxy, then combine with the LOS galaxies to create a.
-**Output:** Output the simulated dataset to .fits files.
-**Visualize:** Output subplots and summary images as .png files for quick inspection.
-**Tracer json:** Save the tracer as a .json file for reproducibility.
-**LOS Diagnostics:** Save the LOS halo sample list and negative sheet values for post-simulation analysis.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The simulated dataset is output to the ``dataset/imaging/los_halos`` folder.
+- **Grid:** Define the 2D grid on which the image is evaluated and simulated.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **PSF:** A Gaussian PSF models the telescope optics.
+- **Simulator:** The simulator defines the exposure time, PSF, background sky level, and noise properties.
+- **LOS Configuration:** Parameters controlling the line-of-sight halo population.
+- **Sample LOS Halos:** The ``LOSSampler`` handles the full pipeline.
+- **Ray Tracing:** Define the main lens galaxy and source galaxy, then combine with the LOS galaxies to create a.
+- **Output:** Output the simulated dataset to .fits files.
+- **Visualize:** Output subplots and summary images as .png files for quick inspection.
+- **Tracer json:** Save the tracer as a .json file for reproducibility.
+- **LOS Diagnostics:** Save the LOS halo sample list and negative sheet values for post-simulation analysis.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/mass_stellar_dark/chaining.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/chaining.py
@@ -33,16 +33,16 @@ provides the following benefits:
 
 __Contents__
 
-**Dataset + Masking:** Load, plot and mask the `Imaging` data.
-**Paths:** The path the results of all chained searches are output.
-**Model (Search 1):** Search 1 fits a lens model where the lens galaxy's light is an MGE bulge and the lens galaxy's mass and source galaxy are omitted.
-**Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
-**Model (Search 2):** Search 2 fits the lens galaxy's mass using a stellar mass distribution initialized from the bulge light model inferred by search 1, alongside a dark matter profile.
-**Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using this model.
-**Result (Search 2):** The final results of the chained model-fit.
-**Wrap Up:** In this example, we passed a bulge lens light model to a decomposed stellar + dark matter mass model.
-**SLaM (Source, Light and Mass):** An even more advanced approach which uses search chaining are the SLaM pipelines, which break the lens modeling processing into a series of fits.
+- **Dataset + Masking:** Load, plot and mask the `Imaging` data.
+- **Paths:** The path the results of all chained searches are output.
+- **Model (Search 1):** Search 1 fits a lens model where the lens galaxy's light is an MGE bulge and the lens galaxy's mass and source galaxy are omitted.
+- **Search + Analysis + Model-Fit (Search 1):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 1):** The results which are used for prior passing are summarised in the `info` attribute.
+- **Model (Search 2):** Search 2 fits the lens galaxy's mass using a stellar mass distribution initialized from the bulge light model inferred by search 1, alongside a dark matter profile.
+- **Search + Analysis + Model-Fit (Search 2):** We now create the non-linear search, analysis and perform the model-fit using this model.
+- **Result (Search 2):** The final results of the chained model-fit.
+- **Wrap Up:** In this example, we passed a bulge lens light model to a decomposed stellar + dark matter mass model.
+- **SLaM (Source, Light and Mass):** An even more advanced approach which uses search chaining are the SLaM pipelines, which break the lens modeling processing into a series of fits.
 
 __Start Here Notebook__
 

--- a/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
@@ -9,17 +9,17 @@ This script fits a mass model which decomposes the lens galaxy's mass into its s
 
 __Contents__
 
-**Advantages & Disadvantages:** Decomposed mass models measure direct properties of the stars and dark matter, for example the.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** Decomposed mass models measure direct properties of the stars and dark matter, for example the.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/advanced/mass_stellar_dark/simulator.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/simulator.py
@@ -13,13 +13,13 @@ where a discussion of the advantages and disadvantages of fitting decomposed mas
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/slam.py
@@ -10,17 +10,17 @@ MASS LIGHT DARK PIPELINE.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
-**MASS LIGHT DARK PIPELINE:** The MASS LIGHT DARK PIPELINE fits a mass model where the stellar mass is tied to the lens light.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
+- **MASS LIGHT DARK PIPELINE:** The MASS LIGHT DARK PIPELINE fits a mass model where the stellar mass is tied to the lens light.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/operated_light_profile/modeling.py
+++ b/scripts/imaging/features/advanced/operated_light_profile/modeling.py
@@ -23,17 +23,17 @@ required fitting other components of a galaxy without convolution they could be 
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Fit:** Fit the lens model to the dataset.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Model:** Compose the lens model fitted to the data.
+- **Fit:** Fit the lens model to the dataset.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/operated_light_profile/simulator.py
+++ b/scripts/imaging/features/advanced/operated_light_profile/simulator.py
@@ -18,13 +18,13 @@ emission using an operated light profile.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/shapelets/fit.py
+++ b/scripts/imaging/features/advanced/shapelets/fit.py
@@ -19,18 +19,18 @@ feature).
 
 __Contents__
 
-**Advantages & Disadvantages:** Symmetric light profiles (e.g.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Basis:** We first build a `Basis`, which is built from multiple light profiles (in this case, shapelets).
-**Coefficients:** The `Basis` is composed of many shapelets, each with different coefficients (n and m) values and a.
-**Linear Light Profiles:** We now show Composing a basis of multiple shapelets and use them to fit the source galaxy's light.
-**Fit:** Fit the lens model to the dataset.
-**Positive Negative Solver:** In other examples which use linear algebra to fit the data, for example linear light profiles, the.
-**Intensities:** The fit contains the solved for intensity values.
-**Shapelet Cartesian:** The shapelets above were defined on a polar grid, which is suitable for modeling radially symmetric.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** Symmetric light profiles (e.g.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Basis:** We first build a `Basis`, which is built from multiple light profiles (in this case, shapelets).
+- **Coefficients:** The `Basis` is composed of many shapelets, each with different coefficients (n and m) values and a.
+- **Linear Light Profiles:** We now show Composing a basis of multiple shapelets and use them to fit the source galaxy's light.
+- **Fit:** Fit the lens model to the dataset.
+- **Positive Negative Solver:** In other examples which use linear algebra to fit the data, for example linear light profiles, the.
+- **Intensities:** The fit contains the solved for intensity values.
+- **Shapelet Cartesian:** The shapelets above were defined on a polar grid, which is suitable for modeling radially symmetric.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/advanced/shapelets/modeling.py
+++ b/scripts/imaging/features/advanced/shapelets/modeling.py
@@ -19,25 +19,25 @@ feature).
 
 __Contents__
 
-**Advantages & Disadvantages:** Symmetric light profiles (e.g.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Positive Negative Solver:** In other examples which use linear algebra to fit the data, for example linear light profiles, the.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
-**Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Shapelet Cartesian:** The shapelets above were defined on a polar grid, which is suitable for modeling radially symmetric.
-**Cartesian Shapelets:** Overview of cartesian shapelets for this example.
-**Fit:** Fit the lens model to the dataset.
-**Lens Shapelets:** A model where the lens is modeled as shapelets can be composed and fitted as shown below.
-**Regularization:** There is one downside to `Basis` functions, we may compose a model with too much freedom.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** Symmetric light profiles (e.g.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Positive Negative Solver:** In other examples which use linear algebra to fit the data, for example linear light profiles, the.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
+- **Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Shapelet Cartesian:** The shapelets above were defined on a polar grid, which is suitable for modeling radially symmetric.
+- **Cartesian Shapelets:** Overview of cartesian shapelets for this example.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Shapelets:** A model where the lens is modeled as shapelets can be composed and fitted as shown below.
+- **Regularization:** There is one downside to `Basis` functions, we may compose a model with too much freedom.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/advanced/sky_background/fit.py
+++ b/scripts/imaging/features/advanced/sky_background/fit.py
@@ -21,11 +21,11 @@ a non-linear free parameter (e.g. an extra dimension in the non-linear parameter
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fit:** Fit the lens model to the dataset.
-**Wrap Up:** Summary of the script and next steps.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fit:** Fit the lens model to the dataset.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/sky_background/modeling.py
+++ b/scripts/imaging/features/advanced/sky_background/modeling.py
@@ -21,15 +21,15 @@ a non-linear free parameter (e.g. an extra dimension in the non-linear parameter
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/sky_background/simulator.py
+++ b/scripts/imaging/features/advanced/sky_background/simulator.py
@@ -10,13 +10,13 @@ the `autolens_workspace/*/modeling/features/sky_background.py` example.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/subhalo/detect/database.py
+++ b/scripts/imaging/features/advanced/subhalo/detect/database.py
@@ -14,11 +14,11 @@ can also write results directly to the database during the fit by using a sessio
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Start Here Notebooks:** You should be familiar with dark matter subhalo detection, by reading the example.
-**Grid Searches:** If the results of the database include a grid search of non-linear searches, the aggregator has a.
-**Grid Search Visualization:** The grid search visualization tools can also be used to plot the results of the grid search.
-**Best Fit:** We can retrieve a new aggregator containing only the maximum log evidence results of the grid.
+- **Model:** Compose the lens model fitted to the data.
+- **Start Here Notebooks:** You should be familiar with dark matter subhalo detection, by reading the example.
+- **Grid Searches:** If the results of the database include a grid search of non-linear searches, the aggregator has a.
+- **Grid Search Visualization:** The grid search visualization tools can also be used to plot the results of the grid search.
+- **Best Fit:** We can retrieve a new aggregator containing only the maximum log evidence results of the grid.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/subhalo/detect/start_here.py
+++ b/scripts/imaging/features/advanced/subhalo/detect/start_here.py
@@ -15,22 +15,22 @@ The example illustrates DM subhalo detection with **PyAutoLens**.
 
 __Contents__
 
-**SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
-**Grid Search:** The second stage of the SUBHALO PIPELINE uses a grid-search of non-linear searches to determine the.
-**Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
-**Bayesian Evidence:** To determine if a DM subhalo was detected by the pipeline, we can compare the log of the Bayesian.
-**Log Likelihood:** Different metrics can be used to inspect whether a DM subhalo was detected.
-**Grid Search Result:** The grid search results have attributes which can be used to inspect the results of the DM subhalo.
+- **SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
+- **Grid Search:** The second stage of the SUBHALO PIPELINE uses a grid-search of non-linear searches to determine the.
+- **Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Bayesian Evidence:** To determine if a DM subhalo was detected by the pipeline, we can compare the log of the Bayesian.
+- **Log Likelihood:** Different metrics can be used to inspect whether a DM subhalo was detected.
+- **Grid Search Result:** The grid search results have attributes which can be used to inspect the results of the DM subhalo.
 
 __SLaM Pipelines__
 

--- a/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.py
+++ b/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_parametric.py
@@ -7,16 +7,16 @@ using light profiles.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens mass uses an `Isothermal` with its centre fixed.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
-**Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
-**Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens mass uses an `Isothermal` with its centre fixed.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
+- **Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
+- **Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.py
+++ b/scripts/imaging/features/advanced/subhalo/sensitivity/slam_source_pixelized.py
@@ -11,19 +11,19 @@ morphologies of real source galaxies.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens mass uses an `Isothermal` with its centre fixed.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
-**Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
-**Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens mass uses an `Isothermal` with its centre fixed.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
+- **Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
+- **Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Model__
 

--- a/scripts/imaging/features/advanced/subhalo/sensitivity/start_here.py
+++ b/scripts/imaging/features/advanced/subhalo/sensitivity/start_here.py
@@ -20,19 +20,19 @@ with different parameters.
 
 __Contents__
 
-**Subhalo Detection Discussion:** For strong lensing, this process is crucial for dark matter substructure detection, as discussed in.
-**Subhalo Sensitivity Mapping:** Sensitivity mapping is a process where we simulate many thousands of strong lens images.
-**SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
-**Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
-**Base Model:** We now define the `base_model` that we use to perform sensitivity mapping.
-**Perturb Model:** We now define the `perturb_model`, which is the model component whose parameters we iterate over to.
-**Mapping Grid:** Sensitivity mapping is typically performed over a large range of parameters.
-**Perturb Model Prior Func:** The default priors on the `perturb_model` are `UniformPrior`'s bounded around each sensitivity grid.
-**Simulation Instance:** We are performing sensitivity mapping to determine where a subhalo is detectable.
-**Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
-**Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
-**Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
-**Results:** You should now look at the results of the sensitivity mapping in the folder.
+- **Subhalo Detection Discussion:** For strong lensing, this process is crucial for dark matter substructure detection, as discussed in.
+- **Subhalo Sensitivity Mapping:** Sensitivity mapping is a process where we simulate many thousands of strong lens images.
+- **SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
+- **Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
+- **Base Model:** We now define the `base_model` that we use to perform sensitivity mapping.
+- **Perturb Model:** We now define the `perturb_model`, which is the model component whose parameters we iterate over to.
+- **Mapping Grid:** Sensitivity mapping is typically performed over a large range of parameters.
+- **Perturb Model Prior Func:** The default priors on the `perturb_model` are `UniformPrior`'s bounded around each sensitivity grid.
+- **Simulation Instance:** We are performing sensitivity mapping to determine where a subhalo is detectable.
+- **Simulate Function Class:** We now write the `simulate_cls`, which takes the `simulation_instance` of our model (defined above).
+- **Base Fit:** We have defined a `Simulate` class that will be used to simulate every dataset simulated by the.
+- **Perturb Fit:** We now define a `PerturbFit` class, which defines how the `perturb_model` is fitted to each.
+- **Results:** You should now look at the results of the sensitivity mapping in the folder.
 
 __Subhalo Detection Discussion__
 

--- a/scripts/imaging/features/advanced/subhalo/simulator.py
+++ b/scripts/imaging/features/advanced/subhalo/simulator.py
@@ -11,15 +11,15 @@ This is used in `advanced/subhalo` to illustrate how to fit a lens model which i
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Subhalo Difference Image:** An informative way to visualize the effect of a subhalo on a strong lens is to subtract the.
-**No Lens Light:** The code below simulates the same lens, but without a lens light component.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Subhalo Difference Image:** An informative way to visualize the effect of a subhalo on a strong lens is to subtract the.
+- **No Lens Light:** The code below simulates the same lens, but without a lens light component.
 
 __Model__
 

--- a/scripts/imaging/features/extra_galaxies/modeling.py
+++ b/scripts/imaging/features/extra_galaxies/modeling.py
@@ -20,20 +20,20 @@ best approach to take.
 
 __Contents__
 
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Extra Galaxies Over Sampling:** Over sampling is a numerical technique where the images of light profiles and galaxies are.
-**Extra Galaxies Noise Scaling:** To prevent extra galaxies from impacting the model-fit, we do not mask them entirely from the fit.
-**Extra Galaxies Dataset:** We are now going to model the dataset with extra galaxies included in the model, where these.
-**Extra Galaxies Centres:** To set up a lens model including each extra galaxy with light and / or mass profile, we input.
-**Model:** Compose the lens model fitted to the data.
-**Extra Galaxies Model:** We now use the modeling API to create the model for the extra galaxies.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Approaches to Extra Galaxies:** We illustrated two extremes of how to prevent the emission of extra galaxies impacting the.
-**Scaling Relations:** The modeling API has full support for composing the extra galaxies such that their light and or.
-**Wrap Up:** Summary of the script and next steps.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Extra Galaxies Over Sampling:** Over sampling is a numerical technique where the images of light profiles and galaxies are.
+- **Extra Galaxies Noise Scaling:** To prevent extra galaxies from impacting the model-fit, we do not mask them entirely from the fit.
+- **Extra Galaxies Dataset:** We are now going to model the dataset with extra galaxies included in the model, where these.
+- **Extra Galaxies Centres:** To set up a lens model including each extra galaxy with light and / or mass profile, we input.
+- **Model:** Compose the lens model fitted to the data.
+- **Extra Galaxies Model:** We now use the modeling API to create the model for the extra galaxies.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Approaches to Extra Galaxies:** We illustrated two extremes of how to prevent the emission of extra galaxies impacting the.
+- **Scaling Relations:** The modeling API has full support for composing the extra galaxies such that their light and or.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Data Preparation__
 

--- a/scripts/imaging/features/extra_galaxies/simulator.py
+++ b/scripts/imaging/features/extra_galaxies/simulator.py
@@ -19,17 +19,17 @@ galaxies. This is used to illustrate the extra galaxies API in the script above.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Other Scripts:** This dataset is used in the following scripts.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Galaxies:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Extra Galaxies:** Includes two extra galaxies, which must be modeled or masked to ensure they do not impact the fit.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Mask Extra Galaxies:** Building and saving `mask_extra_galaxies.fits` so consumers can load it directly.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Multiple Images:** Output the multiple image positions of the source galaxy which can help with lens modeling.
+- **Model:** Compose the lens model fitted to the data.
+- **Other Scripts:** This dataset is used in the following scripts.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Galaxies:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Extra Galaxies:** Includes two extra galaxies, which must be modeled or masked to ensure they do not impact the fit.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Mask Extra Galaxies:** Building and saving `mask_extra_galaxies.fits` so consumers can load it directly.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Multiple Images:** Output the multiple image positions of the source galaxy which can help with lens modeling.
 
 __Model__
 

--- a/scripts/imaging/features/extra_galaxies/slam.py
+++ b/scripts/imaging/features/extra_galaxies/slam.py
@@ -10,20 +10,20 @@ only documents how the pipeline differs from that reference.
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Group SLaM:** This pipeline is designed for the galaxy-scale regime with a small number of nearby extra galaxies.
-**This Script:** Using SOURCE LP, SOURCE PIX, LIGHT LP and MASS TOTAL pipelines this script fits `Imaging` data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except each extra galaxy is included in the model with a.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except extra-galaxy light is fixed from `source_lp` and their.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except extra galaxies are fully fixed as instances from.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except extra-galaxy mass is fixed from `source_pix[1]` and their.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except extra-galaxy light is fixed from `light[1]` and their.
-**Dataset:** Load and plot the strong lens dataset.
-**Extra Galaxies Centres:** The centres of the extra galaxies are loaded from a `.json` file and used to set up the light and.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Group SLaM:** This pipeline is designed for the galaxy-scale regime with a small number of nearby extra galaxies.
+- **This Script:** Using SOURCE LP, SOURCE PIX, LIGHT LP and MASS TOTAL pipelines this script fits `Imaging` data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except each extra galaxy is included in the model with a.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except extra-galaxy light is fixed from `source_lp` and their.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except extra galaxies are fully fixed as instances from.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except extra-galaxy mass is fixed from `source_pix[1]` and their.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except extra-galaxy light is fixed from `light[1]` and their.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Extra Galaxies Centres:** The centres of the extra galaxies are loaded from a `.json` file and used to set up the light and.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/linear_light_profiles/fit.py
+++ b/scripts/imaging/features/linear_light_profiles/fit.py
@@ -12,16 +12,16 @@ light profiles!
 
 __Contents__
 
-**Advantages & Disadvantages:** Each light profile's `intensity` parameter is therefore not a free parameter in the model-fit.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Model:** Compose the lens model fitted to the data.
-**Notes:** This script is identical to `modeling/start_here.py` except that the light profiles are switched to.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fit:** Fit the lens model to the dataset.
-**Intensities:** The fit contains the solved for intensity values.
-**Visualization:** Linear light profiles and objects containing them (e.g.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** Each light profile's `intensity` parameter is therefore not a free parameter in the model-fit.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model fitted to the data.
+- **Notes:** This script is identical to `modeling/start_here.py` except that the light profiles are switched to.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fit:** Fit the lens model to the dataset.
+- **Intensities:** The fit contains the solved for intensity values.
+- **Visualization:** Linear light profiles and objects containing them (e.g.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/imaging/features/linear_light_profiles/likelihood_function.py
@@ -21,21 +21,21 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Prerequisites:** The likelihood function of a linear light profile builds on that used for standard light profiles.
-**Dataset:** Load and plot the strong lens dataset.
-**Masked Image Grid:** To perform galaxy calculations we used a 2D image-plane grid of (y,x) coordinates, which evaluated.
-**Linear Light Profiles:** To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the.
-**LightProfileLinearObjFuncList:** For standard light profiles, we combined our linear light profiles into a single `Galaxies` object.
-**Mapping Matrix:** The `mapping_matrix` is a matrix where each column is an image of each linear light profiles.
-**Combining Matrices:** The linear algebra system solves for all light profile `intensity` values at once, so we need to.
-**Image Reconstruction:** Using the reconstructed `intensity` values we can map the reconstruction back to the image plane.
-**Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Prerequisites:** The likelihood function of a linear light profile builds on that used for standard light profiles.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Masked Image Grid:** To perform galaxy calculations we used a 2D image-plane grid of (y,x) coordinates, which evaluated.
+- **Linear Light Profiles:** To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the.
+- **LightProfileLinearObjFuncList:** For standard light profiles, we combined our linear light profiles into a single `Galaxies` object.
+- **Mapping Matrix:** The `mapping_matrix` is a matrix where each column is an image of each linear light profiles.
+- **Combining Matrices:** The linear algebra system solves for all light profile `intensity` values at once, so we need to.
+- **Image Reconstruction:** Using the reconstructed `intensity` values we can map the reconstruction back to the image plane.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -12,22 +12,22 @@ light profiles!
 
 __Contents__
 
-**Advantages & Disadvantages:** Each light profile's `intensity` parameter is therefore not a free parameter in the model-fit.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Model:** Compose the lens model fitted to the data.
-**Notes:** This script is identical to `modeling/start_here.py` except that the light profiles are switched to.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Intensities:** The intensities of linear light profiles are not a part of the model parameterization and therefore.
-**Visualization:** Linear light profiles and objects containing them (e.g.
-**Wrap Up:** Summary of the script and next steps.
-**Max Likelihood Inversion:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_fit`, which contains.
+- **Advantages & Disadvantages:** Each light profile's `intensity` parameter is therefore not a free parameter in the model-fit.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model fitted to the data.
+- **Notes:** This script is identical to `modeling/start_here.py` except that the light profiles are switched to.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Intensities:** The intensities of linear light profiles are not a part of the model parameterization and therefore.
+- **Visualization:** Linear light profiles and objects containing them (e.g.
+- **Wrap Up:** Summary of the script and next steps.
+- **Max Likelihood Inversion:** As seen elsewhere in the workspace, the result contains a `max_log_likelihood_fit`, which contains.
 
 __Advantages__
 

--- a/scripts/imaging/features/linear_light_profiles/slam.py
+++ b/scripts/imaging/features/linear_light_profiles/slam.py
@@ -20,17 +20,17 @@ in more reliable and faster inference.
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except the lens galaxy's bulge uses a linear `Sersic` light.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/fit.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/fit.py
@@ -12,18 +12,18 @@ profiles like the `Sersic`.
 
 __Contents__
 
-**Advantages & Disadvantages:** Symmetric light profiles (e.g.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**MGE Source Galaxy:** The MGE was designed to model the light of lens galaxies, because they are typically elliptical.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Basis:** We first build a `Basis`, which is built from multiple light profiles (in this case, Gaussians).
-**Gaussians:** The `Basis` is composed of many Gaussians, each with different sizes (the `sigma` value) and.
-**Linear Light Profiles:** We now show Composing a basis of multiple Gaussians and use them to fit the lens galaxy's light in.
-**Fit:** Fit the lens model to the dataset.
-**Intensities:** The fit contains the solved for intensity values.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** Symmetric light profiles (e.g.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **MGE Source Galaxy:** The MGE was designed to model the light of lens galaxies, because they are typically elliptical.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Basis:** We first build a `Basis`, which is built from multiple light profiles (in this case, Gaussians).
+- **Gaussians:** The `Basis` is composed of many Gaussians, each with different sizes (the `sigma` value) and.
+- **Linear Light Profiles:** We now show Composing a basis of multiple Gaussians and use them to fit the lens galaxy's light in.
+- **Fit:** Fit the lens model to the dataset.
+- **Intensities:** The fit contains the solved for intensity values.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -19,23 +19,23 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Prerequisites:** The likelihood function of a multi Gaussian expansion builds on that used for standard light.
-**Dataset:** Load and plot the strong lens dataset.
-**Masked Image Grid:** To perform galaxy calculations we used a 2D image-plane grid of (y,x) coordinates, which evaluated.
-**Multiple Gaussians & Linear Light Profiles:** To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the.
-**Basis:** For a multi-Gaussian expansion (and other mdoels where the light profile is a superposition of.
-**Comparison To Linear Light Profiles Example:** The text below is nearly identical to the `linear_light_profile/likelihood_function.ipynb` example.
-**LightProfileLinearObjFuncList:** For standard light profiles, we combined our linear light profiles into a single `Galaxies` object.
-**Combining Matrices:** In the `linear_light_profile/log_likelihood_function.py` example, we used two.
-**Mapping Matrix:** The `mapping_matrix` is a matrix where each column is an image of each Gaussian linear light.
-**Image Reconstruction:** Using the reconstructed `intensity` values we can map the reconstruction back to the image plane.
-**Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
-**Fit:** Fit the lens model to the dataset.
-**Galaxy Modeling:** To fit a galaxy model to data, the likelihood function illustrated in this tutorial is sampled.
-**Wrap Up:** Summary of the script and next steps.
+- **Prerequisites:** The likelihood function of a multi Gaussian expansion builds on that used for standard light.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Masked Image Grid:** To perform galaxy calculations we used a 2D image-plane grid of (y,x) coordinates, which evaluated.
+- **Multiple Gaussians & Linear Light Profiles:** To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the.
+- **Basis:** For a multi-Gaussian expansion (and other mdoels where the light profile is a superposition of.
+- **Comparison To Linear Light Profiles Example:** The text below is nearly identical to the `linear_light_profile/likelihood_function.ipynb` example.
+- **LightProfileLinearObjFuncList:** For standard light profiles, we combined our linear light profiles into a single `Galaxies` object.
+- **Combining Matrices:** In the `linear_light_profile/log_likelihood_function.py` example, we used two.
+- **Mapping Matrix:** The `mapping_matrix` is a matrix where each column is an image of each Gaussian linear light.
+- **Image Reconstruction:** Using the reconstructed `intensity` values we can map the reconstruction back to the image plane.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Galaxy Modeling:** To fit a galaxy model to data, the likelihood function illustrated in this tutorial is sampled.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -12,21 +12,21 @@ profiles like the `Sersic`.
 
 __Contents__
 
-**Advantages & Disadvantages:** Symmetric light profiles (e.g.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**MGE Source Galaxy:** The MGE was designed to model the light of lens galaxies, because they are typically elliptical.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Source MGE:** As discussed at the beginning of this tutorial, an MGE is an effective way to model the light of a.
-**Wrap Up:** Summary of the script and next steps.
-**Description:** There is one downside to `Basis` functions, we may compose a model with too much freedom.
+- **Advantages & Disadvantages:** Symmetric light profiles (e.g.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **MGE Source Galaxy:** The MGE was designed to model the light of lens galaxies, because they are typically elliptical.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Source MGE:** As discussed at the beginning of this tutorial, an MGE is an effective way to model the light of a.
+- **Wrap Up:** Summary of the script and next steps.
+- **Description:** There is one downside to `Basis` functions, we may compose a model with too much freedom.
 
 __Advantages__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/simulator.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/simulator.py
@@ -14,13 +14,13 @@ features using a Multi-Gaussian Expansion (MGE).
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/slam.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/slam.py
@@ -13,15 +13,15 @@ differs from the standard SLaM pipelines described in the SLaM start here guide.
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py` with `gaussian_per_basis=1` for both the lens and source MGE.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py` with `gaussian_per_basis=1` for both the lens and source MGE.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`, except.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/source_science.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/source_science.py
@@ -12,15 +12,15 @@ which is conceptually the simplest case for source science calculations and a go
 
 __Contents__
 
-**Simulated Dataset:** We load and plot the `simple__no_lens_light` example dataset, which is simulated imaging of a.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Lens:** The simulated dataset was created using a lens galaxy with an Isothermal mass profile and External.
-**Multi Gaussian Expansion Source:** The default workspace source model is a Multi Gaussian Expansion (MGE) profile, which is a.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
-**Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
-**Wrap Up:** Summary of the script and next steps.
+- **Simulated Dataset:** We load and plot the `simple__no_lens_light` example dataset, which is simulated imaging of a.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Lens:** The simulated dataset was created using a lens galaxy with an Isothermal mass profile and External.
+- **Multi Gaussian Expansion Source:** The default workspace source model is a Multi Gaussian Expansion (MGE) profile, which is a.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
+- **Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/imaging/features/no_lens_light/modeling.py
+++ b/scripts/imaging/features/no_lens_light/modeling.py
@@ -9,18 +9,18 @@ This example illustrates how to fit a lens model to data where the lens galaxy's
 
 __Contents__
 
-**Advantages & Disadvantages:** The main advantage of fitting data without lens light is the reduction in the number of free.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Fit:** Fit the lens model to the dataset.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Advantages & Disadvantages:** The main advantage of fitting data without lens light is the reduction in the number of free.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Fit:** Fit the lens model to the dataset.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Advantages__
 

--- a/scripts/imaging/features/no_lens_light/simulator.py
+++ b/scripts/imaging/features/no_lens_light/simulator.py
@@ -10,14 +10,14 @@ lens model to data where the lens galaxy's light is not present (e.g. because it
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Mask Extra Galaxies:** Save an empty `mask_extra_galaxies.fits` so noise-scaling tutorials can load it.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Mask Extra Galaxies:** Save an empty `mask_extra_galaxies.fits` so noise-scaling tutorials can load it.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/features/no_lens_light/slam.py
+++ b/scripts/imaging/features/no_lens_light/slam.py
@@ -13,16 +13,16 @@ how the pipeline differs from the standard SLaM pipelines described in the SLaM 
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Model:** Compose the lens model fitted to the data.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py` with `lens_bulge=None` to omit lens light from the model.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py` except no lens light is included in the model.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py` with `lens_bulge=None` to omit lens light from the model.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py` except no lens light is included in the model.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/pixelization/adaptive.py
+++ b/scripts/imaging/features/pixelization/adaptive.py
@@ -42,16 +42,16 @@ pixelization in one search:
 
 __Contents__
 
-**Model:** This script chains three searches to fit `Imaging` data of a 'galaxy-scale' strong lens with a model where the lens galaxy's total mass distribution is an `Isothermal` and the source galaxy's light uses an MGE followed by a pixelization.
-**Dataset + Masking + Positions:** Load, plot and mask the `Imaging` data.
-**Paths:** The path the results of all chained searches are output.
-**Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear` and the source galaxy's light is an MGE.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before modeling.
-**Analysis + Position Likelihood:** We add a penalty term to the likelihood function, which penalizes models where the brightest multiple images of the lensed source galaxy do not trace close to one another in the source plane.
-**Brief Description:** In this example we update the positions between searches, where the positions correspond to the (y,x) locations of the lensed source's multiple images.
-**Adaptive Pixelization:** Search 3 uses two adaptive pixelization classes: `RectangularAdaptImage` mesh and `Adapt` regularization, which adapt the source reconstruction to the source galaxy's morphology.
-**Adapt Images:** When we create the analysis, we pass it an `adapt_images`, which contains a dictionary mapping each galaxy name to the corresponding lens subtracted image of the source galaxy from the result of a previous search.
-**SLaM Pipelines:** The API above allows you to write modeling code using adaptive features yourself, but it is recommended you use the Source, Light and Mass (SLaM) pipeline.
+- **Model:** This script chains three searches to fit `Imaging` data of a 'galaxy-scale' strong lens with a model where the lens galaxy's total mass distribution is an `Isothermal` and the source galaxy's light uses an MGE followed by a pixelization.
+- **Dataset + Masking + Positions:** Load, plot and mask the `Imaging` data.
+- **Paths:** The path the results of all chained searches are output.
+- **Model (Search 1):** Search 1 fits a lens model where the lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear` and the source galaxy's light is an MGE.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before modeling.
+- **Analysis + Position Likelihood:** We add a penalty term to the likelihood function, which penalizes models where the brightest multiple images of the lensed source galaxy do not trace close to one another in the source plane.
+- **Brief Description:** In this example we update the positions between searches, where the positions correspond to the (y,x) locations of the lensed source's multiple images.
+- **Adaptive Pixelization:** Search 3 uses two adaptive pixelization classes: `RectangularAdaptImage` mesh and `Adapt` regularization, which adapt the source reconstruction to the source galaxy's morphology.
+- **Adapt Images:** When we create the analysis, we pass it an `adapt_images`, which contains a dictionary mapping each galaxy name to the corresponding lens subtracted image of the source galaxy from the result of a previous search.
+- **SLaM Pipelines:** The API above allows you to write modeling code using adaptive features yourself, but it is recommended you use the Source, Light and Mass (SLaM) pipeline.
 
 __Model__
 

--- a/scripts/imaging/features/pixelization/cpu_fast_modeling.py
+++ b/scripts/imaging/features/pixelization/cpu_fast_modeling.py
@@ -17,14 +17,14 @@ which is not currently optimized in JAX.
 
 __Contents__
 
-**Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**Fit:** Fit the lens model to the dataset.
-**Model:** Compose the lens model fitted to the data.
-**SLaM Pipeline:** The example `guides/modeling//slam_start_here.ipynb` introduces the SLaM (Source, Light and Mass).
-**SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
-**CPU Fast SLaM Pipelines:** The SLaM pipeline is mostly identical to other examples, but via the `SettingsSearch` it uses a.
-**Wrap Up:** Summary of the script and next steps.
+- **Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **Fit:** Fit the lens model to the dataset.
+- **Model:** Compose the lens model fitted to the data.
+- **SLaM Pipeline:** The example `guides/modeling//slam_start_here.ipynb` introduces the SLaM (Source, Light and Mass).
+- **SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
+- **CPU Fast SLaM Pipelines:** The SLaM pipeline is mostly identical to other examples, but via the `SettingsSearch` it uses a.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/imaging/features/pixelization/delaunay.py
+++ b/scripts/imaging/features/pixelization/delaunay.py
@@ -57,35 +57,35 @@ you can jump to that example to study the source galaxy.
 
 __Contents__
 
-**Image Mesh:** For a Delaunay mesh, the vertices of the triangles are defined by (y, x) coordinates in the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Fit:** Fit the lens model to the dataset.
-**Source Science:** Source science focuses on studying the highly magnified properties of the background lensed source.
-**Model:** Compose the lens model fitted to the data.
-**JAX CPU:** On CPU, the Delaunay mesh computation via JAX can lead to slow down or indefinite freezing.
-**VRAM:** The `pixelization/modeling` example explains how VRAM use is an important consideration for.
-**Adaptive Delaunay:** The example `imaging/features/pixelization/adaptive.py` illustrates how to use adaptive features to.
-**SLaM Pipelines:** The API above allows you to use adaptive features yourself, and you should go ahead an explore them.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
-**Likelihood Function:** The example `imaging/features/pixelization/likelihood_function.py` provides a step-by-step.
-**Source Galaxy Pixelization and Regularization:** The source galaxy is reconstructed using a pixel-grid, in this example a Delaunay mesh, which.
-**Lens Light:** Overview of lens light for this example.
-**Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a Delaunay mesh, we need to determine the centres.
-**Ray Tracing:** Overview of ray tracing for this example.
-**Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
-**Delaunay Mesh:** The relocated mesh grid is used to create the `Pixelization`'s Delaunay mesh using the.
-**Interpolation:** Overview of interpolation for this example.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Sub Gridding:** The calculation above uses a `Grid2D` object, with a `sub-size=1`, meaning it does not perform.
-**Sourrce Plane Interpolation:** For the `Delaunay` mesh used in this example, every image-sub pixel maps to a single source Voronoi.
-**Wrap Up:** Summary of the script and next steps.
+- **Image Mesh:** For a Delaunay mesh, the vertices of the triangles are defined by (y, x) coordinates in the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Fit:** Fit the lens model to the dataset.
+- **Source Science:** Source science focuses on studying the highly magnified properties of the background lensed source.
+- **Model:** Compose the lens model fitted to the data.
+- **JAX CPU:** On CPU, the Delaunay mesh computation via JAX can lead to slow down or indefinite freezing.
+- **VRAM:** The `pixelization/modeling` example explains how VRAM use is an important consideration for.
+- **Adaptive Delaunay:** The example `imaging/features/pixelization/adaptive.py` illustrates how to use adaptive features to.
+- **SLaM Pipelines:** The API above allows you to use adaptive features yourself, and you should go ahead an explore them.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Likelihood Function:** The example `imaging/features/pixelization/likelihood_function.py` provides a step-by-step.
+- **Source Galaxy Pixelization and Regularization:** The source galaxy is reconstructed using a pixel-grid, in this example a Delaunay mesh, which.
+- **Lens Light:** Overview of lens light for this example.
+- **Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a Delaunay mesh, we need to determine the centres.
+- **Ray Tracing:** Overview of ray tracing for this example.
+- **Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
+- **Delaunay Mesh:** The relocated mesh grid is used to create the `Pixelization`'s Delaunay mesh using the.
+- **Interpolation:** Overview of interpolation for this example.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Sub Gridding:** The calculation above uses a `Grid2D` object, with a `sub-size=1`, meaning it does not perform.
+- **Sourrce Plane Interpolation:** For the `Delaunay` mesh used in this example, every image-sub pixel maps to a single source Voronoi.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/imaging/features/pixelization/fit.py
+++ b/scripts/imaging/features/pixelization/fit.py
@@ -26,22 +26,22 @@ initial setup can be performed before lens modeling and saved to hard disk for f
 
 __Contents__
 
-**CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
-**Advantages & Disadvantages:** Many strongly lensed source galaxies are complex, and have asymmetric and irregular morphologies.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Pixelization:** We create a `Pixelization` object to perform the pixelized source reconstruction, which is made up.
-**Fit:** Fit the lens model to the dataset.
-**Mask Extra Galaxies:** There may be extra galaxies nearby the lens and source galaxies, whose emission blends with the.
-**Wrap Up:** Summary of the script and next steps.
-**Linear Objects:** An `Inversion` contains all of the linear objects used to reconstruct the data in its.
-**Grids:** The role of a mapper is to map between the image-plane and source-plane.
-**Reconstruction:** The source reconstruction is also available as a 1D numpy array of values representative of the.
-**Mapped Reconstructed Images:** The source reconstruction(s) are mapped to the image-plane in order to fit the lens model.
-**Simulated Imaging:** We load the source galaxy image from the pixelized inversion of a previous fit, which was performed.
+- **CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
+- **Advantages & Disadvantages:** Many strongly lensed source galaxies are complex, and have asymmetric and irregular morphologies.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Pixelization:** We create a `Pixelization` object to perform the pixelized source reconstruction, which is made up.
+- **Fit:** Fit the lens model to the dataset.
+- **Mask Extra Galaxies:** There may be extra galaxies nearby the lens and source galaxies, whose emission blends with the.
+- **Wrap Up:** Summary of the script and next steps.
+- **Linear Objects:** An `Inversion` contains all of the linear objects used to reconstruct the data in its.
+- **Grids:** The role of a mapper is to map between the image-plane and source-plane.
+- **Reconstruction:** The source reconstruction is also available as a 1D numpy array of values representative of the.
+- **Mapped Reconstructed Images:** The source reconstruction(s) are mapped to the image-plane in order to fit the lens model.
+- **Simulated Imaging:** We load the source galaxy image from the pixelized inversion of a previous fit, which was performed.
 
 __Advantages__
 

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -14,33 +14,33 @@ This script has the following aims:
 
 __Contents__
 
-**Simplifications:** This example uses a `RectangularUniform` mesh, where all rectangular source pixels have the same.
-**Prerequisites:** The likelihood function of a pixelization builds on that used for standard light profiles and.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Masked Image Grid:** To perform lensing calculations we first must define the 2D image-plane (y,x) coordinates used in.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Lens Galaxy:** We set up a lens galaxy with the lens light and mass, which we will use to demonstrate a pixelized.
-**Source Galaxy Pixelization and Regularization:** The source galaxy is reconstructed using a pixel-grid, in this example a RectangularUniform mesh.
-**Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the.
-**Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
-**Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
-**Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a RectangularUniform mesh, we need to determine the.
-**Interpolation:** We now combine grids computed above to create an `Interpolator`, which describes how image grid.
-**Mapper:** We now use the interpolator to create a `Mapper`, which describes the mapping between every image.
-**Alternative Meshes:** We can briefly consider how this step differs for other mesh types.
-**Mapping Matrix:** The `mapping_matrix` represents the image-pixel to source-pixel mappings above in a 2D matrix.
-**Image Reconstruction:** Using the reconstructed source pixel fluxes we can map the source reconstruction back to the image.
-**Likelihood Function:** We now quantify the goodness-of-fit of our lens model and source reconstruction.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Regularization Term:** The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added.
-**Complexity Terms:** Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the five terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Simplifications:** This example uses a `RectangularUniform` mesh, where all rectangular source pixels have the same.
+- **Prerequisites:** The likelihood function of a pixelization builds on that used for standard light profiles and.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Masked Image Grid:** To perform lensing calculations we first must define the 2D image-plane (y,x) coordinates used in.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Lens Galaxy:** We set up a lens galaxy with the lens light and mass, which we will use to demonstrate a pixelized.
+- **Source Galaxy Pixelization and Regularization:** The source galaxy is reconstructed using a pixel-grid, in this example a RectangularUniform mesh.
+- **Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the.
+- **Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
+- **Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
+- **Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a RectangularUniform mesh, we need to determine the.
+- **Interpolation:** We now combine grids computed above to create an `Interpolator`, which describes how image grid.
+- **Mapper:** We now use the interpolator to create a `Mapper`, which describes the mapping between every image.
+- **Alternative Meshes:** We can briefly consider how this step differs for other mesh types.
+- **Mapping Matrix:** The `mapping_matrix` represents the image-pixel to source-pixel mappings above in a 2D matrix.
+- **Image Reconstruction:** Using the reconstructed source pixel fluxes we can map the source reconstruction back to the image.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our lens model and source reconstruction.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Regularization Term:** The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added.
+- **Complexity Terms:** Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the five terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Simplifications__
 

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -36,26 +36,26 @@ to make things run extra fast on GPU.
 
 __Contents__
 
-**GPU Run Times:** On consumer laptop GPUs, the run times of pixelization modeling can be a bit prohibitive, for.
-**CPU Users:** On CPU, JAX pixelization calculations are not accelerated and are therefore relatively slow.
-**Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Search:** Configure the non-linear search used to fit the model.
-**Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
-**Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Mask Extra Galaxies:** There may be extra galaxies nearby the lens and source galaxies, whose emission blends with the.
-**Wrap Up:** Summary of the script and next steps.
-**Chaining:** Modeling with a pixelization can be made more efficient, robust, and automated using the non-linear.
-**HowToGalaxy:** A full description of how pixelizations work—which relies heavily on linear algebra, Bayesian.
+- **GPU Run Times:** On consumer laptop GPUs, the run times of pixelization modeling can be a bit prohibitive, for.
+- **CPU Users:** On CPU, JAX pixelization calculations are not accelerated and are therefore relatively slow.
+- **Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
+- **Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Mask Extra Galaxies:** There may be extra galaxies nearby the lens and source galaxies, whose emission blends with the.
+- **Wrap Up:** Summary of the script and next steps.
+- **Chaining:** Modeling with a pixelization can be made more efficient, robust, and automated using the non-linear.
+- **HowToGalaxy:** A full description of how pixelizations work—which relies heavily on linear algebra, Bayesian.
 
 __Advantages__
 

--- a/scripts/imaging/features/pixelization/slam.py
+++ b/scripts/imaging/features/pixelization/slam.py
@@ -18,17 +18,17 @@ The differences from `slam_start_here` are:
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except `AdaptSplit` regularization is used instead of `Adapt`.
-**LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except `AdaptSplit` regularization is used instead of `Adapt`.
+- **LIGHT LP PIPELINE:** Identical to `slam_start_here.py`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/imaging/features/pixelization/source_science.py
+++ b/scripts/imaging/features/pixelization/source_science.py
@@ -17,15 +17,15 @@ for analysis without the need for PyAutoLens.
 
 __Contents__
 
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Interpolated Source:** The simplest way to perform source science calculations on a pixelized source reconstruction is to.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Zoom:** The interpolation grid above was large in extent (-3.0" to 3.0" in both the y and x directions).
-**Errors:** The interpolated errors on the source reconstruction can also be computed, which will allow you to.
-**Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Masking:** Reconstructions can be imperfect, for example having faint source flux in pixels at the edge of the.
-**Magnification via Mesh:** The calculations above used an interpolation of the source-plane reconstruction to a 2D grid of.
-**Reconstruction CSV:** In the results `image` folder there is a .csv file called `source_plane_reconstruction_0.csv` which.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Interpolated Source:** The simplest way to perform source science calculations on a pixelized source reconstruction is to.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Zoom:** The interpolation grid above was large in extent (-3.0" to 3.0" in both the y and x directions).
+- **Errors:** The interpolated errors on the source reconstruction can also be computed, which will allow you to.
+- **Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Masking:** Reconstructions can be imperfect, for example having faint source flux in pixels at the edge of the.
+- **Magnification via Mesh:** The calculations above used an interpolation of the source-plane reconstruction to a 2D grid of.
+- **Reconstruction CSV:** In the results `image` folder there is a .csv file called `source_plane_reconstruction_0.csv` which.
 
 """
 

--- a/scripts/imaging/features/scaling_relation/modeling.py
+++ b/scripts/imaging/features/scaling_relation/modeling.py
@@ -22,18 +22,18 @@ The free parameters are now only those related to the scaling relation, for exam
 
 __Contents__
 
-**Mass Model And Scaling Relation:** This example shows how to compose a scaling-relation lens model using the dual Pseudo-Isothermal.
-**Centres:** Scaling relations parameterize the mass of each galaxy, but not their centres.
-**Redshifts:** In this example all line of sight galaxies are at the same redshift as the lens galaxy, meaning.
-**Extra Galaxies API:** **PyAutoLens** refers to all galaxies surrounded the strong lens as `extra_galaxies`, with the.
-**Dataset:** Load and plot the strong lens dataset.
-**Luminosities:** We also need the luminosity of each galaxy, which in this example is the measured property we.
-**Scaling Relation:** We now compose our scaling relation models, using **PyAutoFits** relational model API, which works.
-**Model:** Compose the lens model fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Wrap Up:** Summary of the script and next steps.
+- **Mass Model And Scaling Relation:** This example shows how to compose a scaling-relation lens model using the dual Pseudo-Isothermal.
+- **Centres:** Scaling relations parameterize the mass of each galaxy, but not their centres.
+- **Redshifts:** In this example all line of sight galaxies are at the same redshift as the lens galaxy, meaning.
+- **Extra Galaxies API:** **PyAutoLens** refers to all galaxies surrounded the strong lens as `extra_galaxies`, with the.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Luminosities:** We also need the luminosity of each galaxy, which in this example is the measured property we.
+- **Scaling Relation:** We now compose our scaling relation models, using **PyAutoFits** relational model API, which works.
+- **Model:** Compose the lens model fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Mass Model And Scaling Relation__
 

--- a/scripts/imaging/features/simulator_manual_signal_to_noise_ratio.py
+++ b/scripts/imaging/features/simulator_manual_signal_to_noise_ratio.py
@@ -28,13 +28,13 @@ The use of the `light_snr` profiles changes the meaning of `exposure_time` and `
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Ray Tracing:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -15,16 +15,16 @@ This example uses functionality described fully in other examples in the `guides
 
 __Contents__
 
-**Loading Data:** We we begin by loading the strong lens dataset `simple__no_lens_light` from .fits files, which is.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Fitting:** Fit the lens model to the dataset and inspect the results.
-**Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
-**Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
-**Figures of Merit:** There are single valued floats which quantify the goodness of fit.
-**Plane Quantities:** The `FitImaging` object has specific quantities which break down each image of each plane.
-**Unmasked Quantities:** All of the quantities above are computed using the mask which was used to fit the data.
-**Pixel Counting:** An alternative way to quantify residuals like the lens light residuals is pixel counting.
-**Outputting Results:** You may wish to output certain results to .fits files for later inspection.
+- **Loading Data:** We we begin by loading the strong lens dataset `simple__no_lens_light` from .fits files, which is.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Fitting:** Fit the lens model to the dataset and inspect the results.
+- **Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
+- **Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
+- **Figures of Merit:** There are single valued floats which quantify the goodness of fit.
+- **Plane Quantities:** The `FitImaging` object has specific quantities which break down each image of each plane.
+- **Unmasked Quantities:** All of the quantities above are computed using the mask which was used to fit the data.
+- **Pixel Counting:** An alternative way to quantify residuals like the lens light residuals is pixel counting.
+- **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
 
 """
 

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -16,23 +16,23 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
-**Lens Galaxy Mass:** We next define the mass profiles which represents the lens galaxy's mass, which will be used to.
-**Lens Galaxy:** We now combine the light and mass profiles into a single `Galaxy` object for the lens galaxy.
-**Source Galaxy Light Profile:** The source galaxy is fitted using another analytic light profile, in this example another.
-**Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the an.
-**Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
-**Source Image:** We pass the traced grid and blurring grid of coordinates to the source galaxy to evaluate its 2D.
-**Convolution:** Convolve the 2D image of the lens and source above with the PSF in real-space (as opposed to via an.
-**Likelihood Function:** We now quantify the goodness-of-fit of our lens and source model.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the two terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
+- **Lens Galaxy Mass:** We next define the mass profiles which represents the lens galaxy's mass, which will be used to.
+- **Lens Galaxy:** We now combine the light and mass profiles into a single `Galaxy` object for the lens galaxy.
+- **Source Galaxy Light Profile:** The source galaxy is fitted using another analytic light profile, in this example another.
+- **Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the an.
+- **Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
+- **Source Image:** We pass the traced grid and blurring grid of coordinates to the source galaxy to evaluate its 2D.
+- **Convolution:** Convolve the 2D image of the lens and source above with the PSF in real-space (as opposed to via an.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our lens and source model.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the lens model, by combining the two terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -7,29 +7,29 @@ This script is the starting point for lens modeling of CCD imaging data (E.g. Hu
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Plotters:** Overview of plotting tools used for visualization.
-**Simulation:** Overview of how the simulated dataset was generated.
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Model Composition:** Compose the lens model using the Model and Collection API.
-**Coordinates:** Coordinate system assumptions for the model-fit.
-**Improved Lens Model:** The previous model used Sérsic light profiles for the lens and source galaxies.
-**Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge and disk via the ``lp_linear``.
-**Concise API:** The MGE model composition API is quite long and technical, so we simply load the MGE models for the.
-**Search:** Configure the non-linear search used to fit the model.
-**Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-**Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**VRAM Use:** When running with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Overview of the results of the model-fit.
-**Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
-**HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
-**Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
+- **Model:** Compose the lens model fitted to the data.
+- **Plotters:** Overview of plotting tools used for visualization.
+- **Simulation:** Overview of how the simulated dataset was generated.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Model Composition:** Compose the lens model using the Model and Collection API.
+- **Coordinates:** Coordinate system assumptions for the model-fit.
+- **Improved Lens Model:** The previous model used Sérsic light profiles for the lens and source galaxies.
+- **Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge and disk via the ``lp_linear``.
+- **Concise API:** The MGE model composition API is quite long and technical, so we simply load the MGE models for the.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
+- **Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **VRAM Use:** When running with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Overview of the results of the model-fit.
+- **Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
+- **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
+- **Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
 
 __Model__
 

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -9,16 +9,16 @@ After reading this script, the `examples` folder provide examples for simulating
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Plotters:** Overview of plotting tools used for visualization.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Ray Tracing:** We now define the lens galaxy's light (elliptical Sersic + Exponential), mass (SIE+Shear) and.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** In the same folder as the .fits files, we also output subplots of the simulated dataset in .png.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Multiple Images:** Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x).
+- **Model:** Compose the lens model fitted to the data.
+- **Plotters:** Overview of plotting tools used for visualization.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Grid:** Define the 2d grid of (y,x) coordinates that the lens and source galaxy images are evaluated and.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Ray Tracing:** We now define the lens galaxy's light (elliptical Sersic + Exponential), mass (SIE+Shear) and.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** In the same folder as the .fits files, we also output subplots of the simulated dataset in .png.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Multiple Images:** Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x).
 
 __Model__
 

--- a/scripts/imaging/simulator_sample.py
+++ b/scripts/imaging/simulator_sample.py
@@ -21,11 +21,11 @@ and source galaxies are visible in each image.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
-**Sample Model Distributions:** To simulate a sample, we draw random instances of lens and source galaxies where the parameters of.
-**Sample Instances:** Within a for loop, we will now generate instances of the lens and source galaxies using the.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid with the adaptive over sampling scheme.
+- **Sample Model Distributions:** To simulate a sample, we draw random instances of lens and source galaxies where the parameters of.
+- **Sample Instances:** Within a for loop, we will now generate instances of the lens and source galaxies using the.
 
 __Model__
 

--- a/scripts/imaging/source_science.py
+++ b/scripts/imaging/source_science.py
@@ -12,13 +12,13 @@ is conceptually the simplest case for source science calculations and a good int
 
 __Contents__
 
-**Simulated Dataset:** We load and plot the `simple__no_lens_light` example dataset, which is simulated imaging of a.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
-**Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
+- **Simulated Dataset:** We load and plot the `simple__no_lens_light` example dataset, which is simulated imaging of a.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
+- **Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
 
 """
 

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -14,21 +14,21 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Extra Galaxy Removal:** There may be regions of an image that have signal near the lens and source that is from other.
-**Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
-**Model:** Compose the lens model fitted to the data.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
-**Result:** Overview of the results of the model-fit.
-**Extra Galaxy Removal GUI:** The model-fit above removed a region of the image to the south-east of the lens, which contains.
-**Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
-**Simulator:** Let’s now switch gears and simulate our own strong lens imaging.
-**Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Extra Galaxy Removal:** There may be regions of an image that have signal near the lens and source that is from other.
+- **Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
+- **Model:** Compose the lens model fitted to the data.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
+- **Result:** Overview of the results of the model-fit.
+- **Extra Galaxy Removal GUI:** The model-fit above removed a region of the image to the south-east of the lens, which contains.
+- **Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
+- **Simulator:** Let’s now switch gears and simulate our own strong lens imaging.
+- **Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/interferometer/casa_reduction.py
+++ b/scripts/interferometer/casa_reduction.py
@@ -26,18 +26,18 @@ feedback directly shapes these examples.
 
 __Contents__
 
-**PyAutoLens Requirements:** What the `al.Interferometer` object expects as input.
-**CASA in Five Steps:** The canonical CASA reduction pipeline for PyAutoLens.
-**Step 1 — Split by Field / SPW:** Isolate the lens target and each spectral window.
-**Step 2 — Channel Averaging:** Reduce visibility count by averaging channels.
-**Step 3 — Continuum Subtraction:** Optional `uvcontsub` for line observations.
-**Step 4 — Rescale Sigmas:** `statwt` makes the SIGMA column reflect real scatter.
-**Step 5 — Export to FITS:** Python helpers to read the .ms and write .fits.
-**Combining Spectral Windows:** Concatenate per-SPW arrays into a single dataset.
-**Polarisations:** Averaging XX/YY (or RR/LL) into a single complex visibility.
-**Building the Interferometer Object:** Load the FITS files into `al.Interferometer`.
-**Troubleshooting:** Common pitfalls and what to check.
-**SLACK:** Where to ask for help.
+- **PyAutoLens Requirements:** What the `al.Interferometer` object expects as input.
+- **CASA in Five Steps:** The canonical CASA reduction pipeline for PyAutoLens.
+- **Step 1 — Split by Field / SPW:** Isolate the lens target and each spectral window.
+- **Step 2 — Channel Averaging:** Reduce visibility count by averaging channels.
+- **Step 3 — Continuum Subtraction:** Optional `uvcontsub` for line observations.
+- **Step 4 — Rescale Sigmas:** `statwt` makes the SIGMA column reflect real scatter.
+- **Step 5 — Export to FITS:** Python helpers to read the .ms and write .fits.
+- **Combining Spectral Windows:** Concatenate per-SPW arrays into a single dataset.
+- **Polarisations:** Averaging XX/YY (or RR/LL) into a single complex visibility.
+- **Building the Interferometer Object:** Load the FITS files into `al.Interferometer`.
+- **Troubleshooting:** Common pitfalls and what to check.
+- **SLACK:** Where to ask for help.
 
 __PyAutoLens Requirements__
 

--- a/scripts/interferometer/data_preparation.py
+++ b/scripts/interferometer/data_preparation.py
@@ -8,18 +8,18 @@ which will help you prepare your dataset to adhere to them if it does not alread
 
 __Contents__
 
-**SLACK:** Contact information for help with interferometer data preparation.
-**Pixel Scale:** Choosing the correct pixel scale for interferometer datasets.
-**Visibilities:** Loading and inspecting visibility data from FITS files.
-**Noise-Map:** Loading and inspecting the noise map for the interferometer dataset.
-**UV Wavelengths:** Loading and inspecting the uv-wavelength baselines.
-**Real Space Mask:** Setting up the real-space mask for Fourier transform evaluation.
-**Data Processing Complete:** Summary of required data standards and overview of optional steps.
-**Positions (Optional):** Marking multiply-imaged source positions to constrain mass models.
-**Lens Light Centre (Optional):** Marking the lens galaxy light centre to fix or constrain mass model parameters.
-**Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for inclusion in the model.
-**Mask Extra Galaxies (Optional):** Creating masks to remove signal from nearby extra galaxies.
-**Info (Optional):** Storing auxiliary information like redshifts as a JSON file.
+- **SLACK:** Contact information for help with interferometer data preparation.
+- **Pixel Scale:** Choosing the correct pixel scale for interferometer datasets.
+- **Visibilities:** Loading and inspecting visibility data from FITS files.
+- **Noise-Map:** Loading and inspecting the noise map for the interferometer dataset.
+- **UV Wavelengths:** Loading and inspecting the uv-wavelength baselines.
+- **Real Space Mask:** Setting up the real-space mask for Fourier transform evaluation.
+- **Data Processing Complete:** Summary of required data standards and overview of optional steps.
+- **Positions (Optional):** Marking multiply-imaged source positions to constrain mass models.
+- **Lens Light Centre (Optional):** Marking the lens galaxy light centre to fix or constrain mass model parameters.
+- **Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for inclusion in the model.
+- **Mask Extra Galaxies (Optional):** Creating masks to remove signal from nearby extra galaxies.
+- **Info (Optional):** Storing auxiliary information like redshifts as a JSON file.
 
 __SLACK__
 

--- a/scripts/interferometer/features/datacube/delaunay.py
+++ b/scripts/interferometer/features/datacube/delaunay.py
@@ -20,22 +20,22 @@ mesh (and its regularization) changes.
 
 __Contents__
 
-**Mask:** Define the 2D real-space mask applied to every channel.
-**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
-**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
-**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
-**Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the Delaunay inversion.
-**Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
-**Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
-**Image Mesh:** Build the image-plane mesh of (y, x) points that get ray-traced and Delaunay-triangulated.
-**Edge Zeroing:** Append a ring of edge pixels so the source-plane reconstruction zeroes at the mesh boundary.
-**Adapt Images:** Pair the image-plane mesh with the source galaxy via `al.AdaptImages`.
-**Model:** Compose the shared `Isothermal + ExternalShear` lens and Delaunay-pixelized source.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with shared `adapt_images` and `PositionsLH`.
-**FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
-**Search:** Configure the `Nautilus` non-linear search.
-**Model Fit:** Run the fit. Per-channel cost is comparable to the rectangular variant.
-**Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
+- **Mask:** Define the 2D real-space mask applied to every channel.
+- **Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+- **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+- **Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+- **Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the Delaunay inversion.
+- **Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
+- **Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
+- **Image Mesh:** Build the image-plane mesh of (y, x) points that get ray-traced and Delaunay-triangulated.
+- **Edge Zeroing:** Append a ring of edge pixels so the source-plane reconstruction zeroes at the mesh boundary.
+- **Adapt Images:** Pair the image-plane mesh with the source galaxy via `al.AdaptImages`.
+- **Model:** Compose the shared `Isothermal + ExternalShear` lens and Delaunay-pixelized source.
+- **Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with shared `adapt_images` and `PositionsLH`.
+- **FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
+- **Search:** Configure the `Nautilus` non-linear search.
+- **Model Fit:** Run the fit. Per-channel cost is comparable to the rectangular variant.
+- **Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/features/datacube/modeling.py
+++ b/scripts/interferometer/features/datacube/modeling.py
@@ -16,20 +16,20 @@ walkthrough; this file is the one to copy and adapt for your own cube.
 
 __Contents__
 
-**Mask:** Define the 2D real-space mask applied to every channel.
-**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
-**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
-**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
-**Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the pixelized source inversion.
-**Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
-**Mesh Shape:** Pixelization mesh size — fixed before modeling because JAX needs static-shape arrays.
-**Model:** Compose the shared `Isothermal + ExternalShear` lens and pixelized source.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True`.
-**FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
-**Search:** Configure the `Nautilus` non-linear search.
-**Model Fit:** Run the fit. Per-channel inversion cost dominates runtime — see notes inline.
-**Wrap Up:** Summary of the script and pointers to the JAX likelihood walkthrough in
-``autolens_workspace_developer/datacube/likelihood_function.py``.
+- **Mask:** Define the 2D real-space mask applied to every channel.
+- **Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+- **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+- **Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+- **Sparse Operators:** Pre-compute per-channel sparse-operator matrices used by the pixelized source inversion.
+- **Settings:** Disable the positive-only solver so visibility-space inversions can take negative pixel values.
+- **Mesh Shape:** Pixelization mesh size — fixed before modeling because JAX needs static-shape arrays.
+- **Model:** Compose the shared `Isothermal + ExternalShear` lens and pixelized source.
+- **Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True`.
+- **FactorGraph:** Wrap each analysis in an `AnalysisFactor` and combine via `af.FactorGraphModel`.
+- **Search:** Configure the `Nautilus` non-linear search.
+- **Model Fit:** Run the fit. Per-channel inversion cost dominates runtime — see notes inline.
+- **Wrap Up:** Summary of the script and pointers to the JAX likelihood walkthrough in
+  ``autolens_workspace_developer/datacube/likelihood_function.py``.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/features/datacube/modeling_parametric.py
+++ b/scripts/interferometer/features/datacube/modeling_parametric.py
@@ -25,18 +25,18 @@ default, and we explicitly override the source `intensity` prior per `AnalysisFa
 
 __Contents__
 
-**Mask:** Define the 2D real-space mask applied to every channel.
-**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
-**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
-**Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
-**Positions:** Load multiple-image positions and build a shared `PositionsLH` penalty.
-**Settings:** Default `al.Settings()` — no positive-only-solver tweak needed (no inversion).
-**Model:** Compose the shared `Isothermal + ExternalShear` lens and `Sersic` source.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True` and the shared `PositionsLH`.
-**FactorGraph:** Per-factor `model.copy()` with the source `intensity` prior overridden per channel.
-**Search:** Configure the `Nautilus` non-linear search.
-**Model Fit:** Run the fit. Per-channel cost is much cheaper than the pixelization variant.
-**Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
+- **Mask:** Define the 2D real-space mask applied to every channel.
+- **Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+- **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+- **Dataset Loading:** Loop over the channel folders and load each as an `Interferometer` object.
+- **Positions:** Load multiple-image positions and build a shared `PositionsLH` penalty.
+- **Settings:** Default `al.Settings()` — no positive-only-solver tweak needed (no inversion).
+- **Model:** Compose the shared `Isothermal + ExternalShear` lens and `Sersic` source.
+- **Per-Channel Analyses:** One `AnalysisInterferometer` per channel, with `use_jax=True` and the shared `PositionsLH`.
+- **FactorGraph:** Per-factor `model.copy()` with the source `intensity` prior overridden per channel.
+- **Search:** Configure the `Nautilus` non-linear search.
+- **Model Fit:** Run the fit. Per-channel cost is much cheaper than the pixelization variant.
+- **Wrap Up:** Pointers to `modeling.py`, `start_here.py`, and the JAX likelihood walkthrough.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/features/datacube/simulator.py
+++ b/scripts/interferometer/features/datacube/simulator.py
@@ -18,17 +18,17 @@ datasets look like once narrow-band continuum subtraction has been performed.
 
 __Contents__
 
-**Cube Configuration:** Number of channels and the emission-line shape used to drive the per-channel intensity.
-**Dataset Paths:** Where the per-channel datasets, summary JSON and overview plots are written.
-**uv_wavelengths:** Reuse the SMA `uv_wavelengths.fits` shipped with the workspace as a stand-in for ALMA coverage.
-**Real-Space Grid:** The 2D image-plane grid each channel is evaluated on before the Fourier transform.
-**Lens Galaxy:** Shared `Isothermal + ExternalShear` lens, identical for every channel.
-**Per-Channel Source:** A Gaussian emission line in channel index drives the per-channel `Sersic.intensity`.
-**Per-Channel Simulate:** Loop over channels: build the tracer, simulate, write FITS + tracer.json to disk.
-**Multiple Images:** Compute and save the lensed multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
-**Cube Summary:** Dump the emission-line parameters and per-channel intensities to `cube_summary.json`.
-**Cube Overview Plot:** Row-per-channel sanity figure (lensed image, uv-plane Re/Im, |vis| vs baseline length).
-**Spectrum Plot:** Source intensity as a function of channel index.
+- **Cube Configuration:** Number of channels and the emission-line shape used to drive the per-channel intensity.
+- **Dataset Paths:** Where the per-channel datasets, summary JSON and overview plots are written.
+- **uv_wavelengths:** Reuse the SMA `uv_wavelengths.fits` shipped with the workspace as a stand-in for ALMA coverage.
+- **Real-Space Grid:** The 2D image-plane grid each channel is evaluated on before the Fourier transform.
+- **Lens Galaxy:** Shared `Isothermal + ExternalShear` lens, identical for every channel.
+- **Per-Channel Source:** A Gaussian emission line in channel index drives the per-channel `Sersic.intensity`.
+- **Per-Channel Simulate:** Loop over channels: build the tracer, simulate, write FITS + tracer.json to disk.
+- **Multiple Images:** Compute and save the lensed multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
+- **Cube Summary:** Dump the emission-line parameters and per-channel intensities to `cube_summary.json`.
+- **Cube Overview Plot:** Row-per-channel sanity figure (lensed image, uv-plane Re/Im, |vis| vs baseline length).
+- **Spectrum Plot:** Source intensity as a function of channel index.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/features/datacube/start_here.py
+++ b/scripts/interferometer/features/datacube/start_here.py
@@ -24,23 +24,23 @@ that sums them.
 
 __Contents__
 
-**JAX:** GPU/CPU acceleration via JAX — the same backend that single-channel interferometer fits use.
-**Imports:** Standard PyAutoLens imports + `autofit` for the FactorGraph wiring.
-**Mask:** A single 2D real-space mask shared across all channels.
-**Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
-**Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
-**Dataset Loading:** Loop over channel folders to build a `dataset_list` of `Interferometer` objects.
-**Sparse Operators:** Per-channel sparse-operator pre-compute used by the pixelized source inversion.
-**Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
-**Settings:** Disable the positive-only solver (visibility inversions can take negative pixel values).
-**Mesh Shape:** The pixelization mesh shape — fixed before modeling because JAX needs static shapes.
-**Model:** Shared lens galaxy + pixelized source. The same model is reused unchanged across every channel.
-**Per-Channel Analyses:** One `AnalysisInterferometer` per channel, all sharing the same `PositionsLH`.
-**FactorGraph:** Wrap each analysis in an `AnalysisFactor`; combine via `af.FactorGraphModel`.
-**Search:** Configure the `Nautilus` non-linear search.
-**Model Fit:** Fit the cube — the FactorGraph routes shared lens parameters into every channel's likelihood.
-**Result:** What the returned `result_list` contains and how to inspect per-channel reconstructions.
-**Wrap Up:** Pointers to `modeling.py`, `simulator.py`, and the JAX likelihood walkthrough.
+- **JAX:** GPU/CPU acceleration via JAX — the same backend that single-channel interferometer fits use.
+- **Imports:** Standard PyAutoLens imports + `autofit` for the FactorGraph wiring.
+- **Mask:** A single 2D real-space mask shared across all channels.
+- **Dataset:** Where the per-channel cube lives on disk and how to point this script at your own.
+- **Dataset Auto-Simulation:** Run `simulator.py` automatically if the cube isn't already on disk.
+- **Dataset Loading:** Loop over channel folders to build a `dataset_list` of `Interferometer` objects.
+- **Sparse Operators:** Per-channel sparse-operator pre-compute used by the pixelized source inversion.
+- **Positions:** Load the cube's multiple-image positions and build a shared `PositionsLH` penalty.
+- **Settings:** Disable the positive-only solver (visibility inversions can take negative pixel values).
+- **Mesh Shape:** The pixelization mesh shape — fixed before modeling because JAX needs static shapes.
+- **Model:** Shared lens galaxy + pixelized source. The same model is reused unchanged across every channel.
+- **Per-Channel Analyses:** One `AnalysisInterferometer` per channel, all sharing the same `PositionsLH`.
+- **FactorGraph:** Wrap each analysis in an `AnalysisFactor`; combine via `af.FactorGraphModel`.
+- **Search:** Configure the `Nautilus` non-linear search.
+- **Model Fit:** Fit the cube — the FactorGraph routes shared lens parameters into every channel's likelihood.
+- **Result:** What the returned `result_list` contains and how to inspect per-channel reconstructions.
+- **Wrap Up:** Pointers to `modeling.py`, `simulator.py`, and the JAX likelihood walkthrough.
 
 __JAX__
 

--- a/scripts/interferometer/features/extra_galaxies/modeling.py
+++ b/scripts/interferometer/features/extra_galaxies/modeling.py
@@ -16,18 +16,18 @@ these galaxies, in order to reduce model complexity.
 
 __Contents__
 
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Extra Galaxies Dataset:** We are now going to model the dataset with extra galaxies included in the model, where these.
-**Extra Galaxies Centres:** To set up a lens model including each extra galaxy with a mass profile, we input manually the.
-**Model:** Compose the lens model fitted to the data.
-**Extra Galaxies Model:** We now use the modeling API to create the model for the extra galaxies.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Scaling Relations:** The modeling API has full support for composing the extra galaxies such that their mass follows.
-**Wrap Up:** Summary of the script and next steps.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Extra Galaxies Dataset:** We are now going to model the dataset with extra galaxies included in the model, where these.
+- **Extra Galaxies Centres:** To set up a lens model including each extra galaxy with a mass profile, we input manually the.
+- **Model:** Compose the lens model fitted to the data.
+- **Extra Galaxies Model:** We now use the modeling API to create the model for the extra galaxies.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Scaling Relations:** The modeling API has full support for composing the extra galaxies such that their mass follows.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Data Preparation__
 

--- a/scripts/interferometer/features/extra_galaxies/simulator.py
+++ b/scripts/interferometer/features/extra_galaxies/simulator.py
@@ -22,16 +22,16 @@ galaxies. This is used to illustrate the extra galaxies API in the script above.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Other Scripts:** To illustrate how compose and fit a lens model which includes the extra galaxies as light and mass.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Simulate:** Simulate the image using a (y,x) grid.
-**Galaxies:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
-**Extra Galaxies:** Includes two extra galaxies, which must be modeled to ensure the lens model is accurate.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Multiple Images:** Output the multiple image positions of the source galaxy which can help with lens modeling.
+- **Model:** Compose the lens model fitted to the data.
+- **Other Scripts:** To illustrate how compose and fit a lens model which includes the extra galaxies as light and mass.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Simulate:** Simulate the image using a (y,x) grid.
+- **Galaxies:** Setup the lens galaxy's light, mass and source galaxy light for this simulated lens.
+- **Extra Galaxies:** Includes two extra galaxies, which must be modeled to ensure the lens model is accurate.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Multiple Images:** Output the multiple image positions of the source galaxy which can help with lens modeling.
 
 __Model__
 

--- a/scripts/interferometer/features/extra_galaxies/slam.py
+++ b/scripts/interferometer/features/extra_galaxies/slam.py
@@ -13,22 +13,22 @@ differs from the standard SLaM pipelines described in the SLaM start here guide.
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Group SLaM:** This SLaM pipeline is designed for the regime where one is modeling galaxy scale lenses with nearby.
-**This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
-**SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
-**Extra Galaxies Centres:** This is the same API as described in the `features/extra_galaxies.ipynb` example, where the centres.
-**Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-**Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
-**Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**Extra Galaxies:** Build the extra galaxies model: each extra galaxy has an `IsothermalSph` mass profile with its.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
-**Output:** The `start_here.ipynb` example describes how results can be output to hard-disk after the SLaM.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Group SLaM:** This SLaM pipeline is designed for the regime where one is modeling galaxy scale lenses with nearby.
+- **This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
+- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Extra Galaxies Centres:** This is the same API as described in the `features/extra_galaxies.ipynb` example, where the centres.
+- **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
+- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
+- **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **Extra Galaxies:** Build the extra galaxies model: each extra galaxy has an `IsothermalSph` mass profile with its.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Output:** The `start_here.ipynb` example describes how results can be output to hard-disk after the SLaM.
 
 __Prerequisites__
 

--- a/scripts/interferometer/features/pixelization/delaunay.py
+++ b/scripts/interferometer/features/pixelization/delaunay.py
@@ -58,32 +58,32 @@ you can jump to that example to study the source galaxy.
 
 __Contents__
 
-**Image Mesh:** For a Delaunay mesh, the vertices of the triangles are defined by (y, x) coordinates in the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Fit:** Fit the lens model to the dataset.
-**Model:** Compose the lens model fitted to the data.
-**VRAM:** The `pixelization/modeling` example explains how VRAM use is an important consideration for.
-**Adaptive Delaunay:** The example `imaging/features/pixelization/adaptive.py` illustrates how to use adaptive features to.
-**SLaM Pipelines:** The API above allows you to use adaptive features yourself, and you should go ahead an explore them.
-**SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, using an MGE for the lens and source light profiles.
-**SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
-**Prerequisites:** The likelihood function of pixelizations is the most complicated likelihood function.
-**Likelihood Function:** The example `interferometer/pixelization/likelihood_function.py` provides a step-by-step.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Source Galaxy Pixelization and Regularization:** We combine the pixelization into a single `Galaxy` object.
-**Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a Delaunay mesh, we need to determine the centres.
-**Ray Tracing:** Overview of ray tracing for this example.
-**Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
-**Delaunay Mesh:** The relocated mesh grid is used to create the `Pixelization`'s Delaunay mesh using the.
-**Interpolation:** Overview of interpolation for this example.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Image Mesh:** For a Delaunay mesh, the vertices of the triangles are defined by (y, x) coordinates in the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Fit:** Fit the lens model to the dataset.
+- **Model:** Compose the lens model fitted to the data.
+- **VRAM:** The `pixelization/modeling` example explains how VRAM use is an important consideration for.
+- **Adaptive Delaunay:** The example `imaging/features/pixelization/adaptive.py` illustrates how to use adaptive features to.
+- **SLaM Pipelines:** The API above allows you to use adaptive features yourself, and you should go ahead an explore them.
+- **SOURCE LP PIPELINE:** Identical to `slam_start_here.py`, using an MGE for the lens and source light profiles.
+- **SOURCE PIX PIPELINE 1:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, except the source pixelization uses a Delaunay mesh.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** The likelihood function of pixelizations is the most complicated likelihood function.
+- **Likelihood Function:** The example `interferometer/pixelization/likelihood_function.py` provides a step-by-step.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Source Galaxy Pixelization and Regularization:** We combine the pixelization into a single `Galaxy` object.
+- **Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a Delaunay mesh, we need to determine the centres.
+- **Ray Tracing:** Overview of ray tracing for this example.
+- **Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
+- **Delaunay Mesh:** The relocated mesh grid is used to create the `Pixelization`'s Delaunay mesh using the.
+- **Interpolation:** Overview of interpolation for this example.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/interferometer/features/pixelization/fit.py
+++ b/scripts/interferometer/features/pixelization/fit.py
@@ -24,24 +24,24 @@ initial setup can be performed before lens modeling and saved to hard disk for f
 
 __Contents__
 
-**CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
-**Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
-**Settings:** As discussed above, disable the default position only linear algebra solver so the source.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Pixelization:** We create a `Pixelization` object to perform the pixelized source reconstruction, which is made up.
-**Fit:** Fit the lens model to the dataset.
-**Wrap Up:** Summary of the script and next steps.
-**Linear Objects:** An `Inversion` contains all of the linear objects used to reconstruct the data in its.
-**Grids:** The role of a mapper is to map between the image-plane and source-plane.
-**Reconstruction:** The source reconstruction is also available as a 1D numpy array of values representative of the.
-**Mapped Reconstructed Images:** The source reconstruction(s) are mapped to the image-plane in order to fit the lens model.
-**Simulated Interferometer:** We load the source galaxy image from the pixelized inversion of a previous fit, which was performed.
+- **CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
+- **Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
+- **Settings:** As discussed above, disable the default position only linear algebra solver so the source.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Pixelization:** We create a `Pixelization` object to perform the pixelized source reconstruction, which is made up.
+- **Fit:** Fit the lens model to the dataset.
+- **Wrap Up:** Summary of the script and next steps.
+- **Linear Objects:** An `Inversion` contains all of the linear objects used to reconstruct the data in its.
+- **Grids:** The role of a mapper is to map between the image-plane and source-plane.
+- **Reconstruction:** The source reconstruction is also available as a 1D numpy array of values representative of the.
+- **Mapped Reconstructed Images:** The source reconstruction(s) are mapped to the image-plane in order to fit the lens model.
+- **Simulated Interferometer:** We load the source galaxy image from the pixelized inversion of a previous fit, which was performed.
 
 __Advantages__
 

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -14,33 +14,33 @@ This script has the following aims:
 
 __Contents__
 
-**Simplifications:** This example uses a `RectangularUniform` mesh, where all rectangular source pixels have the same.
-**Prerequisites:** The likelihood function of pixelizations is the most complicated likelihood function.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
-**Lens Galaxy:** We set up a lens galaxy with the lens light and mass, which we will use to demonstrate a pixelized.
-**Source Galaxy Pixelization and Regularization:** We combine the pixelization into a single `Galaxy` object.
-**Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
-**Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
-**Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a mesh, we need to determine the centres of the.
-**Interpolation:** We now combine grids computed above to create an `Interpolator`, which describes how image grid.
-**Mapper:** We now use the interpolator to create a `Mapper`, which describes the mapping between every image.
-**Alternative Meshes:** We can briefly consider how this step differs for other mesh types.
-**Mapping Matrix:** The `mapping_matrix` represents the image-pixel to source-pixel mappings above in a 2D matrix.
-**Visibilities Reconstruction:** Using the reconstructed pixel fluxes we can map the reconstruction back to the image plane (via the.
-**Likelihood Function:** We now quantify the goodness-of-fit of our pixelization source galaxy reconstruction.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Regularization Term:** The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added.
-**Complexity Terms:** Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the model, by combining the five terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Simplifications:** This example uses a `RectangularUniform` mesh, where all rectangular source pixels have the same.
+- **Prerequisites:** The likelihood function of pixelizations is the most complicated likelihood function.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
+- **Lens Galaxy:** We set up a lens galaxy with the lens light and mass, which we will use to demonstrate a pixelized.
+- **Source Galaxy Pixelization and Regularization:** We combine the pixelization into a single `Galaxy` object.
+- **Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
+- **Border Relocation:** Coordinates that are ray-traced near the mass profile centres are heavily demagnified and may trace.
+- **Source Pixel Centre Calculation:** In order to reconstruct the source galaxy using a mesh, we need to determine the centres of the.
+- **Interpolation:** We now combine grids computed above to create an `Interpolator`, which describes how image grid.
+- **Mapper:** We now use the interpolator to create a `Mapper`, which describes the mapping between every image.
+- **Alternative Meshes:** We can briefly consider how this step differs for other mesh types.
+- **Mapping Matrix:** The `mapping_matrix` represents the image-pixel to source-pixel mappings above in a 2D matrix.
+- **Visibilities Reconstruction:** Using the reconstructed pixel fluxes we can map the reconstruction back to the image plane (via the.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our pixelization source galaxy reconstruction.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Regularization Term:** The second term, $s^{T} H s$, corresponds to the $\lambda $G_{\rm L}$ regularization term we added.
+- **Complexity Terms:** Up to this point, it is unclear why we chose a value of `regularization_coefficient=1.0`.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the model, by combining the five terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Simplifications__
 

--- a/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
+++ b/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
@@ -32,11 +32,11 @@ and computes it from scratch if not.
 
 __Contents__
 
-**High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
-**Profiling Dataset:** The code above loads a dataset with very few visibilities and a low resolution real space mask, so.
-**Curvature Preload:** Pixelized source modeling requires dense linear algebra operations.
-**Curvature Preload Output:** We now output the `nufft_precision_operator` object to hard-disk, so it can be loaded quickly in.
-**Wrap Up:** Summary of the script and next steps.
+- **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
+- **Profiling Dataset:** The code above loads a dataset with very few visibilities and a low resolution real space mask, so.
+- **Curvature Preload:** Pixelized source modeling requires dense linear algebra operations.
+- **Curvature Preload Output:** We now output the `nufft_precision_operator` object to hard-disk, so it can be loaded quickly in.
+- **Wrap Up:** Summary of the script and next steps.
 
 __High Resolution Dataset__
 

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -26,29 +26,29 @@ initial setup can be performed before lens modeling and saved to hard disk for f
 
 __Contents__
 
-**CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
-**Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
-**Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
-**Model:** Compose the lens model fitted to the data.
-**High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
-**Settings:** As discussed above, disable the default position only linear algebra solver so the source.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
-**Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
-**Search:** Configure the non-linear search used to fit the model.
-**Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
-**Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Result Use:** There are many things you can do with the result of a pixelixaiton, including analysing the.
-**Wrap Up:** Summary of the script and next steps.
-**Chaining:** Modeling using a pixelization can be more efficient, robust and automated using the non-linear.
-**HowToLens:** A full description of how pixelizations work, which comes down to a lot of linear algebra, Bayesian.
+- **CPU Users:** Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra.
+- **Advantages & Disadvantages:** Many strongly lensed source galaxies exhibit complex, asymmetric, and irregular morphologies.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model fitted to the data.
+- **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Sparse Operators:** Pixelized source modeling requires dense linear algebra operations.
+- **Settings:** As discussed above, disable the default position only linear algebra solver so the source.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Mesh Shape:** The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to reconstruct the.
+- **Edge Zeroing:** By default, all pixels at the edge of the mesh in the source-plane are forced to solutions of zero.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Position Likelihood:** We add a penalty term ot the likelihood function, which penalizes models where the brightest.
+- **Brief Description:** Unlike other example scripts, we also pass the `AnalysisImaging` object below a `PositionsLH`.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **VRAM:** The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Result Use:** There are many things you can do with the result of a pixelixaiton, including analysing the.
+- **Wrap Up:** Summary of the script and next steps.
+- **Chaining:** Modeling using a pixelization can be more efficient, robust and automated using the non-linear.
+- **HowToLens:** A full description of how pixelizations work, which comes down to a lot of linear algebra, Bayesian.
 
 __Advantages__
 

--- a/scripts/interferometer/features/pixelization/slam.py
+++ b/scripts/interferometer/features/pixelization/slam.py
@@ -24,19 +24,19 @@ Other than that, the interferometer SLaM pipeline is identical to the imaging SL
 
 __Contents__
 
-**Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
-**Interferometer SLaM Description:** The `slam_start_here` notebook provides a detailed description of the SLaM pipelines, but it does.
-**High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
-**SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
-**Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-**Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
-**Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **Interferometer SLaM Description:** The `slam_start_here` notebook provides a detailed description of the SLaM pipelines, but it does.
+- **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
+- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
+- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
+- **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __Prerequisites__
 

--- a/scripts/interferometer/features/pixelization/source_science.py
+++ b/scripts/interferometer/features/pixelization/source_science.py
@@ -17,15 +17,15 @@ for analysis without the need for PyAutoLens.
 
 __Contents__
 
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Interpolated Source:** The simplest way to perform source science calculations on a pixelized source reconstruction is to.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Zoom:** The interpolation grid above was large in extent (-3.0" to 3.0" in both the y and x directions).
-**Errors:** The interpolated errors on the source reconstruction can also be computed, which will allow you to.
-**Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Masking:** Reconstructions can be imperfect, for example having faint source flux in pixels at the edge of the.
-**Magnification via Mesh:** The calculations above used an interpolation of the source-plane reconstruction to a 2D grid of.
-**Reconstruction CSV:** In the results `image` folder there is a .csv file called `source_plane_reconstruction_0.csv` which.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Interpolated Source:** The simplest way to perform source science calculations on a pixelized source reconstruction is to.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Zoom:** The interpolation grid above was large in extent (-3.0" to 3.0" in both the y and x directions).
+- **Errors:** The interpolated errors on the source reconstruction can also be computed, which will allow you to.
+- **Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Masking:** Reconstructions can be imperfect, for example having faint source flux in pixels at the edge of the.
+- **Magnification via Mesh:** The calculations above used an interpolation of the source-plane reconstruction to a 2D grid of.
+- **Reconstruction CSV:** In the results `image` folder there is a .csv file called `source_plane_reconstruction_0.csv` which.
 
 """
 

--- a/scripts/interferometer/features/subhalo/detect/start_here.py
+++ b/scripts/interferometer/features/subhalo/detect/start_here.py
@@ -15,20 +15,20 @@ The example illustrates DM subhalo detection with **PyAutoLens**.
 
 __Contents__
 
-**SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
-**Grid Search:** The second stage of the SUBHALO PIPELINE uses a grid-search of non-linear searches to determine the.
-**Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
-**Model:** Compose the lens model fitted to the data.
-**SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-**SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
-**MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
-**Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-**Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
-**Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+- **SLaM Pipelines:** The Source, (lens) Light and Mass (SLaM) pipelines are advanced lens modeling pipelines which.
+- **Grid Search:** The second stage of the SUBHALO PIPELINE uses a grid-search of non-linear searches to determine the.
+- **Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
+- **Model:** Compose the lens model fitted to the data.
+- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
+- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
+- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
+- **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
 
 __SLaM Pipelines__
 

--- a/scripts/interferometer/features/subhalo/simulator.py
+++ b/scripts/interferometer/features/subhalo/simulator.py
@@ -10,12 +10,12 @@ This script simulates `Interferometer` data of a 'galaxy-scale' strong lens wher
 
 __Contents__
 
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated (in this case, `Interferometer` data).
-**Simulate:** For simulating interferometer data of a strong lens, we recommend using a Grid2D object with a.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear), subhalo (NFW) and source galaxy light (elliptical Sersic).
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated (in this case, `Interferometer` data).
+- **Simulate:** For simulating interferometer data of a strong lens, we recommend using a Grid2D object with a.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear), subhalo (NFW) and source galaxy light (elliptical Sersic).
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Start Here Notebook__
 

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -15,14 +15,14 @@ This example uses functionality described fully in other examples in the `guides
 
 __Contents__
 
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Loading Data:** We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset we.
-**Fitting:** Fit the lens model to the dataset and inspect the results.
-**Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
-**Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
-**Figures of Merit:** There are single valued floats which quantify the goodness of fit.
-**Plane Quantities:** The `FitInterferometer` object has specific quantities which break down each image of each plane.
-**Outputting Results:** You may wish to output certain results to .fits files for later inspection.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Loading Data:** We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset we.
+- **Fitting:** Fit the lens model to the dataset and inspect the results.
+- **Bad Fit:** A bad lens model will show features in the residual-map and chi-squared map.
+- **Fit Quantities:** The maximum log likelihood fit contains many 1D and 2D arrays showing the fit.
+- **Figures of Merit:** There are single valued floats which quantify the goodness of fit.
+- **Plane Quantities:** The `FitInterferometer` object has specific quantities which break down each image of each plane.
+- **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
 
 """
 

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -16,24 +16,24 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
-**Lens Galaxy Mass:** We next define the mass profiles which represents the lens galaxy's mass, which will be used to.
-**Lens Galaxy:** We now combine the light and mass profiles into a single `Galaxy` object for the lens galaxy.
-**Source Galaxy Light Profile:** The source galaxy is fitted using another analytic light profile, in this example another.
-**Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the an.
-**Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
-**Source Image:** We pass the traced grid of coordinates to the source galaxy to evaluate its 2D image.
-**Fourier Transform:** Fourier Transform the 2D image of the galaxy above using the Non Uniform Fast Fourier Transform.
-**Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
-**Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
-**Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
-**Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
-**Fit:** Fit the lens model to the dataset.
-**Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
-**Wrap Up:** Summary of the script and next steps.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Masked Image Grid:** To perform galaxy calculations we define a 2D image-plane grid of (y,x) coordinates.
+- **Lens Galaxy Mass:** We next define the mass profiles which represents the lens galaxy's mass, which will be used to.
+- **Lens Galaxy:** We now combine the light and mass profiles into a single `Galaxy` object for the lens galaxy.
+- **Source Galaxy Light Profile:** The source galaxy is fitted using another analytic light profile, in this example another.
+- **Lens Light:** Compute a 2D image of the lens galaxy's light as the sum of its individual light profiles (the an.
+- **Ray Tracing:** To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\theta$ from the.
+- **Source Image:** We pass the traced grid of coordinates to the source galaxy to evaluate its 2D image.
+- **Fourier Transform:** Fourier Transform the 2D image of the galaxy above using the Non Uniform Fast Fourier Transform.
+- **Likelihood Function:** We now quantify the goodness-of-fit of our galaxy model.
+- **Chi Squared:** The first term is a $\chi^2$ statistic, which is defined above in our merit function as and is.
+- **Noise Normalization Term:** Our likelihood function assumes the imaging data consists of independent Gaussian noise in every.
+- **Calculate The Log Likelihood:** We can now, finally, compute the `log_likelihood` of the galaxy model, by combining the two terms.
+- **Fit:** Fit the lens model to the dataset.
+- **Lens Modeling:** To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -7,28 +7,28 @@ visibilities (e.g. SMA, ALMA) and it provides an overview of the lens modeling A
 
 __Contents__
 
-**Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
-**Model:** Compose the lens model fitted to the data.
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Dataset:** Load and plot the strong lens dataset.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Coordinates:** Coordinate system assumptions for the model-fit.
-**Improved Lens Model:** The previous model used Sérsic light profiles for the source galaxy.
-**Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge via the ``lp_linear`` API.
-**Concise API:** The MGE model composition API is quite long and technical, so we simply load the MGE models for the.
-**Search:** Configure the non-linear search used to fit the model.
-**Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-**Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Overview of the results of the model-fit.
-**Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
-**Data Preparation:** Data standards required for fitting with PyAutoLens.
-**HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
-**Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
+- **Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
+- **Model:** Compose the lens model fitted to the data.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Coordinates:** Coordinate system assumptions for the model-fit.
+- **Improved Lens Model:** The previous model used Sérsic light profiles for the source galaxy.
+- **Linear Light Profiles:** The MGE model below uses a **linear light profile** for the bulge via the ``lp_linear`` API.
+- **Concise API:** The MGE model composition API is quite long and technical, so we simply load the MGE models for the.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
+- **Iterations Per Update:** Every `iterations_per_quick_update`, the non-linear search outputs the maximum likelihood model and.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Overview of the results of the model-fit.
+- **Features:** This script gives a concise overview of the basic modeling API, fitting one the simplest lens.
+- **Data Preparation:** Data standards required for fitting with PyAutoLens.
+- **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
+- **Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
 
 __Number of Visibilities__
 

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -9,15 +9,15 @@ This script simulates `Interferometer` data of a 'galaxy-scale' strong lens wher
 
 __Contents__
 
-**Grid:** Define the 2d grid of (y,x) coordinates that the galaxy images are evaluated and therefore.
-**Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy light (elliptical Sersic) for this.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Multiple Images:** Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x).
-**Many Visibilities:** Simulating interferometer datasets with many visibilities can be computationally expensive if a.
-**High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
+- **Grid:** Define the 2d grid of (y,x) coordinates that the galaxy images are evaluated and therefore.
+- **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy light (elliptical Sersic) for this.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Multiple Images:** Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x).
+- **Many Visibilities:** Simulating interferometer datasets with many visibilities can be computationally expensive if a.
+- **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
 
 """
 

--- a/scripts/interferometer/source_science.py
+++ b/scripts/interferometer/source_science.py
@@ -12,13 +12,13 @@ is conceptually the simplest case for source science calculations and a good int
 
 __Contents__
 
-**Mask:** Define the 2D mask applied to the dataset for the model-fit.
-**Loading Data:** We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset we.
-**Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
-**Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
-**Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
-**Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
-**Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
+- **Mask:** Define the 2D mask applied to the dataset for the model-fit.
+- **Loading Data:** We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset we.
+- **Source Values:** Source science calculations for real lenses are performed using the best-fitting model inferred.
+- **Source Flux:** A key quantity for a source galaxy is its total flux, which can be used to compute magnitudes (see.
+- **Source Magnification:** The overall magnification of the source is estimated as the ratio of total surface brightness in.
+- **Tracer:** Lens modeling returns a `max_log_likelihood_tracer`, which is likely the object you have at hand to.
+- **Parametric Source Models:** If your lens modeling uses a parametric source model (e.g.
 
 """
 

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -14,18 +14,18 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Model:** Compose the lens model fitted to the data.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Result:** Overview of the results of the model-fit.
-**Model Your Own Lens:** If you have your own strong lens interferometer data, and it has less than ~10000 visibilities, you.
-**Simulator:** Let’s now switch gears and simulate our own strong lens interferometer.
-**Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Model:** Compose the lens model fitted to the data.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Result:** Overview of the results of the model-fit.
+- **Model Your Own Lens:** If you have your own strong lens interferometer data, and it has less than ~10000 visibilities, you.
+- **Simulator:** Let’s now switch gears and simulate our own strong lens interferometer.
+- **Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -23,14 +23,14 @@ the coordinates of the image pixels which are input into these profiles to compu
 
 __Contents__
 
-**Advantages & Disadvantages:** If one fits a lens model to one dataset and applies it to other datasets, it is common to see the.
-**Model:** Compose the lens model fitted to the data.
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
+- **Advantages & Disadvantages:** If one fits a lens model to one dataset and applies it to other datasets, it is common to see the.
+- **Model:** Compose the lens model fitted to the data.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
 
 __Advantages__
 

--- a/scripts/multi/features/dataset_offsets/simulator.py
+++ b/scripts/multi/features/dataset_offsets/simulator.py
@@ -19,15 +19,15 @@ how to include the offset as a free parameter in the model-fit.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Dataset Paths:** Overview of dataset paths for this example.
-**Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
-**Offset:** Offset the second grid from the first grid by the pixel scale in both the y and x directions.
-**Ray Tracing:** The lens galaxy light at each wavelength has a different intensity, thus we create two lens.
-**Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Dataset Paths:** Overview of dataset paths for this example.
+- **Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
+- **Offset:** Offset the second grid from the first grid by the pixel scale in both the y and x directions.
+- **Ray Tracing:** The lens galaxy light at each wavelength has a different intensity, thus we create two lens.
+- **Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/multi/features/imaging_and_interferometer/modeling.py
+++ b/scripts/multi/features/imaging_and_interferometer/modeling.py
@@ -10,15 +10,15 @@ This script fits an `Interferometer` and `Imaging` dataset of a 'galaxy-scale' s
 
 __Contents__
 
-**Benefits:** A number of benefits are apparently if we combine the analysis of both datasets at both wavelengths.
-**Interferometer Masking:** We define the ‘real_space_mask’ which defines the grid the image the strong lens is evaluated using.
-**Interferometer Dataset:** Load and plot the strong lens `Interferometer` dataset `simple__no_lens_light` from .fits files.
-**Imaging Dataset:** Load and plot the strong lens dataset `simple__no_lens_light` via .fits files, which we will fit.
-**Imaging Masking:** Define a 3.0" circular mask, which includes the emission of the lens and source galaxies.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
+- **Benefits:** A number of benefits are apparently if we combine the analysis of both datasets at both wavelengths.
+- **Interferometer Masking:** We define the ‘real_space_mask’ which defines the grid the image the strong lens is evaluated using.
+- **Interferometer Dataset:** Load and plot the strong lens `Interferometer` dataset `simple__no_lens_light` from .fits files.
+- **Imaging Dataset:** Load and plot the strong lens dataset `simple__no_lens_light` via .fits files, which we will fit.
+- **Imaging Masking:** Define a 3.0" circular mask, which includes the emission of the lens and source galaxies.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
 
 __Benefits__
 

--- a/scripts/multi/features/imaging_and_interferometer/simulator.py
+++ b/scripts/multi/features/imaging_and_interferometer/simulator.py
@@ -14,11 +14,11 @@ It is used to demonstrate the combination of imaging and interferometer datasets
 
 __Contents__
 
-**Simulate:** For simulating interferometer data of a strong lens, we recommend using a Grid2D object with a.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy light (elliptical Sersic) for this.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Simulate:** For simulating interferometer data of a strong lens, we recommend using a Grid2D object with a.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy light (elliptical Sersic) for this.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 """
 

--- a/scripts/multi/features/one_by_one/modeling.py
+++ b/scripts/multi/features/one_by_one/modeling.py
@@ -35,15 +35,15 @@ We illustrate different examples in this script, with the appropriate choice dep
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
-**Second Dataset Mass Model Fixed:** We now fit the second dataset using the inferred model of the first dataset as the starting point.
-**Second Dataset Offset:** Multi-wavelength datasets often have offsets between their images, which are due to the different.
+- **Model:** Compose the lens model fitted to the data.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
+- **Second Dataset Mass Model Fixed:** We now fit the second dataset using the inferred model of the first dataset as the starting point.
+- **Second Dataset Offset:** Multi-wavelength datasets often have offsets between their images, which are due to the different.
 
 __Model__
 

--- a/scripts/multi/features/pixelization/modeling.py
+++ b/scripts/multi/features/pixelization/modeling.py
@@ -15,15 +15,15 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Positions:** This fit also uses the arc-second positions of the multiply imaged lensed source galaxy, which were.
-**Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Positions:** This fit also uses the arc-second positions of the multiply imaged lensed source galaxy, which were.
+- **Mesh Shape:** As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
 
 """
 

--- a/scripts/multi/features/pixelization/simulator.py
+++ b/scripts/multi/features/pixelization/simulator.py
@@ -14,13 +14,13 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Dataset Paths:** Overview of dataset paths for this example.
-**Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
-**Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Dataset Paths:** Overview of dataset paths for this example.
+- **Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
+- **Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 """
 

--- a/scripts/multi/features/same_wavelength/modeling.py
+++ b/scripts/multi/features/same_wavelength/modeling.py
@@ -20,12 +20,12 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Pixel Scales:** If observed at the same wavelength, it is likely the datasets have the same pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
+- **Pixel Scales:** If observed at the same wavelength, it is likely the datasets have the same pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
 
 """
 

--- a/scripts/multi/features/same_wavelength/simulator.py
+++ b/scripts/multi/features/same_wavelength/simulator.py
@@ -20,12 +20,12 @@ TODO: NEED TO INCLUDE DIFFERENT POINTING / CENTERINGS.
 
 __Contents__
 
-**Dataset Paths:** Overview of dataset paths for this example.
-**Simulate:** If observed at the same wavelength, it is likely the datasets have the same pixel-scale.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
-**Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Dataset Paths:** Overview of dataset paths for this example.
+- **Simulate:** If observed at the same wavelength, it is likely the datasets have the same pixel-scale.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
+- **Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 """
 

--- a/scripts/multi/features/slam/independent.py
+++ b/scripts/multi/features/slam/independent.py
@@ -32,16 +32,16 @@ fixed to the result of the VIS fit.
 
 __Contents__
 
-**Preqrequisites:** Before using this SLaM pipeline, you should be familiar with.
-**This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
-**Second Dataset Fits:** We now fit the secondary multi-wavelength datasets, which are lower resolution than the main.
-**Dataset Wavebands:** The following list gives the names of the wavebands we are going to fit.
-**Result Dict:** The results of each fit are stored in a dictionary, which is used to pass the results of each fit.
+- **Preqrequisites:** Before using this SLaM pipeline, you should be familiar with.
+- **This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Second Dataset Fits:** We now fit the secondary multi-wavelength datasets, which are lower resolution than the main.
+- **Dataset Wavebands:** The following list gives the names of the wavebands we are going to fit.
+- **Result Dict:** The results of each fit are stored in a dictionary, which is used to pass the results of each fit.
 
 __Preqrequisites__
 

--- a/scripts/multi/features/slam/simultaneous.py
+++ b/scripts/multi/features/slam/simultaneous.py
@@ -27,13 +27,13 @@ them as you see fit.
 
 __Contents__
 
-**Preqrequisites:** Before reading this script, you should have familiarity with the following key concepts.
-**This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
-**Dataset:** Load and plot the strong lens dataset.
-**Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
-**Redshifts:** The redshifts of the lens and source galaxies.
-**SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
-**SLaM Pipeline:** Overview of slam pipeline for this example.
+- **Preqrequisites:** Before reading this script, you should have familiarity with the following key concepts.
+- **This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **SLaM Pipeline Functions:** Overview of slam pipeline functions for this example.
+- **SLaM Pipeline:** Overview of slam pipeline for this example.
 
 __Preqrequisites__
 

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -15,15 +15,15 @@ package. If anything is unclear check those scripts out.
 
 __Contents__
 
-**Effective Radius vs Wavelength:** Unlike other `multi` modeling scripts, the effective radius of the lens and source galaxies as a.
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Wavelengths:** The effective_radius of each source galaxy is parameterized as a function of wavelength.
-**Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model:** Compose the lens model fitted to the data.
-**Search:** Configure the non-linear search used to fit the model.
-**Result:** Overview of the results of the model-fit.
+- **Effective Radius vs Wavelength:** Unlike other `multi` modeling scripts, the effective radius of the lens and source galaxies as a.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Wavelengths:** The effective_radius of each source galaxy is parameterized as a function of wavelength.
+- **Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model:** Compose the lens model fitted to the data.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Result:** Overview of the results of the model-fit.
 
 __Effective Radius vs Wavelength__
 

--- a/scripts/multi/features/wavelength_dependence/simulator.py
+++ b/scripts/multi/features/wavelength_dependence/simulator.py
@@ -22,15 +22,15 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band), red (r-band) and.
-**Wavelengths:** The intensity of each source galaxy is parameterized as a function of wavelength.
-**Dataset Paths:** Overview of dataset paths for this example.
-**Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
-**Intensity vs Wavelength:** We will assume that the `intensity` of the lens and source galaxies linearly varies as a function.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
-**Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band), red (r-band) and.
+- **Wavelengths:** The intensity of each source galaxy is parameterized as a function of wavelength.
+- **Dataset Paths:** Overview of dataset paths for this example.
+- **Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
+- **Intensity vs Wavelength:** We will assume that the `intensity` of the lens and source galaxies linearly varies as a function.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) for this simulated lens.
+- **Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 """
 

--- a/scripts/multi/modeling.py
+++ b/scripts/multi/modeling.py
@@ -15,20 +15,20 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Model:** Compose the lens model fitted to the data.
-**Model Extension:** Galaxies change appearance across wavelength, for example their ellipticities.
-**Linear Light Profiles:** As an advanced user you should be familiar wiht linear light profiles, see elsewhere in the.
-**Analysis List:** Set up two instances of the `Analysis` class object, one for each dataset.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs it with the model and prepares.
-**Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
-**Search:** Configure the non-linear search used to fit the model.
-**VRAM Use:** The `modeling` examples of individual dataset types explain how VRAM is used during GPU-based.
-**Result:** Overview of the results of the model-fit.
-**Wrap Up:** Summary of the script and next steps.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Pixel Scales:** Every multi-wavelength dataset can have its own unique pixel-scale.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Model:** Compose the lens model fitted to the data.
+- **Model Extension:** Galaxies change appearance across wavelength, for example their ellipticities.
+- **Linear Light Profiles:** As an advanced user you should be familiar wiht linear light profiles, see elsewhere in the.
+- **Analysis List:** Set up two instances of the `Analysis` class object, one for each dataset.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs it with the model and prepares.
+- **Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
+- **Search:** Configure the non-linear search used to fit the model.
+- **VRAM Use:** The `modeling` examples of individual dataset types explain how VRAM is used during GPU-based.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
 
 """
 

--- a/scripts/multi/plot.py
+++ b/scripts/multi/plot.py
@@ -16,12 +16,12 @@ The dedicated `aplt.subplot_imaging_dataset()` function is also shown for single
 
 __Contents__
 
-**Dataset:** Load and plot the strong lens dataset.
-**Single Dataset Subplots:** Plot the full subplot overview of each dataset using `aplt.subplot_imaging_dataset()`.
-**Multi Dataset Plot:** Plot the data image from each dataset side-by-side on the same matplotlib figure.
-**Multi Dataset Array Plot:** We can also call `aplt.plot_array()` for each dataset separately.
-**Multi Fits:** We can also output a list of figures to a single `.fits` file, where each image goes in each HDU.
-**Wrap Up:** Summary of the script and next steps.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Single Dataset Subplots:** Plot the full subplot overview of each dataset using `aplt.subplot_imaging_dataset()`.
+- **Multi Dataset Plot:** Plot the data image from each dataset side-by-side on the same matplotlib figure.
+- **Multi Dataset Array Plot:** We can also call `aplt.plot_array()` for each dataset separately.
+- **Multi Fits:** We can also output a list of figures to a single `.fits` file, where each image goes in each HDU.
+- **Wrap Up:** Summary of the script and next steps.
 
 __Start Here Notebook__
 

--- a/scripts/multi/simulator.py
+++ b/scripts/multi/simulator.py
@@ -15,13 +15,13 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
-**Dataset Paths:** Overview of dataset paths for this example.
-**Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
-**Ray Tracing:** The lens galaxy light at each wavelength has a different intensity, thus we create two lens.
-**Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
-**Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Colors:** The colors of the multi-wavelength image, which in this case are green (g-band) and red (r-band).
+- **Dataset Paths:** Overview of dataset paths for this example.
+- **Simulate:** The pixel-scale of each color image is different meaning we make a list of grids for the simulation.
+- **Ray Tracing:** The lens galaxy light at each wavelength has a different intensity, thus we create two lens.
+- **Output:** Output each simulated dataset to the dataset path as .fits files, with a tag describing its color.
+- **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 """
 

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -21,19 +21,19 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Extra Galaxy Removal:** There may be regions of an image that have signal near the lens and source that is from other.
-**Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
-**Model:** Compose the lens model fitted to the data.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Result:** Overview of the results of the model-fit.
-**Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
-**Simulator:** In the example `start_here_imaging.ipynb`, we showed how to simulate CCD imaging of a strong lens.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Extra Galaxy Removal:** There may be regions of an image that have signal near the lens and source that is from other.
+- **Masking:** Lens modeling does not need to fit the entire image, only the region containing lens and source.
+- **Model:** Compose the lens model fitted to the data.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Result:** Overview of the results of the model-fit.
+- **Model Your Own Lens:** If you have your own strong lens imaging data, you are now ready to model it yourself by adapting.
+- **Simulator:** In the example `start_here_imaging.ipynb`, we showed how to simulate CCD imaging of a strong lens.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/point_source/features/deblending/modeling.py
+++ b/scripts/point_source/features/deblending/modeling.py
@@ -28,17 +28,17 @@ properties of the lens galaxy's light.
 
 __Contents__
 
-**Image Plane Multiple Images:** When fitting the `Imaging` dataset in order to deblend the lensed point-source images and lens.
-**Point Source Host Galaxy:** For high quality imaging of a lensed point source, the light from the point source's host galaxy.
-**Imaging:** This example script fits `Imaging` data, using many of the features described in the.
-**Model:** Compose the lens model fitted to the data.
-**Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
-**Model Cookbook:** A full description of model composition is provided by the model cookbook.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Run Time:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Point Source:** After the analysis above is complete, the lens model infers the following information.
+- **Image Plane Multiple Images:** When fitting the `Imaging` dataset in order to deblend the lensed point-source images and lens.
+- **Point Source Host Galaxy:** For high quality imaging of a lensed point source, the light from the point source's host galaxy.
+- **Imaging:** This example script fits `Imaging` data, using many of the features described in the.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset & Mask:** Standard set up of the dataset and mask that is fitted.
+- **Model Cookbook:** A full description of model composition is provided by the model cookbook.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Point Source:** After the analysis above is complete, the lens model infers the following information.
 
 __Image Plane Multiple Images__
 

--- a/scripts/point_source/features/deblending/simulator.py
+++ b/scripts/point_source/features/deblending/simulator.py
@@ -17,12 +17,12 @@ The simulation procedure in this script simulates the lens in two steps:
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Point Solver:** We use a `PointSolver` to locate the multiple images.
-**Fluxes:** Use the positions to compute the magnification of the `Tracer` at every position.
-**Output:** Output the simulated dataset to the dataset path as .fits files.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Point Solver:** We use a `PointSolver` to locate the multiple images.
+- **Fluxes:** Use the positions to compute the magnification of the `Tracer` at every position.
+- **Output:** Output the simulated dataset to the dataset path as .fits files.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Model__
 

--- a/scripts/point_source/features/fluxes.py
+++ b/scripts/point_source/features/fluxes.py
@@ -16,13 +16,13 @@ or confident the fluxes are not affected by it.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset:** Load and plot the strong lens dataset.
-**Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
 
 __Model__
 

--- a/scripts/point_source/features/multiple_sources/modeling.py
+++ b/scripts/point_source/features/multiple_sources/modeling.py
@@ -33,16 +33,16 @@ is correct as soon as #480 lands; no script changes will be needed once it does.
 
 __Contents__
 
-**Dataset:** Load the list of `PointDataset` objects, one per lensed source.
-**Point Solver:** We set up the `PointSolver`, which determines the multiple images of each point source.
-**Model:** Compose the multi-plane lens model fitted to the data.
-**Name Pairing:** Each `PointDataset` name is paired with a `Point` model component of the same name.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis List:** Set up one `AnalysisPoint` per dataset.
-**Analysis Factor:** Each analysis is wrapped in an `AnalysisFactor` paired with the shared lens model.
-**Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`.
-**Model-Fit:** Pass the factor graph to the non-linear search.
-**Result:** Iterate the per-analysis results returned by the factor-graph fit.
+- **Dataset:** Load the list of `PointDataset` objects, one per lensed source.
+- **Point Solver:** We set up the `PointSolver`, which determines the multiple images of each point source.
+- **Model:** Compose the multi-plane lens model fitted to the data.
+- **Name Pairing:** Each `PointDataset` name is paired with a `Point` model component of the same name.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis List:** Set up one `AnalysisPoint` per dataset.
+- **Analysis Factor:** Each analysis is wrapped in an `AnalysisFactor` paired with the shared lens model.
+- **Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`.
+- **Model-Fit:** Pass the factor graph to the non-linear search.
+- **Result:** Iterate the per-analysis results returned by the factor-graph fit.
 
 __Start Here Notebook__
 

--- a/scripts/point_source/features/multiple_sources/simulator.py
+++ b/scripts/point_source/features/multiple_sources/simulator.py
@@ -28,12 +28,12 @@ intended form so the example is correct as soon as #480 lands; no script changes
 
 __Contents__
 
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy `Point` for this simulated lens.
-**Point Solver:** We use a `PointSolver` to locate the multiple images.
-**Point Datasets:** Create a point-source data object and output this to a `.json` file, which is the format used to.
-**Visualize:** Output a subplot of the simulated point source dictionary and the tracer's quantities to the.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE+Shear) and source galaxy `Point` for this simulated lens.
+- **Point Solver:** We use a `PointSolver` to locate the multiple images.
+- **Point Datasets:** Create a point-source data object and output this to a `.json` file, which is the format used to.
+- **Visualize:** Output a subplot of the simulated point source dictionary and the tracer's quantities to the.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 
 __Start Here Notebook__
 

--- a/scripts/point_source/features/time_delays.py
+++ b/scripts/point_source/features/time_delays.py
@@ -16,14 +16,14 @@ or another measureable quantity that uses time delays.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset:** Load and plot the strong lens dataset.
-**Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
-**Search:** Configure the non-linear search used to fit the model.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Result:** Overview of the results of the model-fit.
-**Cosmology:** Time Delay lenses allow the Hubble constant to be constrained, because the difference between the.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Point Solver:** We set up the `PointSolver`, which is used to compute the multiple images of the point source in.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Cosmology:** Time Delay lenses allow the Hubble constant to be constrained, because the difference between the.
 
 __Model__
 

--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -22,23 +22,23 @@ If you are new to analyzing strong lenses with point sources, this guide is the 
 
 __Contents__
 
-**Lensed Point Source:** To begin, we create a strong lens image using an isothermal mass model and a source with a compact.
-**Point Source:** The image above visually illustrates where the source’s light is traced on the image plane.
-**Point Solver:** For a point source, our goal is to find the (y, x) coordinates in the image plane that map directly.
-**Number of Solutions:** The number of solutions (e.g.
-**Solving the Lens Equation:** In the literature, the process of finding the multiple images of a source in the image-plane is.
-**Triangle Tracing:** Computing the multiple image positions of a point source is a non-linear problem.
-**Dataset:** Load and plot the strong lens dataset.
-**Name Pairing:** The names of the point-source datasets have an even more important role, the names are used to pair.
-**Fitting:** Fit the lens model to the dataset and inspect the results.
-**Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
-**Fluxes:** Another measurable quantity of a point source is its flux—the total amount of light received from.
-**Flux Point Dataset:** The fluxes are not input a `PointDataset` object, alongside the image-plane coordinates of the.
-**Flux Fitting:** Above, we used a `FitPointDataset` to fit the positions of the point source in the image-plane.
-**Time Delays:** Another measurable quantity of a point source is its time delay—the time it takes for light to.
-**Time Delay Fitting:** We can also use the `FitPointDataset` to fit the time delays of the point source, which is done by.
-**New User Wrap Up:** The `point_source` package of the `autolens_workspace` contains numerous example scripts for.
-**Shape Solver:** All calculations above assumed the source was a point source with no size.
+- **Lensed Point Source:** To begin, we create a strong lens image using an isothermal mass model and a source with a compact.
+- **Point Source:** The image above visually illustrates where the source’s light is traced on the image plane.
+- **Point Solver:** For a point source, our goal is to find the (y, x) coordinates in the image plane that map directly.
+- **Number of Solutions:** The number of solutions (e.g.
+- **Solving the Lens Equation:** In the literature, the process of finding the multiple images of a source in the image-plane is.
+- **Triangle Tracing:** Computing the multiple image positions of a point source is a non-linear problem.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Name Pairing:** The names of the point-source datasets have an even more important role, the names are used to pair.
+- **Fitting:** Fit the lens model to the dataset and inspect the results.
+- **Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
+- **Fluxes:** Another measurable quantity of a point source is its flux—the total amount of light received from.
+- **Flux Point Dataset:** The fluxes are not input a `PointDataset` object, alongside the image-plane coordinates of the.
+- **Flux Fitting:** Above, we used a `FitPointDataset` to fit the positions of the point source in the image-plane.
+- **Time Delays:** Another measurable quantity of a point source is its time delay—the time it takes for light to.
+- **Time Delay Fitting:** We can also use the `FitPointDataset` to fit the time delays of the point source, which is done by.
+- **New User Wrap Up:** The `point_source` package of the `autolens_workspace` contains numerous example scripts for.
+- **Shape Solver:** All calculations above assumed the source was a point source with no size.
 
 """
 

--- a/scripts/point_source/modeling.py
+++ b/scripts/point_source/modeling.py
@@ -7,24 +7,24 @@ positions of a lensed quasar.
 
 __Contents__
 
-**Not Using Light Profiles:** Users who are familiar with analysing imaging or interferometer data will be used to performing.
-**Model:** Compose the lens model fitted to the data.
-**Dataset:** Load and plot the strong lens dataset.
-**Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
-**Model Composition:** Compose the lens model using the Model and Collection API.
-**Name Pairing:** Every point-source dataset in the `PointDataset` has a name, which in this example was `point_0`.
-**Coordinates:** Coordinate system assumptions for the model-fit.
-**Search:** Configure the non-linear search used to fit the model.
-**Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-**Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
-**Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
-**Run Times:** Profiling the expected run time of the model-fit.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Overview of the results of the model-fit.
-**Results:** Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
-**Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
+- **Not Using Light Profiles:** Users who are familiar with analysing imaging or interferometer data will be used to performing.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
+- **Model Composition:** Compose the lens model using the Model and Collection API.
+- **Name Pairing:** Every point-source dataset in the `PointDataset` has a name, which in this example was `point_0`.
+- **Coordinates:** Coordinate system assumptions for the model-fit.
+- **Search:** Configure the non-linear search used to fit the model.
+- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
+- **Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
+- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **VRAM Use:** When running AutoLens with JAX on a GPU, the analysis must fit within the GPU’s available VRAM.
+- **Run Times:** Profiling the expected run time of the model-fit.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Overview of the results of the model-fit.
+- **Results:** Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+- **Modeling Customization:** The folders `autolens_workspace/*/guides/modeling/searches` gives an overview of alternative.
 
 __Not Using Light Profiles__
 

--- a/scripts/point_source/simulator.py
+++ b/scripts/point_source/simulator.py
@@ -9,17 +9,17 @@ After reading this script, the `examples` folder provide examples for simulating
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated (in this case, `PointDataset` data).
-**Ray Tracing:** Setup the lens galaxy's mass (SIE) and source galaxy (a point source) for this simulated lens.
-**Point Solver:** For a point source, our goal is to find the (y, x) coordinates in the image plane that map directly.
-**Point Datasets:** All the quantities computed above are stored in a `PointDataset` object, which organizes.
-**Visualize:** Output a subplot of the simulated point source dataset as a .png file.
-**Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
-**Imaging:** Point-source data typically comes with imaging data of the strong lens, for example showing the 4.
-**Fluxes:** Another measurable quantity of a point source is its flux—the total amount of light received from.
-**Point Dataset:** The fluxes are not input a `PointDataset` object, alongside the image-plane coordinates of the.
-**Time Delays:** Another measurable quantity of a point source is its time delay—the time it takes for light to.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated (in this case, `PointDataset` data).
+- **Ray Tracing:** Setup the lens galaxy's mass (SIE) and source galaxy (a point source) for this simulated lens.
+- **Point Solver:** For a point source, our goal is to find the (y, x) coordinates in the image plane that map directly.
+- **Point Datasets:** All the quantities computed above are stored in a `PointDataset` object, which organizes.
+- **Visualize:** Output a subplot of the simulated point source dataset as a .png file.
+- **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
+- **Imaging:** Point-source data typically comes with imaging data of the strong lens, for example showing the 4.
+- **Fluxes:** Another measurable quantity of a point source is its flux—the total amount of light received from.
+- **Point Dataset:** The fluxes are not input a `PointDataset` object, alongside the image-plane coordinates of the.
+- **Time Delays:** Another measurable quantity of a point source is its time delay—the time it takes for light to.
 
 __Model__
 

--- a/scripts/point_source/simulator_sample.py
+++ b/scripts/point_source/simulator_sample.py
@@ -20,12 +20,12 @@ Cosmological parameters.
 
 __Contents__
 
-**Model:** Compose the lens model fitted to the data.
-**Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
-**Point Solver:** We use a `PointSolver` to locate the multiple images.
-**Sample Model Distributions:** To simulate a sample, we draw random instances of lens and source galaxies where the parameters of.
-**Simulate:** Simulate the image data using a (y,x) grid with the adaptive over sampling scheme.
-**Sample Instances:** Within a for loop, we will now generate instances of the lens and source galaxies using the.
+- **Model:** Compose the lens model fitted to the data.
+- **Dataset Paths:** The `dataset_type` describes the type of data being simulated and `dataset_name` gives it a.
+- **Point Solver:** We use a `PointSolver` to locate the multiple images.
+- **Sample Model Distributions:** To simulate a sample, we draw random instances of lens and source galaxies where the parameters of.
+- **Simulate:** Simulate the image data using a (y,x) grid with the adaptive over sampling scheme.
+- **Sample Instances:** Within a for loop, we will now generate instances of the lens and source galaxies using the.
 
 __Model__
 

--- a/scripts/point_source/start_here.py
+++ b/scripts/point_source/start_here.py
@@ -23,20 +23,20 @@ imaging data to constrain the lens model itself.
 
 __Contents__
 
-**JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-**Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
-**Imports:** Import the required Python libraries.
-**Dataset:** Load and plot the strong lens dataset.
-**Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
-**Model:** Compose the lens model fitted to the data.
-**Name Pairing:** The `PointDataset` above had a name, `point_0`.
-**Model Fit:** Perform the model-fit using the search and analysis.
-**Result:** Overview of the results of the model-fit.
-**Model Your Own Lens:** If you have your own strong lens point source data, you are now ready to model it yourself by.
-**Fluxes and Time Delays:** If you have measured the fluxes and/or time delays of the lensed point sources, these can also be.
-**Simulator:** Let’s now switch gears and simulate our own strong lens point sources.
-**Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
-**Wrap Up:** Summary of the script and next steps.
+- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
+- **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
+- **Imports:** Import the required Python libraries.
+- **Dataset:** Load and plot the strong lens dataset.
+- **Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
+- **Model:** Compose the lens model fitted to the data.
+- **Name Pairing:** The `PointDataset` above had a name, `point_0`.
+- **Model Fit:** Perform the model-fit using the search and analysis.
+- **Result:** Overview of the results of the model-fit.
+- **Model Your Own Lens:** If you have your own strong lens point source data, you are now ready to model it yourself by.
+- **Fluxes and Time Delays:** If you have measured the fluxes and/or time delays of the lensed point sources, these can also be.
+- **Simulator:** Let’s now switch gears and simulate our own strong lens point sources.
+- **Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
+- **Wrap Up:** Summary of the script and next steps.
 
 __JAX__
 

--- a/scripts/weak/simulator.py
+++ b/scripts/weak/simulator.py
@@ -12,13 +12,13 @@ source in real weak-lensing data — each galaxy has a random unlensed elliptici
 
 __Contents__
 
-**Model:** Compose the lens model the shear field is computed from.
-**Dataset Paths:** The `dataset_type` and `dataset_name` define the on-disk output folder.
-**Ray Tracing:** Build a Tracer from an Isothermal lens galaxy.
-**Source Positions:** Draw a uniform-random distribution of background source galaxy positions.
-**Simulator:** Construct a `SimulatorShearYX` with the desired shape-noise level and random seed.
-**Output:** Save the simulated `WeakDataset` and the `Tracer` to JSON.
-**Visualize:** Placeholders only — the visualization layer is built in `prompt/weak/2_visualization.md`.
+- **Model:** Compose the lens model the shear field is computed from.
+- **Dataset Paths:** The `dataset_type` and `dataset_name` define the on-disk output folder.
+- **Ray Tracing:** Build a Tracer from an Isothermal lens galaxy.
+- **Source Positions:** Draw a uniform-random distribution of background source galaxy positions.
+- **Simulator:** Construct a `SimulatorShearYX` with the desired shape-noise level and random seed.
+- **Output:** Save the simulated `WeakDataset` and the `Tracer` to JSON.
+- **Visualize:** Placeholders only — the visualization layer is built in `prompt/weak/2_visualization.md`.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports


### PR DESCRIPTION
## Summary

Convert `__Contents__` blocks at the top of every workspace tutorial script's module docstring from plain `**Section:**` lines into Markdown list bullets (`- **Section:**`).

Without bullet markers, GitHub and JupyterLab collapse the entire block into one continuous paragraph in the generated notebook's first markdown cell — exactly the opposite of what the index is meant to do. The fix is purely Markdown: prefixing each entry with `- ` makes it render as a list. No Python semantics change, no notebook execution change, no `.py`-script behaviour change.

A worked example shipped earlier on `ic50_workspace` (commit [`4cde480`](https://github.com/Jammy2211/ic50_workspace/commit/4cde480)).

## Scripts Changed

199 scripts under `scripts/`, covering: `cluster`, `group`, `guides`, `imaging`, `interferometer`, `multi`, `point_source`, `weak`.

All edits are confined to the top-level module docstring — the `__Contents__` block. Where wrapped continuation lines appeared, they were re-indented two spaces so they belong to the same list item.

## Test Plan
- [ ] Smoke tests pass

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)