### PR TITLE
Add 3D-FITS data layout, data_preparation.py, relocated JAX walkthrough

### DIFF
--- a/scripts/interferometer/features/datacube/README.md
+++ b/scripts/interferometer/features/datacube/README.md
@@ -5,12 +5,21 @@ The `datacube` folder contains example scripts showing how to model an ALMA-styl
 The following example scripts illustrate datacube lens modeling where:
 
 - `start_here`: A first walkthrough — load a 4-channel cube, build the FactorGraph, fit with Nautilus.
-- `simulator`: Simulate a representative cube with a Gaussian emission line in the source. Also writes `positions.json` with the multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
+- `simulator`: Simulate a representative cube with a Gaussian emission line in the source. Writes both layouts: per-channel folders (`channel_NNN/{data,noise_map,uv_wavelengths}.fits`) and a single 3D-FITS cube (`{visibilities,noise_map,uv_wavelengths}_cube.fits`, all shape `(n_chan, n_vis, 2)`). Also writes `positions.json`.
+- `data_preparation`: How to bridge from CASA's 4D `(n_pol, n_chan, n_vis, 2)` visibilities to the canonical `(n_chan, n_vis, 2)` layout — polarisation handling (average vs concatenate) and a self-contained `dataset_list_from_3d_fits()` loader function. Copy that into your own script if you have a 3D cube on disk.
 - `modeling`: Focused FactorGraph + `RectangularAdaptDensity` pixelization fit, ready to point at your own cube.
 - `modeling_parametric`: Same wiring with a parametric `Sersic` source — shared morphology, per-channel intensity. Faster than the pixelization variant; appropriate when the source is well-described by a single Sersic.
 - `delaunay`: Same wiring with a Delaunay-pixelized source — image-plane `Overlay` mesh ray-traced and triangulated in the source plane, with `ConstantSplit` regularization. More flexible than the rectangular mesh; the canonical follow-up once the rectangular fit converges on a sensible lens model.
+- `likelihood_function`: Step-by-step JAX walkthrough of the per-channel log-evidence sum with an explicit eager-vs-JIT correctness check at `rtol=1e-4`. Useful for understanding what `af.FactorGraphModel` is doing under the hood.
 
 Every modeling script loads `positions.json` and applies an `al.PositionsLH` penalty. **For pixelized fits this is essentially required** — without the penalty the search routinely converges on demagnified-source local maxima where the source pixels are reconstructed in low-magnification regions of the source plane.
+
+# On-disk Layouts
+
+The simulator writes both supported layouts side by side. Pick whichever matches the data you already have on disk:
+
+- **Per-channel folders** — `channel_NNN/{data,noise_map,uv_wavelengths}.fits`, each `(n_vis, 2)`. Used by every modeling script in this folder by default.
+- **3D-FITS cube** — `{visibilities,noise_map,uv_wavelengths}_cube.fits`, each `(n_chan, n_vis, 2)`. Matches what CASA gives you (after polarisation collapse). Use the `dataset_list_from_3d_fits()` loader from `data_preparation.py` to load this layout directly.
 
 # Overview
 

--- a/scripts/interferometer/features/datacube/data_preparation.py
+++ b/scripts/interferometer/features/datacube/data_preparation.py
@@ -1,0 +1,275 @@
+"""
+Data Preparation: Datacube
+============================
+
+Most users come to datacube modeling with a single 4D FITS file from CASA, with shape
+``(n_pol, n_chan, n_vis, 2)`` — for example, an ALMA observation of a CO emission line might be
+``(2, 34, 16984, 2)``: two polarisations, 34 spectral channels, ~17k visibilities per channel, real/imag.
+
+This script shows how to bridge from that on-disk shape to the canonical input PyAutoLens expects:
+
+  * **In memory**: a Python ``list`` of ``al.Interferometer`` objects, one per channel.
+  * **On disk** (canonical 3D layout): three FITS files ``visibilities_cube.fits``,
+    ``noise_map_cube.fits`` and ``uv_wavelengths_cube.fits``, all of shape ``(n_chan, n_vis, 2)``.
+
+Two preprocessing steps are usually needed before the 3D layout is reached:
+
+  1. **Polarisation collapse** — averaging or concatenating the two polarisation entries.
+  2. **Optional `uv_wavelengths` / `noise_map` reduction** — both quantities change very little
+     channel-to-channel, so for the purposes of modeling they're often averaged across channels and
+     stored as a single ``(n_vis, 2)`` array shared across the cube.
+
+The script is structured as runnable explanation. The reusable bit is
+``dataset_list_from_3d_fits()`` near the bottom — copy that into your own script if you have a 3D
+cube already laid out on disk.
+
+__Contents__
+
+- **What ALMA Gives You:** The 4D shape `(n_pol, n_chan, n_vis, 2)` straight from CASA.
+- **Polarisation Handling:** Average vs concatenate; tradeoffs and one-line numpy.
+- **Canonical 3D Shape:** `(n_chan, n_vis, 2)` is what every loader below assumes.
+- **Shared vs Per-Channel uv_wavelengths / noise_map:** When channel-invariant quantities can be a
+  single shared `(n_vis, 2)` array, and how the loader handles either case.
+- **3D-FITS Loader:** A self-contained `dataset_list_from_3d_fits()` function that builds the
+  in-memory `dataset_list`.
+- **Worked Example:** Loads the reference cube (written by `simulator.py`) and confirms the
+  resulting `dataset_list` matches what the per-channel-folder loader would produce.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+from pathlib import Path
+
+import numpy as np
+
+import autolens as al
+
+"""
+__What ALMA Gives You__
+
+A typical ALMA spectral-line `visibilities.fits` from CASA has shape ``(n_pol, n_chan, n_vis, 2)``.
+For Hannah's data this is ``(2, 34, 16984, 2)``: two polarisations, 34 channels of an emission line,
+about 17k visibilities per channel, real/imag.
+
+`noise_map.fits` and `uv_wavelengths.fits` typically share the polarisation and channel dimensions
+(though `uv_wavelengths` may collapse to `(n_pol, n_vis, 2)` if your reduction has decided the
+baselines are channel-invariant — which is usually a good approximation for narrow emission lines).
+
+This script does NOT load Hannah's actual data — it walks through the preprocessing on simulated
+arrays so you can see what each step does. Replace the synthetic arrays below with
+``al.ndarray_via_fits_from(file_path=Path('your_visibilities.fits'), hdu=0)`` when you have real data.
+"""
+n_pol = 2
+n_chan = 4
+n_vis = 190
+
+rng = np.random.default_rng(seed=0)
+visibilities_4d = rng.normal(size=(n_pol, n_chan, n_vis, 2)).astype(np.float64)
+noise_map_4d = 1000.0 + rng.normal(size=(n_pol, n_chan, n_vis, 2)).astype(np.float64) * 50.0
+uv_wavelengths_3d = rng.normal(size=(n_pol, n_vis, 2)) * 1e5  # baselines per polarisation, channel-invariant
+
+print(f"On-disk shapes:")
+print(f"  visibilities_4d:    {visibilities_4d.shape}  (n_pol, n_chan, n_vis, 2)")
+print(f"  noise_map_4d:       {noise_map_4d.shape}     (n_pol, n_chan, n_vis, 2)")
+print(f"  uv_wavelengths_3d:  {uv_wavelengths_3d.shape}     (n_pol, n_vis, 2)  [channel-invariant]")
+
+"""
+__Polarisation Handling__
+
+Two options for collapsing the polarisation axis. Pick whichever your reduction was designed for —
+the workspace doesn't bake a choice in.
+
+- **Average** preserves ``n_vis``. Best when the two polarisations carry the same source signal and
+  you want to suppress polarisation-mode noise:
+
+      visibilities_collapsed = visibilities_4d.mean(axis=0)        # (n_chan, n_vis, 2)
+
+  For the noise map use inverse-variance weighting, which for equal-noise polarisations reduces to
+  ``noise_map.mean(axis=0) / sqrt(2)``:
+
+      noise_map_collapsed = noise_map_4d.mean(axis=0) / np.sqrt(2)  # (n_chan, n_vis, 2)
+
+- **Concatenate** doubles ``n_vis``. Best when you want to keep every visibility independent and let
+  the model fit each polarisation separately (or when the polarisations carry slightly different
+  signal — the average would smear that out):
+
+      visibilities_collapsed = np.concatenate([visibilities_4d[0], visibilities_4d[1]], axis=1)  # (n_chan, 2*n_vis, 2)
+      noise_map_collapsed   = np.concatenate([noise_map_4d[0], noise_map_4d[1]], axis=1)         # (n_chan, 2*n_vis, 2)
+      uv_wavelengths_collapsed = np.concatenate([uv_wavelengths_3d[0], uv_wavelengths_3d[1]], axis=0)  # (2*n_vis, 2)
+
+We use the averaging path below for clarity. Swap in the concatenate version if that's what your
+reduction expects.
+"""
+visibilities_3d = visibilities_4d.mean(axis=0)
+noise_map_3d = noise_map_4d.mean(axis=0) / np.sqrt(2)
+uv_wavelengths_2d = uv_wavelengths_3d.mean(axis=0)
+
+print(f"\nAfter polarisation averaging:")
+print(f"  visibilities_3d:    {visibilities_3d.shape}    (n_chan, n_vis, 2)")
+print(f"  noise_map_3d:       {noise_map_3d.shape}    (n_chan, n_vis, 2)")
+print(f"  uv_wavelengths_2d:  {uv_wavelengths_2d.shape}        (n_vis, 2)  [shared across channels]")
+
+"""
+__Canonical 3D Shape__
+
+After polarisation collapse, every loader below assumes the canonical post-preprocessing shapes:
+
+- ``visibilities``:    ``(n_chan, n_vis, 2)`` — required.
+- ``noise_map``:       ``(n_chan, n_vis, 2)`` — required, can be channel-invariant if you replicate.
+- ``uv_wavelengths``:  ``(n_chan, n_vis, 2)`` for per-channel baselines, **or** ``(n_vis, 2)`` for
+  channel-invariant baselines (the loader broadcasts).
+
+If your reduction stores `noise_map` as channel-invariant `(n_vis, 2)`, the loader broadcasts the
+same way.
+"""
+
+"""
+__Shared vs Per-Channel `uv_wavelengths` / `noise_map`__
+
+For most ALMA narrow-line cubes both `uv_wavelengths` and `noise_map` change very little
+channel-to-channel and can safely be stored as a single shared `(n_vis, 2)` array. The deferred
+shared-`Lᵀ W̃ L` optimisation Aris designed (see issue #120) will only fire when these arrays are
+actually shared, so there's some real performance reason to use the shared form when you can.
+
+The loader below supports both: if the input `noise_map` or `uv_wavelengths` array is 2D, it gets
+broadcast to all `n_chan` channels; if it's 3D, each channel gets its own slice.
+"""
+
+"""
+__3D-FITS Loader__
+
+Self-contained loader function. Copy this into your own script if you have a 3D cube on disk.
+
+The function takes paths to the three FITS files (or numpy arrays directly — see the `_arrays`
+variant below if you want to skip the disk trip), splits them per-channel, and constructs the list
+of `al.Interferometer` objects.
+"""
+
+
+def dataset_list_from_3d_fits(
+    visibilities_path: Path,
+    noise_map_path: Path,
+    uv_wavelengths_path: Path,
+    real_space_mask: al.Mask2D,
+    transformer_class=al.TransformerNUFFT,
+):
+    """Load a 3D-FITS datacube into a list of `al.Interferometer` objects.
+
+    Parameters
+    ----------
+    visibilities_path
+        Path to a `.fits` file of shape `(n_chan, n_vis, 2)` storing real/imag visibilities for
+        every channel. Polarisations should already be collapsed.
+    noise_map_path
+        Path to a `.fits` file of shape `(n_chan, n_vis, 2)` (per-channel) or `(n_vis, 2)` (shared
+        across channels). The shared form is broadcast to every channel.
+    uv_wavelengths_path
+        Path to a `.fits` file of shape `(n_chan, n_vis, 2)` (per-channel) or `(n_vis, 2)` (shared).
+    real_space_mask
+        The 2D real-space mask used by the Fourier transformer.
+    transformer_class
+        `al.TransformerNUFFT` (default, recommended for >10k visibilities) or `al.TransformerDFT`.
+
+    Returns
+    -------
+    list[al.Interferometer]
+        One `Interferometer` per channel, in cube order.
+    """
+    visibilities_3d = al.ndarray_via_fits_from(file_path=visibilities_path, hdu=0)
+    noise_map_arr = al.ndarray_via_fits_from(file_path=noise_map_path, hdu=0)
+    uv_wavelengths_arr = al.ndarray_via_fits_from(file_path=uv_wavelengths_path, hdu=0)
+
+    if visibilities_3d.ndim != 3:
+        raise ValueError(
+            f"visibilities array must be 3D (n_chan, n_vis, 2); got shape {visibilities_3d.shape}"
+        )
+
+    n_chan = visibilities_3d.shape[0]
+
+    # Broadcast 2D shared arrays to (n_chan, n_vis, 2) so the per-channel loop is uniform.
+    if noise_map_arr.ndim == 2:
+        noise_map_arr = np.broadcast_to(noise_map_arr[None], visibilities_3d.shape).copy()
+    if uv_wavelengths_arr.ndim == 2:
+        uv_wavelengths_arr = np.broadcast_to(
+            uv_wavelengths_arr[None], visibilities_3d.shape
+        ).copy()
+
+    return [
+        al.Interferometer(
+            data=al.Visibilities(visibilities=visibilities_3d[c]),
+            noise_map=al.VisibilitiesNoiseMap(visibilities=noise_map_arr[c]),
+            uv_wavelengths=uv_wavelengths_arr[c],
+            real_space_mask=real_space_mask,
+            transformer_class=transformer_class,
+        )
+        for c in range(n_chan)
+    ]
+
+
+"""
+__Worked Example__
+
+Load the reference cube generated by `simulator.py` and confirm the 3D-FITS loader produces a
+`dataset_list` numerically identical to the per-channel-folder loader. This is a sanity check —
+once you trust this, you can drop the per-channel-folder pattern entirely if you prefer the 3D
+layout.
+"""
+dataset_path = Path("dataset") / "interferometer" / "datacube" / "sim_simple"
+
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/features/datacube/simulator.py"],
+        check=True,
+    )
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256), pixel_scales=0.1, radius=3.5,
+)
+
+dataset_list_3d = dataset_list_from_3d_fits(
+    visibilities_path=dataset_path / "visibilities_cube.fits",
+    noise_map_path=dataset_path / "noise_map_cube.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths_cube.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+# Cross-check against the per-channel-folder loader.
+channel_paths = sorted(
+    p for p in dataset_path.iterdir() if p.is_dir() and p.name.startswith("channel_")
+)
+dataset_list_folders = [
+    al.Interferometer.from_fits(
+        data_path=channel_path / "data.fits",
+        noise_map_path=channel_path / "noise_map.fits",
+        uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+        real_space_mask=real_space_mask,
+        transformer_class=al.TransformerDFT,
+    )
+    for channel_path in channel_paths
+]
+
+assert len(dataset_list_3d) == len(dataset_list_folders), "channel count mismatch"
+
+for c, (d3d, dfolder) in enumerate(zip(dataset_list_3d, dataset_list_folders)):
+    np.testing.assert_allclose(
+        np.asarray(d3d.data.real), np.asarray(dfolder.data.real),
+        rtol=1e-12, err_msg=f"channel {c}: data.real mismatch",
+    )
+    np.testing.assert_allclose(
+        np.asarray(d3d.data.imag), np.asarray(dfolder.data.imag),
+        rtol=1e-12, err_msg=f"channel {c}: data.imag mismatch",
+    )
+    np.testing.assert_allclose(
+        np.asarray(d3d.uv_wavelengths), np.asarray(dfolder.uv_wavelengths),
+        rtol=1e-12, err_msg=f"channel {c}: uv_wavelengths mismatch",
+    )
+
+print(f"\n3D-FITS loader and per-channel-folder loader agree on {len(dataset_list_3d)} channels.")
+print(f"  visibilities/channel:  {dataset_list_3d[0].data.shape[0]}")
+print(f"  uv_wavelengths shape:  {np.asarray(dataset_list_3d[0].uv_wavelengths).shape}")

--- a/scripts/interferometer/features/datacube/likelihood_function.py
+++ b/scripts/interferometer/features/datacube/likelihood_function.py
@@ -1,0 +1,307 @@
+"""
+Datacube Likelihood Function: Step-by-step walkthrough
+=======================================================
+
+Step-by-step exploration of the JAX-compiled likelihood for an ALMA-style
+datacube modeled as a list of ``Interferometer`` channels with a shared
+lens model and a per-channel pixelized source reconstruction.
+
+The walkthrough mirrors the single-channel
+``jax_profiling/interferometer/pixelization.py`` script — same lens model,
+same ``RectangularAdaptDensity`` mesh + ``Constant`` regularization, same JAX
+JIT pattern — but the analysis is now an ``af.FactorGraphModel`` over
+N independent ``AnalysisInterferometer``s.
+
+What's new compared to the single-channel version
+-------------------------------------------------
+
+1. **Dataset.** Instead of one ``Interferometer.from_fits`` call, we build
+   a ``dataset_list`` by looping over ``channel_000/`` ... ``channel_NNN/``.
+2. **Per-channel analyses.** One ``AnalysisInterferometer(dataset=..., use_jax=True)``
+   per channel.
+3. **Likelihood is the explicit sum.** The walkthrough builds the cube
+   log-evidence as ``sum(analysis.log_likelihood_function(instance) for
+   analysis in analysis_list)``, which is exactly what ``af.FactorGraphModel``
+   abstracts over for the user-facing modeling script. Showing the sum
+   directly keeps the JAX path easy to register as a pytree (the base
+   ``Collection`` model is registered, and the same instance is reused
+   across channels).
+4. **All parameters are shared.** The lens mass + shear is a single set of
+   priors used by every channel — that's the "global non-linear lens"
+   half of Hannah's request from the prompt. The pixelization has no free
+   priors; its inversion is a per-channel linear solve run inside each
+   ``AnalysisInterferometer.log_likelihood_function``. That gives us the
+   "per-channel linear solution" half for free, with no extra wiring.
+5. **vmap is skipped.** It would have to wrap the per-channel function
+   rather than the summed loop — that lives in the (deferred)
+   shared-``L^T W~ L`` optimisation issue, not this prototype.
+
+The user-facing ``modeling.py`` script wraps ``analysis_list`` in
+``af.AnalysisFactor`` + ``af.FactorGraphModel`` so the non-linear search
+does the same sum behind the scenes. For the likelihood walkthrough we
+show the loop explicitly.
+
+Phases
+------
+
+* **PART A — Setup.** Auto-simulate the cube if missing, load N channels,
+  build the model, instantiate at prior medians, register the model as a
+  JAX pytree.
+* **PART B — Eager NumPy baseline.** Per-channel ``FitInterferometer``
+  with ``xp=np`` to get a ground-truth log-evidence for each channel and
+  the summed total.
+* **PART C — JIT cube likelihood.** ``jax.jit`` over the explicit sum;
+  time lower / compile / first-call / steady-state.
+* **PART D — Correctness.** Eager-vs-JIT log-evidence agreement at
+  ``rtol=1e-4``.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autolens as al
+from autofit.jax import register_model as _register_model_pytrees
+
+
+# ---------------------------------------------------------------------------
+# Cube configuration
+# ---------------------------------------------------------------------------
+
+CUBE_PATH = Path("dataset") / "interferometer" / "datacube" / "sim_simple"
+N_CHANNELS = 4
+PIXEL_SCALE = 0.1
+REAL_SPACE_SHAPE = (256, 256)
+MASK_RADIUS = 3.0
+MESH_SHAPE = (14, 14)
+REGULARIZATION_COEFFICIENT = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Profiling helpers
+# ---------------------------------------------------------------------------
+
+class Timer:
+    def __init__(self):
+        self.records: list[tuple[str, float]] = []
+
+    @contextmanager
+    def section(self, label: str):
+        start = time.perf_counter()
+        yield
+        elapsed = time.perf_counter() - start
+        self.records.append((label, elapsed))
+        print(f"  [{label}] {elapsed:.4f} s")
+
+
+def block(x):
+    if hasattr(x, "block_until_ready"):
+        x.block_until_ready()
+    return x
+
+
+def jit_profile(func, label, *args, n_repeats=10):
+    jitted = jax.jit(func)
+
+    with timer.section(f"{label}_lower"):
+        lowered = jitted.lower(*args)
+
+    with timer.section(f"{label}_compile"):
+        compiled = lowered.compile()
+
+    with timer.section(f"{label}_first_call"):
+        result = compiled(*args)
+        block(result)
+
+    with timer.section(f"{label}_steady_x{n_repeats}"):
+        for _ in range(n_repeats):
+            result = compiled(*args)
+            block(result)
+
+    per_call = timer.records[-1][1] / n_repeats
+    print(f"    -> per-call avg: {per_call:.6f} s")
+    return compiled, result
+
+
+timer = Timer()
+
+
+# ===================================================================
+# PART A — Setup
+# ===================================================================
+
+print("\n=== PART A — Setup ===")
+
+# Auto-simulate the cube on disk if needed
+_script_dir = Path(__file__).resolve().parent
+if not (CUBE_PATH / "channel_000" / "data.fits").exists():
+    print("  Cube missing on disk, running simulator.py...")
+    subprocess.run(
+        [sys.executable, str(_script_dir / "simulator.py")],
+        check=True,
+    )
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=REAL_SPACE_SHAPE,
+    pixel_scales=PIXEL_SCALE,
+    radius=MASK_RADIUS,
+)
+
+dataset_list = []
+with timer.section("dataset_load"):
+    for c in range(N_CHANNELS):
+        channel_path = CUBE_PATH / f"channel_{c:03d}"
+        dataset_list.append(
+            al.Interferometer.from_fits(
+                data_path=channel_path / "data.fits",
+                noise_map_path=channel_path / "noise_map.fits",
+                uv_wavelengths_path=channel_path / "uv_wavelengths.fits",
+                real_space_mask=real_space_mask,
+                transformer_class=al.TransformerDFT,
+            )
+        )
+
+n_visibilities = dataset_list[0].uv_wavelengths.shape[0]
+print(f"  channels:           {N_CHANNELS}")
+print(f"  visibilities/chan:  {n_visibilities}")
+print(f"  real-space grid:    {REAL_SPACE_SHAPE[0]} x {REAL_SPACE_SHAPE[1]}")
+
+# ---------------------------------------------------------------------------
+# Base model — shared lens, pixelized source
+# ---------------------------------------------------------------------------
+
+print("\n=== PART A — Model construction ===")
+
+with timer.section("model_build"):
+    mass = af.Model(al.mp.Isothermal)
+    mass.centre.centre_0 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    mass.centre.centre_1 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    mass.einstein_radius = af.GaussianPrior(mean=1.6, sigma=0.05)
+    _lens_ell = al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0)
+    mass.ell_comps.ell_comps_0 = af.GaussianPrior(mean=_lens_ell[0], sigma=0.01)
+    mass.ell_comps.ell_comps_1 = af.GaussianPrior(mean=_lens_ell[1], sigma=0.01)
+
+    shear = af.Model(al.mp.ExternalShear)
+    shear.gamma_1 = af.GaussianPrior(mean=0.05, sigma=0.005)
+    shear.gamma_2 = af.GaussianPrior(mean=0.05, sigma=0.005)
+
+    lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+    pixelization = af.Model(
+        al.Pixelization,
+        mesh=al.mesh.RectangularAdaptDensity(shape=MESH_SHAPE),
+        regularization=al.reg.Constant(coefficient=REGULARIZATION_COEFFICIENT),
+    )
+
+    source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+    model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+print(f"  base model free parameters: {model.total_free_parameters}")
+
+# ---------------------------------------------------------------------------
+# Per-channel analyses
+# ---------------------------------------------------------------------------
+
+print("\n=== PART A — Per-channel analyses ===")
+
+analysis_list = [
+    al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+    for dataset in dataset_list
+]
+
+print(f"  channels in analysis_list: {len(analysis_list)}")
+
+# ---------------------------------------------------------------------------
+# Concrete instance + pytree registration
+# ---------------------------------------------------------------------------
+
+print("\n=== PART A — Concrete instance + pytree registration ===")
+
+with timer.section("instance_from_vector"):
+    param_vector = model.physical_values_from_prior_medians
+    instance = model.instance_from_vector(vector=param_vector)
+
+with timer.section("register_pytrees"):
+    _register_model_pytrees(model)
+
+# JIT input: the instance with all parameter leaves promoted to JAX arrays
+params_tree = jax.tree_util.tree_map(jnp.asarray, instance)
+
+
+# ===================================================================
+# PART B — Eager NumPy baseline (per-channel + summed)
+# ===================================================================
+
+print("\n=== PART B — Eager NumPy baseline ===")
+
+tracer = al.Tracer(galaxies=list(instance.galaxies))
+print(f"  tracer planes: {tracer.total_planes}")
+
+per_channel_fom = []
+with timer.section("eager_fit_per_channel"):
+    for c, dataset in enumerate(dataset_list):
+        fit = al.FitInterferometer(dataset=dataset, tracer=tracer, xp=np)
+        per_channel_fom.append(float(fit.figure_of_merit))
+        print(f"    channel {c:03d}: figure_of_merit = {per_channel_fom[-1]:.6f}")
+
+eager_total = sum(per_channel_fom)
+print(f"  summed eager log-evidence: {eager_total:.6f}")
+
+
+# ===================================================================
+# PART C — JIT cube likelihood
+# ===================================================================
+
+print("\n=== PART C — JIT cube likelihood ===")
+
+
+def cube_log_likelihood(params_tree):
+    """Cube log-evidence as an explicit sum across channels.
+
+    This is exactly what ``af.FactorGraphModel`` does internally for the
+    user-facing modeling script: route the same ``instance`` to each
+    per-channel ``AnalysisInterferometer.log_likelihood_function`` and sum
+    the per-channel log-evidences.
+    """
+    total = jnp.zeros(())
+    for analysis in analysis_list:
+        total = total + analysis.log_likelihood_function(instance=params_tree)
+    return total
+
+
+_, jit_total = jit_profile(cube_log_likelihood, "cube_likelihood", params_tree)
+jit_per_call = timer.records[-1][1] / 10
+
+print(f"  JIT total log-evidence: {float(jit_total):.6f}")
+
+
+# ===================================================================
+# PART D — Correctness
+# ===================================================================
+
+print("\n=== PART D — Correctness ===")
+
+np.testing.assert_allclose(
+    float(jit_total),
+    eager_total,
+    rtol=1e-4,
+    err_msg=(
+        "datacube/likelihood_function: JIT FactorGraph log-evidence does not "
+        "match the summed eager per-channel figure_of_merit"
+    ),
+)
+print(f"  Eager-vs-JIT correctness PASSED at rtol=1e-4")
+print(f"    eager total: {eager_total:.6f}")
+print(f"    JIT total:   {float(jit_total):.6f}")
+print(f"    abs diff:    {abs(float(jit_total) - eager_total):.3e}")
+print(f"    JIT per-call (steady): {jit_per_call:.6f} s")

--- a/scripts/interferometer/features/datacube/simulator.py
+++ b/scripts/interferometer/features/datacube/simulator.py
@@ -25,6 +25,7 @@ __Contents__
 - **Lens Galaxy:** Shared `Isothermal + ExternalShear` lens, identical for every channel.
 - **Per-Channel Source:** A Gaussian emission line in channel index drives the per-channel `Sersic.intensity`.
 - **Per-Channel Simulate:** Loop over channels: build the tracer, simulate, write FITS + tracer.json to disk.
+- **3D-FITS Cube:** Stack the per-channel arrays into single `(n_chan, n_vis, 2)` FITS files for users whose data already lives in that shape (e.g. ALMA cubes from CASA).
 - **Multiple Images:** Compute and save the lensed multiple-image positions used by the modeling scripts' `PositionsLH` penalty.
 - **Cube Summary:** Dump the emission-line parameters and per-channel intensities to `cube_summary.json`.
 - **Cube Overview Plot:** Row-per-channel sanity figure (lensed image, uv-plane Re/Im, |vis| vs baseline length).
@@ -191,6 +192,43 @@ for channel in range(N_CHANNELS):
         f"  channel {channel:03d}: intensity={intensity:.4f}, "
         f"|vis|_max={np.max(np.abs(dataset.data)):.3e}"
     )
+
+"""
+__3D-FITS Cube__
+
+ALMA visibilities exit CASA as a single 4D FITS of shape `(n_pol, n_chan, n_vis, 2)`. After the user collapses
+the polarisation axis (averaging or concatenating — see `data_preparation.py`), the canonical input shape is
+`(n_chan, n_vis, 2)`. We write three additional files at the cube root in that shape so users with CASA-native
+data can load the cube via `data_preparation.dataset_list_from_3d_fits` without first splitting into per-channel
+folders. The per-channel `channel_NNN/` folders above are kept as well — both layouts coexist for now.
+"""
+visibilities_cube = np.stack(
+    [np.stack([d.data.real, d.data.imag], axis=-1) for d in datasets], axis=0
+)
+noise_map_cube = np.stack(
+    [np.stack([d.noise_map.real, d.noise_map.imag], axis=-1) for d in datasets], axis=0
+)
+uv_wavelengths_cube = np.stack(
+    [np.asarray(d.uv_wavelengths) for d in datasets], axis=0
+)
+
+al.output_to_fits(
+    values=visibilities_cube,
+    file_path=dataset_path / "visibilities_cube.fits",
+    overwrite=True,
+)
+al.output_to_fits(
+    values=noise_map_cube,
+    file_path=dataset_path / "noise_map_cube.fits",
+    overwrite=True,
+)
+al.output_to_fits(
+    values=uv_wavelengths_cube,
+    file_path=dataset_path / "uv_wavelengths_cube.fits",
+    overwrite=True,
+)
+
+print(f"  3D-FITS cubes: shape {visibilities_cube.shape} (n_chan, n_vis, 2)")
 
 """
 __Multiple Images__


### PR DESCRIPTION
## Summary

Datacube users (e.g. Hannah's ALMA setup, see [issue #120](https://github.com/PyAutoLabs/autolens_workspace/issues/120)) typically have a single 4D FITS file from CASA of shape `(n_pol, n_chan, n_vis, 2)`, not per-channel folders. After polarisation collapse the canonical input shape is `(n_chan, n_vis, 2)`. This change adds first-class support for that on-disk layout without removing the existing per-channel-folder path.

It also relocates the JAX likelihood walkthrough from the private `autolens_workspace_developer` (where external collaborators got 404s) to the public workspace.

## Scripts Changed

- `scripts/interferometer/features/datacube/simulator.py` — additionally writes `visibilities_cube.fits`, `noise_map_cube.fits`, `uv_wavelengths_cube.fits` at the cube root, each shape `(n_chan, n_vis, 2)`. Per-channel `channel_NNN/` folders are still written, so existing modeling scripts are unaffected.
- `scripts/interferometer/features/datacube/data_preparation.py` — NEW. Explains how to bridge from CASA's 4D shape to `(n_chan, n_vis, 2)`: polarisation handling (average vs concatenate) and a self-contained `dataset_list_from_3d_fits()` function. The loader handles `uv_wavelengths` / `noise_map` either shared `(n_vis, 2)` across channels (broadcast) or per-channel `(n_chan, n_vis, 2)` (slice). Worked example confirms it matches the per-channel-folder loader to `rtol=1e-12`.
- `scripts/interferometer/features/datacube/likelihood_function.py` — NEW. JAX likelihood walkthrough, relocated from the (private) `autolens_workspace_developer`. Same content; only the dataset path is adjusted to the workspace layout.
- `scripts/interferometer/features/datacube/README.md` — adds entries for `data_preparation` and `likelihood_function`; documents both on-disk layouts.

## Linked
- Paired with https://github.com/PyAutoLabs/autolens_workspace_developer/pull/51 (deletes the relocated likelihood walkthrough and the prototype simulator from the private dev workspace).
- Followup to #120 and #122.

## Test Plan

- [x] Simulator runs end-to-end and writes both layouts side by side: per-channel folders (`channel_NNN/`) + 3D-FITS cubes (`*_cube.fits`).
- [x] `data_preparation.py` runs end-to-end; the 3D-FITS loader produces a `dataset_list` numerically identical to the per-channel-folder loader (`rtol=1e-12`).
- [x] Relocated `likelihood_function.py` runs end-to-end; eager-vs-JIT correctness passes at `rtol=1e-4` (abs diff ~1e-2).
- [x] All four existing modeling scripts (`start_here.py`, `modeling.py`, `modeling_parametric.py`, `delaunay.py`) pass `TEST MODE 2`.
- [x] `/smoke_test autolens_workspace` corpus passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)