### PR TITLE
docs: refresh interferometer package for nufftax JAX-native NUFFT

### DIFF
--- a/scripts/interferometer/casa_reduction.py
+++ b/scripts/interferometer/casa_reduction.py
@@ -104,11 +104,13 @@ can omit the `spw` argument.
 
 __Step 2 — Channel Averaging__
 
-ALMA observations often have thousands of channels per SPW, producing far more
-visibilities than PyAutoLens can comfortably model (the light-profile path tops
-out around ~10,000 visibilities; the pixelized source path scales to millions
-but is more advanced). For continuum-style lens modeling you typically average
-all channels in an SPW down to one (or a handful) by setting `width`.
+ALMA observations often have thousands of channels per SPW, producing huge
+visibility counts. With the JAX-native `TransformerNUFFT` (backed by `nufftax`),
+the light-profile modeling path scales efficiently to ALMA-class datasets with
+many millions of visibilities, so channel averaging is no longer required purely
+for performance. You may still average channels (typically by setting `width`)
+to reduce the dataset size, simplify the analysis, or maximize signal-to-noise
+for continuum-style lens modeling.
 
 Note that `width` must not exceed the number of channels in the SPW — check with
 the `get_num_chan` helper below if unsure.
@@ -433,9 +435,10 @@ __Troubleshooting__
   dirty image with `aplt.subplot_interferometer_dirty_images` as a sanity
   check.
 - **Sigmas produce a flat chi-squared map** — you probably forgot `statwt`.
-- **n_vis is enormous** — use a larger `width` in `split`, or switch from
-  `TransformerDFT` to `TransformerNUFFT` (and the pixelized source workflow
-  if n_vis > 10,000).
+- **n_vis is enormous** — ensure you are using `TransformerNUFFT` (the default
+  recommendation, backed by JAX-native `nufftax`). It scales to many millions
+  of visibilities. Channel averaging via a larger `width` in `split` is still
+  useful when you want to reduce dataset size for other reasons.
 - **Only one polarisation present** — if CASA has flagged one pol the
   averaging code above will produce NaNs. Check with `get_visibilities`
   and branch accordingly.

--- a/scripts/interferometer/features/datacube/data_preparation.py
+++ b/scripts/interferometer/features/datacube/data_preparation.py
@@ -170,7 +170,8 @@ def dataset_list_from_3d_fits(
     real_space_mask
         The 2D real-space mask used by the Fourier transformer.
     transformer_class
-        `al.TransformerNUFFT` (default, recommended for >10k visibilities) or `al.TransformerDFT`.
+        `al.TransformerNUFFT` (default, JAX-native via `nufftax`, scales to many millions of visibilities)
+        or `al.TransformerDFT`.
 
     Returns
     -------

--- a/scripts/interferometer/features/extra_galaxies/slam.py
+++ b/scripts/interferometer/features/extra_galaxies/slam.py
@@ -16,12 +16,13 @@ __Contents__
 - **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
 - **Group SLaM:** This SLaM pipeline is designed for the regime where one is modeling galaxy scale lenses with nearby.
 - **This Script:** Using a SOURCE LP PIPELINE, SOURCE PIX PIPELINE, LIGHT LP PIPELINE and TOTAL MASS PIPELINE this.
-- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **SOURCE LP PIPELINE:** Initializes the mass model + source-light using MGE light profiles via `TransformerNUFFT`.
+- **SOURCE PIX PIPELINE 1:** Initializes a pixelized source using the adapt image from the SOURCE LP result.
+- **SOURCE PIX PIPELINE 2:** Improves the pixelized source using adapt images from `source_pix_result_1`.
 - **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
 - **Extra Galaxies Centres:** This is the same API as described in the `features/extra_galaxies.ipynb` example, where the centres.
+- **Two Datasets:** Build one Interferometer with `TransformerNUFFT` (source_lp) and one with `TransformerDFT` + sparse operator (source_pix onwards).
 - **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
 - **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
 - **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
 - **Redshifts:** The redshifts of the lens and source galaxies.
@@ -93,33 +94,33 @@ import autolens as al
 import autolens.plot as aplt
 
 """
-__SOURCE PIX PIPELINE 1__
+__SOURCE LP PIPELINE__
 
-Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized source
-pipeline. This is because fitting light profiles to interferometer datasets with many visibilities is slow.
+Initializes a robust mass + source-light model using a Multi Gaussian Expansion (MGE), fit with light profiles.
 
-The search therefore uses a `Constant` regularization (not adaptive) as there is no adapt image available.
+This stage uses `dataset_nufft` (built with `TransformerNUFFT`, backed by JAX-native `nufftax`), which makes
+light-profile fitting fast even on ALMA-class datasets with millions of visibilities. The result provides the
+adapt image and position likelihood threaded into the pixelized pipelines that follow.
 
-The `extra_galaxies` are included in the model, each with an `IsothermalSph` mass profile whose centre is fixed
-to the centre of the extra galaxy.
+Each extra galaxy carries an `IsothermalSph` mass profile centred on its known position. Extra galaxies do not
+have light components in the interferometer pipeline, because interferometer data does not contain lens light
+emission.
 """
 
 
-def source_pix_1(
+def source_lp(
     settings_search: af.SettingsSearch,
     dataset,
+    mask_radius: float,
+    extra_galaxies,
     redshift_lens: float,
     redshift_source: float,
-    positions_likelihood,
-    mesh_shape,
-    settings,
-    extra_galaxies,
-    n_batch: int = 20,
+    n_batch: int = 50,
 ) -> af.Result:
-    analysis = al.AnalysisInterferometer(
-        dataset=dataset,
-        positions_likelihood_list=[positions_likelihood],
-        settings=settings,
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+    source_bulge = al.model_util.mge_model_from(
+        mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
     )
 
     model = af.Collection(
@@ -135,10 +136,87 @@ def source_pix_1(
             source=af.Model(
                 al.Galaxy,
                 redshift=redshift_source,
+                bulge=source_bulge,
+            ),
+        ),
+        extra_galaxies=extra_galaxies,
+    )
+
+    search = af.Nautilus(
+        name="source_lp[1]",
+        **settings_search.search_dict,
+        n_live=200,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 1__
+
+The first search of the SOURCE PIX PIPELINE fits a pixelization whose purpose is to generate a high-quality
+adapt image used in search 2. It uses the adapt image computed from the SOURCE LP result, with the position
+likelihood derived automatically via `source_lp_result.positions_likelihood_from(...)`.
+
+This stage uses `dataset_dft_sparse` (built with `TransformerDFT` + `apply_sparse_operator`). Pixelizations
+exploit sparsity in the linear inversion rather than the NUFFT path.
+
+The `extra_galaxies` mass priors are carried forward from the SOURCE LP result as free model parameters.
+"""
+
+
+def source_pix_1(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    mesh_init,
+    regularization_init,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_lp_result
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_lp_result.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=source_lp_result.model.galaxies.lens.mass,
+        mass_result=source_lp_result.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+
+    extra_galaxies = source_lp_result.model.extra_galaxies
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=source_lp_result.model.galaxies.lens.shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
-                    regularization=al.reg.Constant,
+                    mesh=mesh_init,
+                    regularization=regularization_init,
                 ),
             ),
         ),
@@ -171,8 +249,10 @@ contain lens light emission.
 def source_pix_2(
     settings_search: af.SettingsSearch,
     dataset,
+    source_lp_result: af.Result,
     source_pix_result_1: af.Result,
-    mesh_shape,
+    mesh,
+    regularization,
     settings,
     n_batch: int = 20,
 ) -> af.Result:
@@ -192,7 +272,7 @@ def source_pix_2(
         galaxies=af.Collection(
             lens=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.lens.redshift,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
                 # interferometry does not support lens light
                 bulge=None,
                 disk=None,
@@ -201,11 +281,11 @@ def source_pix_2(
             ),
             source=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.source.redshift,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
-                    regularization=al.reg.Adapt,
+                    mesh=mesh,
+                    regularization=regularization,
                 ),
             ),
         ),
@@ -319,7 +399,7 @@ if not dataset_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/imaging/features/extra_galaxies/simulator.py"],
+        [sys.executable, "scripts/interferometer/features/extra_galaxies/simulator.py"],
         check=True,
     )
 
@@ -334,12 +414,31 @@ if not dataset_path.exists():
 #     )
 
 
-dataset = al.Interferometer.from_fits(
+"""
+__Two Datasets__
+
+The SLaM pipeline runs in two phases that prefer different transformers:
+
+- `dataset_nufft` uses `TransformerNUFFT` (backed by JAX-native `nufftax`) for the `source_lp` stage.
+- `dataset_dft_sparse` uses `TransformerDFT` + `apply_sparse_operator(...)` for `source_pix_1`,
+  `source_pix_2` and `mass_total`.
+
+Both datasets are built from the same FITS files; only the transformer (and sparse-operator preload) differ.
+"""
+dataset_nufft = al.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
     transformer_class=al.TransformerNUFFT,
+)
+
+dataset_dft_sparse = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
 )
 
 """
@@ -362,7 +461,10 @@ pixelized source modeling, especially for many visibilities.
 
 We use a try / except to load the pre-computed curvature preload, which is necessary to use
 the sparse operator formalism. If this file does not exist (e.g. you have not made it manually via
-the `many_visibilities_preparartion` example it is made here.
+the `many_visibilities_preparation` example) it is made here.
+
+The sparse operator is applied only to `dataset_dft_sparse` — the NUFFT-backed `dataset_nufft` used by
+`source_lp` does not need it.
 """
 try:
     nufft_precision_operator = np.load(
@@ -371,21 +473,9 @@ try:
 except FileNotFoundError:
     nufft_precision_operator = None
 
-dataset = dataset.apply_sparse_operator(
+dataset_dft_sparse = dataset_dft_sparse.apply_sparse_operator(
     nufft_precision_operator=nufft_precision_operator, use_jax=True, show_progress=True
 )
-
-"""
-__Position Likelihood__
-
-Load the multiple image positions used for the position likelihood, which resamples bad mass
-models and prevents demagnified solutions being inferred.
-"""
-positions = al.Grid2DIrregular(
-    al.from_json(file_path=Path(dataset_path, "positions.json"))
-)
-
-positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
 
 """
 __Settings__
@@ -449,29 +539,41 @@ __SLaM Pipeline__
 
 The code below calls the full SLaM PIPELINE. See the documentation string above each Python function for
 a description of each pipeline step.
+
+Note the transformer split: `source_lp` is passed `dataset_nufft` (TransformerNUFFT), while every later stage
+is passed `dataset_dft_sparse` (TransformerDFT + sparse operator).
 """
-source_pix_result_1 = source_pix_1(
+source_lp_result = source_lp(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_nufft,
+    mask_radius=mask_radius,
+    extra_galaxies=extra_galaxies,
     redshift_lens=redshift_lens,
     redshift_source=redshift_source,
-    positions_likelihood=positions_likelihood,
-    mesh_shape=mesh_shape,
+)
+
+source_pix_result_1 = source_pix_1(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    mesh_init=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
+    regularization_init=al.reg.Adapt,
     settings=settings,
-    extra_galaxies=extra_galaxies,
 )
 
 source_pix_result_2 = source_pix_2(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
     source_pix_result_1=source_pix_result_1,
-    mesh_shape=mesh_shape,
+    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
+    regularization=al.reg.Adapt,
     settings=settings,
 )
 
 mass_result = mass_total(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     source_pix_result_2=source_pix_result_2,
     settings=settings,

--- a/scripts/interferometer/features/pixelization/fit.py
+++ b/scripts/interferometer/features/pixelization/fit.py
@@ -17,10 +17,11 @@ Pixelizations are covered in detail in chapter 4 of the **HowToLens** lectures.
 
 __CPU Users__
 
-Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra. On GPU, this takes
-seconds, or at most a minute for datasets with tens of millions, or more visibities. On CPU, this can be a lot slower,
-taking over hours. If you are on CPU,  the `feature/pixelization/many_visibilities_preparation` explains how this
-initial setup can be performed before lens modeling and saved to hard disk for fast loading before the model fit.
+Matrices must be set up for a pixelized source reconstruction to speed up the linear algebra. On GPU, this takes
+seconds, or at most a minute for datasets with tens of millions or more visibilities. On CPU, this can be a lot
+slower, taking over an hour for very large datasets. If you are on CPU, the
+`feature/pixelization/many_visibilities_preparation` example explains how this initial setup can be performed
+before lens modeling and saved to hard disk for fast loading before the model fit.
 
 __Contents__
 

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -19,10 +19,11 @@ Pixelizations are covered in detail in Chapter 4 of the HowToLens lecture series
 
 __CPU Users__
 
-Matrices must be set up for a pixelized source reconstruction which speed up the linear algebra. On GPU, this takes
-seconds, or at most a minute for datasets with tens of millions, or more visibities. On CPU, this can be a lot slower,
-taking over hours. If you are on CPU,  the `feature/pixelization/many_visibilities_preparation` explains how this
-initial setup can be performed before lens modeling and saved to hard disk for fast loading before the model fit.
+Matrices must be set up for a pixelized source reconstruction to speed up the linear algebra. On GPU, this takes
+seconds, or at most a minute for datasets with tens of millions or more visibilities. On CPU, this can be a lot
+slower, taking over an hour for very large datasets. If you are on CPU, the
+`feature/pixelization/many_visibilities_preparation` example explains how this initial setup can be performed
+before lens modeling and saved to hard disk for fast loading before the model fit.
 
 __Contents__
 
@@ -67,10 +68,12 @@ Finally, many science applications aim to study the highly magnified source gala
 distant and intrinsically faint galaxies. pixelizations reconstruct the unlensed source emission, enabling detailed
 studies of the source-plane structure.
 
-For CCD imaging, a disadvantage of pixelized source reconstructions is they are the most computationally expensive
-modeling approach. However, for interferometer datasets, the way that JAX and GPUs can exploit the sparsity in the
-linear algebra means pixelized source reconstructions are both significantly faster than other approaches (E.g.
-light profiles) and can scale to millions of visibilities.
+For CCD imaging, a disadvantage of pixelized source reconstructions is that they are the most computationally
+expensive modeling approach. For interferometer datasets, the situation is more nuanced: light-profile modeling
+via the JAX-native `TransformerNUFFT` (backed by `nufftax`) is now also fast at large visibility counts, so
+pixelizations are no longer required purely for performance. Their continuing strengths are morphological
+flexibility (irregular sources) and VRAM efficiency on very large real-space masks, where their sparsity-aware
+linear algebra still wins.
 
 __Disadvantages__
 

--- a/scripts/interferometer/features/pixelization/slam.py
+++ b/scripts/interferometer/features/pixelization/slam.py
@@ -11,27 +11,32 @@ Because the SLaM pipelines are designed around pixelized source modeling, the ex
 describes all design choices and modeling decisions made in this script. This script therefore does not repeat
 that documentation, therefore `slam_start_here` should be read first.
 
-The interferometer SLaM pipeline has one different from the imaging SLaM pipeline, it omits the `source_lp`
-pipeline and does not fit a model with a light profile source. This is because fitting light profiles
-to datasets with many visibilities is slow, whereas pixelized sources are fast. This has two consequences:
+The interferometer SLaM pipeline closely mirrors the imaging SLaM pipeline, with one notable difference:
 
-- You must provide the multiple image locations used for the position likelihoods manually, whereas for the imaging
-  SLaM pipeline they are estimated via the lens model fit in the `source_lp` pipeline.
+- It uses **two datasets with different transformers**. The `source_lp` stage uses `TransformerNUFFT` (backed
+  by the JAX-native `nufftax`, https://github.com/GragasLab/nufftax) so light-profile fitting runs at full GPU
+  speed even on ALMA-class datasets with millions of visibilities. The `source_pix` and `mass` stages switch to
+  `TransformerDFT` combined with the pre-computed sparse operator, because pixelized source reconstructions
+  exploit sparsity rather than the NUFFT path.
 
-- `source_pix[1]` does not have an adapt image and therefore uses a regularization which is not adaptive.
+The interferometer SLaM pipeline still omits the `light_lp` stage, because interferometer data does not contain
+lens light emission. The lens galaxy therefore has no `bulge`/`disk` light components anywhere in the pipeline.
 
-Other than that, the interferometer SLaM pipeline is identical to the imaging SLaM pipeline.
+Now that `source_lp` is included, the position likelihood and adapt image needed by the pixelized pipelines are
+derived automatically from the `source_lp` result (mirroring the imaging pipeline). Manual position input is no
+longer required.
 
 __Contents__
 
 - **Prerequisites:** Before using this SLaM pipeline, you should be familiar with.
 - **Interferometer SLaM Description:** The `slam_start_here` notebook provides a detailed description of the SLaM pipelines, but it does.
 - **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
-- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **SOURCE LP PIPELINE:** Initializes the mass and source-light model with MGE light profiles, fitted via `TransformerNUFFT`.
+- **SOURCE PIX PIPELINE 1:** Initializes a pixelized source using the adapt image from the SOURCE LP result.
+- **SOURCE PIX PIPELINE 2:** Improves the pixelized source using adapt images from `source_pix_result_1`.
 - **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Two Datasets:** Build one Interferometer with `TransformerNUFFT` (source_lp) and one with `TransformerDFT` + sparse operator (source_pix onwards).
 - **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
 - **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
 - **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
 - **Redshifts:** The redshifts of the lens and source galaxies.
@@ -86,29 +91,34 @@ import autolens as al
 import autolens.plot as aplt
 
 """
-__SOURCE PIX PIPELINE 1__
+__SOURCE LP PIPELINE__
 
-Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized source
-pipeline. This is because fitting light profiles to interferometer datasets with many visibilities is slow.
+The SOURCE LP PIPELINE uses one search to initialize a robust model for the source galaxy's light using a Multi
+Gaussian Expansion (MGE). The lens galaxy mass and external shear are fitted at the same time.
 
-The search therefore uses a `Constant` regularization (not adaptive) as there is no adapt image available.
+This stage uses the `dataset_nufft` Interferometer (built with `TransformerNUFFT`, backed by `nufftax`), which
+makes light-profile fitting fast even for ALMA-class datasets with millions of visibilities.
+
+The mass and source models from this search initialize the SOURCE PIX PIPELINE searches that follow, and the
+result also provides the adapt image and position likelihood used by those later stages.
+
+Note that no lens light is fitted: interferometer data does not contain lens light emission, so `lens.bulge` and
+`lens.disk` are kept at `None`.
 """
 
 
-def source_pix_1(
+def source_lp(
     settings_search: af.SettingsSearch,
     dataset,
+    mask_radius: float,
     redshift_lens: float,
     redshift_source: float,
-    positions_likelihood,
-    mesh_shape,
-    settings,
-    n_batch: int = 20,
+    n_batch: int = 50,
 ) -> af.Result:
-    analysis = al.AnalysisInterferometer(
-        dataset=dataset,
-        positions_likelihood_list=[positions_likelihood],
-        settings=settings,
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+    source_bulge = al.model_util.mge_model_from(
+        mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
     )
 
     model = af.Collection(
@@ -116,6 +126,7 @@ def source_pix_1(
             lens=af.Model(
                 al.Galaxy,
                 redshift=redshift_lens,
+                # interferometer data does not contain lens light emission
                 bulge=None,
                 disk=None,
                 mass=af.Model(al.mp.Isothermal),
@@ -124,10 +135,87 @@ def source_pix_1(
             source=af.Model(
                 al.Galaxy,
                 redshift=redshift_source,
+                bulge=source_bulge,
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_lp[1]",
+        **settings_search.search_dict,
+        n_live=200,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 1__
+
+The SOURCE PIX PIPELINE uses two searches to initialize a robust pixelized model of the source galaxy.
+
+The first search fits a pixelization whose purpose is to generate a high-quality adapt image used in
+search 2. It uses the adapt image computed from the SOURCE LP result (passed via `source_lp_result`) and the
+position likelihood is also derived automatically from the SOURCE LP result via
+`source_lp_result.positions_likelihood_from(...)` — no manual positions input is required.
+
+This stage uses the `dataset_dft_sparse` Interferometer (built with `TransformerDFT` + `apply_sparse_operator`).
+Pixelizations do not use the NUFFT path; the sparse-operator + DFT combination is what keeps pixelized source
+reconstructions fast and VRAM-efficient on large datasets.
+"""
+
+
+def source_pix_1(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    mesh_init,
+    regularization_init,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_lp_result
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_lp_result.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=source_lp_result.model.galaxies.lens.mass,
+        mass_result=source_lp_result.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+    shear = source_lp_result.model.galaxies.lens.shear
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
-                    regularization=al.reg.Constant,
+                    mesh=mesh_init,
+                    regularization=regularization_init,
                 ),
             ),
         ),
@@ -151,14 +239,18 @@ pixelization and regularization.
 
 Note that the LIGHT LP PIPELINE from `slam_start_here.py` is omitted here, as interferometer data does not
 contain lens light emission.
+
+Like SOURCE PIX PIPELINE 1, this stage uses the `dataset_dft_sparse` Interferometer.
 """
 
 
 def source_pix_2(
     settings_search: af.SettingsSearch,
     dataset,
+    source_lp_result: af.Result,
     source_pix_result_1: af.Result,
-    mesh_shape,
+    mesh,
+    regularization,
     settings,
     n_batch: int = 20,
 ) -> af.Result:
@@ -178,7 +270,7 @@ def source_pix_2(
         galaxies=af.Collection(
             lens=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.lens.redshift,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
                 # interferometry does not support lens light
                 bulge=None,
                 disk=None,
@@ -187,11 +279,11 @@ def source_pix_2(
             ),
             source=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.source.redshift,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
-                    regularization=al.reg.Adapt,
+                    mesh=mesh,
+                    regularization=regularization,
                 ),
             ),
         ),
@@ -315,12 +407,33 @@ if not dataset_path.exists():
 #     )
 
 
-dataset = al.Interferometer.from_fits(
+"""
+__Two Datasets__
+
+The SLaM pipeline runs in two phases that prefer different transformers:
+
+- `dataset_nufft` uses `TransformerNUFFT` (backed by JAX-native `nufftax`) for the `source_lp` stage. With
+  light profiles this is the fast path at any visibility count, including ALMA-class datasets.
+- `dataset_dft_sparse` uses `TransformerDFT` combined with `apply_sparse_operator(...)` for `source_pix_1`,
+  `source_pix_2` and `mass_total`. Pixelized source reconstructions exploit sparsity in the linear inversion
+  rather than the NUFFT, so this combination is the right choice for the pixelized stages.
+
+Both datasets are built from the same FITS files; only the transformer (and sparse-operator preload) differ.
+"""
+dataset_nufft = al.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
     transformer_class=al.TransformerNUFFT,
+)
+
+dataset_dft_sparse = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
 )
 
 """
@@ -331,7 +444,10 @@ pixelized source modeling, especially for many visibilities.
 
 We use a try / except to load the pre-computed curvature preload, which is necessary to use
 the sparse operator formalism. If this file does not exist (e.g. you have not made it manually via
-the `many_visibilities_preparartion` example it is made here.
+the `many_visibilities_preparation` example) it is made here.
+
+The sparse operator is applied only to `dataset_dft_sparse` — the NUFFT-backed `dataset_nufft` used by
+`source_lp` does not need it.
 """
 try:
     nufft_precision_operator = np.load(
@@ -340,21 +456,9 @@ try:
 except FileNotFoundError:
     nufft_precision_operator = None
 
-dataset = dataset.apply_sparse_operator(
+dataset_dft_sparse = dataset_dft_sparse.apply_sparse_operator(
     nufft_precision_operator=nufft_precision_operator, use_jax=True, show_progress=True
 )
-
-"""
-__Position Likelihood__
-
-Load the multiple image positions used for the position likelihood, which resamples bad mass
-models and prevents demagnified solutions being inferred.
-"""
-positions = al.Grid2DIrregular(
-    al.from_json(file_path=Path(dataset_path, "positions.json"))
-)
-
-positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
 
 """
 __Settings__
@@ -397,28 +501,40 @@ __SLaM Pipeline__
 
 The code below calls the full SLaM PIPELINE. See the documentation string above each Python function for
 a description of each pipeline step.
+
+Note the transformer split: `source_lp` is passed `dataset_nufft` (TransformerNUFFT), while every later stage
+is passed `dataset_dft_sparse` (TransformerDFT + sparse operator).
 """
-source_pix_result_1 = source_pix_1(
+source_lp_result = source_lp(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_nufft,
+    mask_radius=mask_radius,
     redshift_lens=redshift_lens,
     redshift_source=redshift_source,
-    positions_likelihood=positions_likelihood,
-    mesh_shape=mesh_shape,
+)
+
+source_pix_result_1 = source_pix_1(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    mesh_init=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
+    regularization_init=al.reg.Adapt,
     settings=settings,
 )
 
 source_pix_result_2 = source_pix_2(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
     source_pix_result_1=source_pix_result_1,
-    mesh_shape=mesh_shape,
+    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
+    regularization=al.reg.Adapt,
     settings=settings,
 )
 
 mass_result = mass_total(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     source_pix_result_2=source_pix_result_2,
     settings=settings,

--- a/scripts/interferometer/features/subhalo/detect/start_here.py
+++ b/scripts/interferometer/features/subhalo/detect/start_here.py
@@ -19,11 +19,12 @@ __Contents__
 - **Grid Search:** The second stage of the SUBHALO PIPELINE uses a grid-search of non-linear searches to determine the.
 - **Pixelized Source:** Detecting a DM subhalo requires the lens model to be sufficiently accurate that the residuals of.
 - **Model:** Compose the lens model fitted to the data.
-- **SOURCE PIX PIPELINE 1:** Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized.
-- **SOURCE PIX PIPELINE 2:** Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the.
+- **SOURCE LP PIPELINE:** Initializes the mass model + source-light using MGE light profiles via `TransformerNUFFT`.
+- **SOURCE PIX PIPELINE 1:** Initializes a pixelized source using the adapt image from the SOURCE LP result.
+- **SOURCE PIX PIPELINE 2:** Improves the pixelized source using adapt images from `source_pix_result_1`.
 - **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included as interferometer data.
+- **Two Datasets:** Build one Interferometer with `TransformerNUFFT` (source_lp) and one with `TransformerDFT` + sparse operator (source_pix onwards).
 - **Sparse Operators:** The `pixelization/modeling` example describes how the sparse operator formalism speeds up.
-- **Position Likelihood:** Load the multiple image positions used for the position likelihood, which resamples bad mass models.
 - **Settings:** Disable the default position only linear algebra solver so the source reconstruction can have.
 - **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database use, etc.
 - **Redshifts:** The redshifts of the lens and source galaxies.
@@ -112,29 +113,30 @@ import autolens as al
 import autolens.plot as aplt
 
 """
-__SOURCE PIX PIPELINE 1__
+__SOURCE LP PIPELINE__
 
-Unlike `slam_start_here.py`, this pipeline does not use a `source_lp` pipeline before the pixelized source
-pipeline. This is because fitting light profiles to interferometer datasets with many visibilities is slow.
+Initializes a robust mass + source-light model using a Multi Gaussian Expansion (MGE), fit with light profiles.
 
-The search therefore uses a `Constant` regularization (not adaptive) as there is no adapt image available.
+This stage uses `dataset_nufft` (built with `TransformerNUFFT`, backed by JAX-native `nufftax`), which makes
+light-profile fitting fast even on ALMA-class datasets with millions of visibilities. The result provides the
+adapt image and position likelihood threaded into the pixelized pipelines that follow.
+
+No lens light is fitted: interferometer data does not contain lens light emission.
 """
 
 
-def source_pix_1(
+def source_lp(
     settings_search: af.SettingsSearch,
     dataset,
+    mask_radius: float,
     redshift_lens: float,
     redshift_source: float,
-    positions_likelihood,
-    mesh_shape,
-    settings,
-    n_batch: int = 20,
+    n_batch: int = 50,
 ) -> af.Result:
-    analysis = al.AnalysisInterferometer(
-        dataset=dataset,
-        positions_likelihood_list=[positions_likelihood],
-        settings=settings,
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+    source_bulge = al.model_util.mge_model_from(
+        mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
     )
 
     model = af.Collection(
@@ -150,10 +152,83 @@ def source_pix_1(
             source=af.Model(
                 al.Galaxy,
                 redshift=redshift_source,
+                bulge=source_bulge,
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_lp[1]",
+        **settings_search.search_dict,
+        n_live=200,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 1__
+
+The first search of the SOURCE PIX PIPELINE fits a pixelization whose purpose is to generate a high-quality
+adapt image used in search 2. It uses the adapt image computed from the SOURCE LP result, with the position
+likelihood derived automatically via `source_lp_result.positions_likelihood_from(...)`.
+
+This stage uses `dataset_dft_sparse` (built with `TransformerDFT` + `apply_sparse_operator`). Pixelizations
+exploit sparsity in the linear inversion rather than the NUFFT path.
+"""
+
+
+def source_pix_1(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    mesh_init,
+    regularization_init,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_lp_result
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_lp_result.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=source_lp_result.model.galaxies.lens.mass,
+        mass_result=source_lp_result.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+    shear = source_lp_result.model.galaxies.lens.shear
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
-                    regularization=al.reg.Constant,
+                    mesh=mesh_init,
+                    regularization=regularization_init,
                 ),
             ),
         ),
@@ -183,8 +258,10 @@ contain lens light emission.
 def source_pix_2(
     settings_search: af.SettingsSearch,
     dataset,
+    source_lp_result: af.Result,
     source_pix_result_1: af.Result,
-    mesh_shape,
+    mesh,
+    regularization,
     settings,
     n_batch: int = 20,
 ) -> af.Result:
@@ -204,7 +281,7 @@ def source_pix_2(
         galaxies=af.Collection(
             lens=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.lens.redshift,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
                 # interferometry does not support lens light
                 bulge=None,
                 disk=None,
@@ -213,11 +290,11 @@ def source_pix_2(
             ),
             source=af.Model(
                 al.Galaxy,
-                redshift=source_pix_result_1.instance.galaxies.source.redshift,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
                 pixelization=af.Model(
                     al.Pixelization,
-                    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
-                    regularization=al.reg.Adapt,
+                    mesh=mesh,
+                    regularization=regularization,
                 ),
             ),
         ),
@@ -548,12 +625,31 @@ if not dataset_path.exists():
 #     )
 
 
-dataset = al.Interferometer.from_fits(
+"""
+__Two Datasets__
+
+The SLaM pipeline runs in two phases that prefer different transformers:
+
+- `dataset_nufft` uses `TransformerNUFFT` (backed by JAX-native `nufftax`) for the `source_lp` stage.
+- `dataset_dft_sparse` uses `TransformerDFT` + `apply_sparse_operator(...)` for `source_pix_1`,
+  `source_pix_2`, `mass_total`, and every search of the SUBHALO PIPELINE.
+
+Both datasets are built from the same FITS files; only the transformer (and sparse-operator preload) differ.
+"""
+dataset_nufft = al.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
     transformer_class=al.TransformerNUFFT,
+)
+
+dataset_dft_sparse = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
 )
 
 """
@@ -564,7 +660,10 @@ pixelized source modeling, especially for many visibilities.
 
 We use a try / except to load the pre-computed curvature preload, which is necessary to use
 the sparse operator formalism. If this file does not exist (e.g. you have not made it manually via
-the `many_visibilities_preparartion` example it is made here.
+the `many_visibilities_preparation` example) it is made here.
+
+The sparse operator is applied only to `dataset_dft_sparse` — the NUFFT-backed `dataset_nufft` used by
+`source_lp` does not need it.
 """
 try:
     nufft_precision_operator = np.load(
@@ -573,21 +672,9 @@ try:
 except FileNotFoundError:
     nufft_precision_operator = None
 
-dataset = dataset.apply_sparse_operator(
+dataset_dft_sparse = dataset_dft_sparse.apply_sparse_operator(
     nufft_precision_operator=nufft_precision_operator, use_jax=True, show_progress=True
 )
-
-"""
-__Position Likelihood__
-
-Load the multiple image positions used for the position likelihood, which resamples bad mass
-models and prevents demagnified solutions being inferred.
-"""
-positions = al.Grid2DIrregular(
-    al.from_json(file_path=Path(dataset_path, "positions.json"))
-)
-
-positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
 
 """
 __Settings__
@@ -630,28 +717,40 @@ __SLaM Pipeline__
 
 The code below calls the full SLaM PIPELINE. See the documentation string above each Python function for
 a description of each pipeline step.
+
+Note the transformer split: `source_lp` is passed `dataset_nufft` (TransformerNUFFT), while every later stage
+— including the SUBHALO PIPELINE — is passed `dataset_dft_sparse` (TransformerDFT + sparse operator).
 """
-source_pix_result_1 = source_pix_1(
+source_lp_result = source_lp(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_nufft,
+    mask_radius=mask_radius,
     redshift_lens=redshift_lens,
     redshift_source=redshift_source,
-    positions_likelihood=positions_likelihood,
-    mesh_shape=mesh_shape,
+)
+
+source_pix_result_1 = source_pix_1(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    mesh_init=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
+    regularization_init=al.reg.Adapt,
     settings=settings,
 )
 
 source_pix_result_2 = source_pix_2(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
     source_pix_result_1=source_pix_result_1,
-    mesh_shape=mesh_shape,
+    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
+    regularization=al.reg.Adapt,
     settings=settings,
 )
 
 mass_result = mass_total(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     source_pix_result_2=source_pix_result_2,
     settings=settings,
@@ -659,7 +758,7 @@ mass_result = mass_total(
 
 result_no_subhalo = subhalo_no_subhalo(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     mass_result=mass_result,
     settings=settings,
@@ -667,7 +766,7 @@ result_no_subhalo = subhalo_no_subhalo(
 
 result_subhalo_grid_search = subhalo_grid_search(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     mass_result=mass_result,
     subhalo_no_subhalo_result=result_no_subhalo,
@@ -679,7 +778,7 @@ result_subhalo_grid_search = subhalo_grid_search(
 
 result_with_subhalo = subhalo_refine(
     settings_search=settings_search,
-    dataset=dataset,
+    dataset=dataset_dft_sparse,
     source_pix_result_1=source_pix_result_1,
     mass_result=mass_result,
     subhalo_no_subhalo_result=result_no_subhalo,

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -54,13 +54,12 @@ __Loading Data__
 We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset 
 we will use to demonstrate fitting.
 
-This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and compare 
-directly to the visiblities. We use a non-uniform fast Fourier transform, which is the most efficient method for 
-interferometer datasets containing ~1-10 million visibilities.
+This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and
+compare directly to the visibilities. We use `TransformerNUFFT`, the JAX-native Non-Uniform Fast Fourier Transform
+backed by `nufftax`, which scales efficiently from a few hundred visibilities to tens of millions.
 
-This dataset was simulated using the `interferometer/simulator` example, read through that to have a better
-understanding of how the data this exam fits was generated. The simulation uses the `TransformerDFT` to map
-the real-space image to the uv-plane.
+This dataset was simulated using the `interferometer/simulator` example, read through that to understand how
+the data this example fits was generated.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -85,7 +84,7 @@ dataset = al.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -94,7 +94,7 @@ dataset = al.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -2,12 +2,13 @@
 Modeling: Start Here
 ====================
 
-This script is the starting point for lens modeling of interferometer datasets with less than 1000
-visibilities (e.g. SMA, ALMA) and it provides an overview of the lens modeling API.
+This script is the starting point for lens modeling of interferometer datasets (e.g. SMA, ALMA) and it
+provides an overview of the lens modeling API. The same workflow scales from a few hundred visibilities
+to many millions, thanks to the JAX-native `TransformerNUFFT` (backed by `nufftax`).
 
 __Contents__
 
-- **Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
+- **Number of Visibilities:** This example fits a low-resolution dataset, but the same workflow scales to many millions of visibilities.
 - **Model:** Compose the lens model fitted to the data.
 - **Mask:** Define the 2D mask applied to the dataset for the model-fit.
 - **Dataset:** Load and plot the strong lens dataset.
@@ -33,21 +34,17 @@ __Contents__
 __Number of Visibilities__
 
 This example fits a **low-resolution interferometric dataset** with a small number of visibilities (273). The
-dataset is intentionally minimal so that the example runs quickly and allows you to become familiar with the API
-and modeling workflow. The code demonstrated in this example can feasible fit datasets with up to around 10000
-visibilities, above which computational time and VRAM use become significant for this modeling approach.
+dataset is intentionally minimal so the example runs quickly and you can become familiar with the API and
+modeling workflow.
 
-High-resolution datasets with many visibilities (e.g. high-quality ALMA observations
-with **millions hundreds of millions of visibilities**) can be modeled efficiently. However, this requires
-using the more advanced **pixelized source reconstructions** modeling approach. These large datasets fully
-exploit **JAX acceleration**, enable lens modeling to run in **hours on a modern GPU**.
+The same workflow — light profiles + `TransformerNUFFT` (backed by `nufftax`, https://github.com/GragasLab/nufftax) —
+scales to high-resolution datasets with **millions to hundreds of millions of visibilities** (e.g. ALMA), with no
+change beyond the transformer choice. The NUFFT runs inside JAX's jit/vmap pipeline, so both run time and VRAM
+stay manageable on a GPU at any visibility count.
 
-If your dataset contains many visibilities, you should start by working through this example and the other examples
-in the `interferometer` folder. Once you are comfortable with the API, the `feature/pixelization` package provides a
-guided path toward efficiently modeling large interferometric datasets.
-
-The threshold between a dataset having many visibilities and therefore requiring pixelized source reconstructions, or
-being small enough to be modeled with light profiles, is around **10,000 visibilities**.
+Pixelized source reconstructions (see `features/pixelization`) remain the right tool when the source has
+complex, irregular morphology that simple light profiles cannot capture. They are no longer required purely
+because the dataset is large.
 
 __Model__
 
@@ -84,12 +81,13 @@ real_space_mask = al.Mask2D.circular(
 """
 __Dataset__
 
-Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, which we will fit 
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, which we will fit
 with the lens model.
 
-This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and compare 
-directly to the visiblities. We use a non-uniform fast Fourier transform, which is the most efficient method for 
-interferometer datasets containing ~1-10 million visibilities.
+This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and
+compare directly to the visibilities. We use `TransformerNUFFT`, a JAX-native Non-Uniform Fast Fourier Transform
+backed by `nufftax`. This is the recommended choice at any visibility count and scales efficiently to ALMA-class
+datasets with tens of millions of visibilities.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -114,7 +112,7 @@ dataset = al.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)
@@ -361,18 +359,19 @@ chosen batch size is comfortably below their GPU’s total VRAM.
 The method below prints the VRAM usage estimate for the analysis and model with the specified batch size,
 it takes about 20-30 seconds to run so you may want to comment it out once you are familiar with your GPU's VRAM limits.
 
-Interferometer lens modeling using a `TransformerDFT` can be VRAM intensive, with it quickly exceed GBs for many
-visibilities (e.g. > 10000) and real space masks with pixel scales below 0.1". VRAM also does not scale
-with the batch size, so if the analysis fits within VRAM for batch size 1, you should be able to increase it to
-50 to make run times fastest. 
+With `TransformerNUFFT` (backed by `nufftax`), the dominant contributor to VRAM is usually the real-space image
+and its transforms inside the likelihood function, rather than the visibility count itself. VRAM does not scale
+with batch size for the persistent buffers, so if the analysis fits within VRAM for `batch_size=1` you should be
+able to push the batch size up (e.g. to 50) to maximise GPU throughput without running out of memory.
 
-For a MGE model with the low visibility dataset fitted in this example VRAM use is relatively low (~0.3GB). Modeling
-data with more than 273 visibilities, or a highest resolution real space mask, will quickly increase VRAM use
-into the GBs.
+For an MGE model with the small dataset fitted in this example, VRAM use is modest (~0.3 GB). Larger real-space
+masks (finer pixel scales) and higher visibility counts increase VRAM gradually rather than catastrophically, and
+a single GPU comfortably handles millions of visibilities with this approach.
 
-The large VRAM use is an important reason why pixelized source reconstructions, which exploit sparsity to minimize 
-VRAM use, are required for high resolution datasets with millions of visibilities. These keep VRAM use low 
-(e.g. 4 GB) even when there are many visibilities and a high resolution real space mask.
+Pixelized source reconstructions (see `features/pixelization`) take a different VRAM trade-off: they keep VRAM
+use low by exploiting sparsity in the linear inversion, which makes them attractive when the real-space mask is
+very large or the source morphology requires it. They are no longer required purely because the dataset has many
+visibilities.
 """
 analysis.print_vram_use(model=model, batch_size=search.batch_size)
 
@@ -519,11 +518,11 @@ This script gives a concise overview of the basic modeling API, fitting one the 
 Lets now consider what features you should read about to improve your lens modeling, especially if you are aiming
 to fit more complex models to your data.
 
-The examples in the `autolens_workspace/*/interferometer/features` package illustrate other lens modeling 
-features. 
+The examples in the `autolens_workspace/*/interferometer/features` package illustrate other lens modeling
+features.
 
-We recommend you checkout just one feature next, because it makes lens modeling of interferometer datasets 
-in more reliable and efficient and will then allow you to model high resolution datasets with many visibilities:
+We recommend you checkout the `pixelization` feature next, which lets you reconstruct sources with complex,
+irregular morphology that simple light profiles cannot capture:
 
 - ``pixelization``: The source is reconstructed using an adaptive Rectangular mesh or Delaunay mesh.
 

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -16,7 +16,7 @@ __Contents__
 - **Visualize:** Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset.
 - **Tracer json:** Save the `Tracer` in the dataset folder as a .json file, ensuring the true light profiles, mass.
 - **Multiple Images:** Lens modeling can use a "positions likelihood penalty", whereby mass models which traces the (y,x).
-- **Many Visibilities:** Simulating interferometer datasets with many visibilities can be computationally expensive if a.
+- **Many Visibilities:** Simulating interferometer datasets with many visibilities using the JAX-native `TransformerNUFFT`.
 - **High Resolution Dataset:** A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts.
 
 """
@@ -82,14 +82,18 @@ uv_wavelengths = al.ndarray_via_fits_from(
 )
 
 """
-To simulate the interferometer dataset we first create a simulator, which defines the exposure time, noise levels 
+To simulate the interferometer dataset we first create a simulator, which defines the exposure time, noise levels
 and Fourier transform method used in the simulation.
+
+We use `TransformerNUFFT` (backed by `nufftax`, https://github.com/GragasLab/nufftax), a JAX-native Non-Uniform
+Fast Fourier Transform. This is the recommended transformer at any visibility count and is fast enough to
+simulate ALMA-class datasets with millions of visibilities end-to-end on a GPU.
 """
 simulator = al.SimulatorInterferometer(
     uv_wavelengths=uv_wavelengths,
     exposure_time=300.0,
     noise_sigma=1000.0,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 """
@@ -230,18 +234,16 @@ The dataset can be viewed in the folder `autolens_workspace/imaging/simple`.
 
 __Many Visibilities__
 
-Simulating interferometer datasets with many visibilities can be computationally expensive
-if a direct Fourier transform is used. 
+Simulating interferometer datasets with many visibilities is fast end-to-end when `TransformerNUFFT` is used,
+which is backed by the JAX-native `nufftax` library (https://github.com/GragasLab/nufftax). The NUFFT scales
+efficiently from a few hundred visibilities up to ALMA-class datasets with tens of millions of visibilities,
+all inside the JAX jit/vmap pipeline.
 
-Therefore, for simulating high-resolution datasets with many visibilities (e.g. > 10000), we recommend using the
-`TransformerNUFFT` transformer, which uses a non-uniform fast Fourier transform via the library pynufft to 
-perform the Fourier transform efficiently.
+Higher resolution datasets also require a higher resolution real space grid, which is the dominant remaining
+cost — visibility count alone is no longer the bottleneck.
 
-Higher resolution datasets also require a higher resolution real space grid, which also increases the computational
-costs of simulating the dataset.
-
-The code below loads a `uv_wavelengths` file with many over 1 million visibilities and simulates the dataset using 
-the `TransformerNUFFT`.
+The code below loads a `uv_wavelengths` file with over 1 million visibilities and simulates the dataset using
+`TransformerNUFFT`.
 
 __High Resolution Dataset__
 
@@ -276,11 +278,11 @@ simulator = al.SimulatorInterferometer(
     uv_wavelengths=uv_wavelengths,
     exposure_time=300.0,
     noise_sigma=1000.0,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 """
-The code below is identical to above, outputting images, data, tracer and multiple image 
+The code below is identical to above, outputting images, data, tracer and multiple image
 positions to the dataset folder.
 """
 aplt.plot_array(array=tracer.image_2d_from(grid=grid), title="Image")

--- a/scripts/interferometer/source_science.py
+++ b/scripts/interferometer/source_science.py
@@ -50,13 +50,12 @@ __Loading Data__
 We we begin by loading the strong lens dataset `simple` from .fits files, which is the dataset 
 we will use to demonstrate fitting.
 
-This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and compare 
-directly to the visiblities. We use a non-uniform fast Fourier transform, which is the most efficient method for 
-interferometer datasets containing ~1-10 million visibilities.
+This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and
+compare directly to the visibilities. We use `TransformerNUFFT`, the JAX-native Non-Uniform Fast Fourier Transform
+backed by `nufftax`, which scales efficiently from a few hundred visibilities to tens of millions.
 
-This dataset was simulated using the `interferometer/simulator` example, read through that to have a better
-understanding of how the data this exam fits was generated. The simulation uses the `TransformerDFT` to map
-the real-space image to the uv-plane.
+This dataset was simulated using the `interferometer/simulator` example, read through that to understand how
+the data this example fits was generated.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -81,7 +80,7 @@ dataset = al.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -15,14 +15,15 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 __Contents__
 
 - **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-- **Number of Visibilities:** This example fits a **low-resolution interferometric dataset** with a small number of visibilities.
+- **NUFFT (nufftax):** A JAX-native Non-Uniform FFT, used for the image to uv-plane transform of light profiles.
+- **Number of Visibilities:** This example fits a low-resolution interferometric dataset, but the same workflow scales to millions of visibilities.
 - **Google Colab Setup:** The introduction `start_here` examples are available on Google Colab, which allows you to run them.
 - **Imports:** Import the required Python libraries.
 - **Dataset:** Load and plot the strong lens dataset.
 - **Model:** Compose the lens model fitted to the data.
 - **Model Fit:** Perform the model-fit using the search and analysis.
 - **Result:** Overview of the results of the model-fit.
-- **Model Your Own Lens:** If you have your own strong lens interferometer data, and it has less than ~10000 visibilities, you.
+- **Model Your Own Lens:** Adapting this script to fit your own interferometer dataset.
 - **Simulator:** Let’s now switch gears and simulate our own strong lens interferometer.
 - **Sample:** Often we want to simulate *many* strong lenses — for example, to train a neural network or to.
 - **Wrap Up:** Summary of the script and next steps.
@@ -38,24 +39,38 @@ If you don’t have a GPU locally, consider Google Colab which provides free GPU
 We also show how to simulate interferometer datasets. This is useful for building machine
 learning training datasets, or for investigating lensing effects in a controlled way.
 
+__NUFFT (nufftax)__
+
+The image-to-visibilities Fourier transform is performed by a Non-Uniform Fast Fourier Transform (NUFFT),
+exposed in **PyAutoLens** as `TransformerNUFFT`. The default backend is `nufftax`, a pure-JAX NUFFT
+that jit-compiles and vmap-batches like the rest of the library:
+
+  https://github.com/GragasLab/nufftax
+
+Because `nufftax` is JAX-native, light-profile interferometer modeling now runs at full GPU speed for
+datasets with **arbitrarily many visibilities** — including high-resolution ALMA observations with tens of
+millions to hundreds of millions of visibilities. Previously this was only practical for small datasets,
+or required switching to a pixelized source reconstruction. Pixelized sources are still recommended for
+complex, irregular source morphologies (see `features/pixelization`), but they are no longer a
+performance requirement for large datasets.
+
+If `nufftax` is not installed, install it via `pip install nufftax`. A legacy pynufft-backed
+transformer (`TransformerNUFFTPyNUFFT`) is also available as a non-JAX fallback.
+
 __Number of Visibilities__
 
 This example fits a **low-resolution interferometric dataset** with a small number of visibilities (273). The
 dataset is intentionally minimal so that the example runs quickly and allows you to become familiar with the API
-and modeling workflow. The code demonstrated in this example can feasible fit datasets with up to around 10000
-visibilities, above which computational time and VRAM use become significant for this modeling approach.
+and modeling workflow.
 
-High-resolution datasets with many visibilities (e.g. high-quality ALMA observations
-with **millions hundreds of millions of visibilities**) can be modeled efficiently. However, this requires
-using the more advanced **pixelized source reconstructions** modeling approach. These large datasets fully
-exploit **JAX acceleration**, enable lens modeling to run in **hours on a modern GPU**.
+The same modeling workflow — light profiles + `TransformerNUFFT` (nufftax) — scales to high-resolution
+datasets with **millions to hundreds of millions of visibilities** (e.g. ALMA), with no special handling
+beyond switching the transformer choice. Both computational time and VRAM use stay manageable on a GPU
+because `nufftax` runs the NUFFT inside the JAX jit/vmap pipeline.
 
-If your dataset contains many visibilities, you should start by working through this example and the other examples
-in the `interferometer` folder. Once you are comfortable with the API, the `feature/pixelization` package provides a
-guided path toward efficiently modeling large interferometric datasets.
-
-The threshold between a dataset having many visibilities and therefore requiring pixelized source reconstructions, or
-being small enough to be modeled with light profiles, is around **10,000 visibilities**.
+Pixelized source reconstructions (see `features/pixelization`) remain the right tool when the source has
+complex, irregular morphology that simple light profiles cannot capture. They are no longer required
+purely because the dataset is large.
 
 __Google Colab Setup__
 
@@ -129,14 +144,17 @@ We begin by loading an `Interferometer` dataset from FITS, three ingredients are
 - `noise_map.fits`: per-visibility complex RMS
 - `uv_wavelengths.fits`: (u, v) sampling of the interferometer in wavelengths
 
-We must also choose a transformer:
+We must also choose a transformer for mapping the real-space image to visibilities:
 
-- `TransformerDFT`: exact Discrete FT (robust, slower for large n_vis).
-- `TransformerNUFFT`: approximate Non-Uniform FFT (fast, accurate for large n_vis) using the pynufft library.
+- `TransformerNUFFT`: JAX-native Non-Uniform FFT (default, backed by `nufftax`). Recommended for any
+  dataset size — runs at full GPU speed for millions of visibilities.
+- `TransformerDFT`: exact Discrete FT. Slower than the NUFFT for large `n_vis`, but useful as a reference
+  for verification and for the pixelized source reconstruction's sparse-operator workflow (see
+  `features/pixelization`).
 
-We load a low resolution Square Mile Array (SMA) dataset for this example, which has just
-273 visibilities. This has so few visibilities that we can use the exact DFT transformer without
-the computation being too slow (for larger datasets with many visibilities the NUFFT transformer is recommended).
+We load a low resolution Square Mile Array (SMA) dataset for this example, which has just 273 visibilities.
+We use `TransformerNUFFT` so that this example reflects the recommended workflow at any visibility count;
+for 273 visibilities `TransformerDFT` would also work and produce a near-identical result.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -161,7 +179,7 @@ dataset = al.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=al.TransformerDFT,
+    transformer_class=al.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)
@@ -285,9 +303,9 @@ packages of the workspace contains all the information you need to analyze your 
 
 __Model Your Own Lens__
 
-If you have your own strong lens interferometer data, and it has less than ~10000 visibilities, you are now ready to 
-model it yourself by adapting the code above and simply inputting the path to your own .fits files into 
-the `Interferometer.from_fits()` function.
+If you have your own strong lens interferometer data — at any visibility count, from a handful up to the
+hundreds of millions typical of ALMA — you are ready to model it yourself by adapting the code above and
+inputting the path to your own .fits files into the `Interferometer.from_fits()` function.
 
 A few things to note, with full details on data preparation provided in the main workspace documentation:
 
@@ -385,7 +403,7 @@ simulator = al.SimulatorInterferometer(
     uv_wavelengths=uv_wavelengths,
     exposure_time=300.0,  # Length of observation in seconds, higher time = higher S/N
     noise_sigma=1000.0,  # RMS of the complex Gaussian noise added to the visibilities
-    transformer_class=al.TransformerDFT,  # keep consistent with your modeling choice
+    transformer_class=al.TransformerNUFFT,  # JAX-native NUFFT (nufftax) — scales to many visibilities
 )
 
 dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)


### PR DESCRIPTION
## Summary

Refreshes the interferometer package in light of `nufftax` (the new JAX-native NUFFT backend for `TransformerNUFFT`, https://github.com/GragasLab/nufftax). Light-profile interferometer modeling now runs at full GPU speed for any visibility count, so the long-standing prose framing — a 10,000-visibility ceiling for LPs, pixelizations recommended for performance — is no longer accurate.

Also restructures the three interferometer SLaM pipelines (pixelization, extra_galaxies, subhalo/detect) to add a `source_lp` stage and a two-dataset transformer pattern: `TransformerNUFFT` for source_lp (fast at any visibility count) and `TransformerDFT` + `apply_sparse_operator(...)` for source_pix onwards (the existing sparse-operator path for pixelizations).

## Scripts Changed

- `scripts/interferometer/start_here.py` — new `__NUFFT__` section crediting nufftax; rewrote `__Number of Visibilities__`; dropped the "<10000 visibilities" caveat; demo transformer switched to `TransformerNUFFT`
- `scripts/interferometer/modeling.py` — Number-of-Visibilities + VRAM narrative refresh; demo transformer switched to `TransformerNUFFT`; `Features` recommendation reframed (pixelizations for morphology, not speed)
- `scripts/interferometer/simulator.py` — `Many Visibilities` rewrite; both simulator demos switched to `TransformerNUFFT`
- `scripts/interferometer/fit.py`, `source_science.py`, `likelihood_function.py` — narrative refresh + `TransformerNUFFT` switch in `Interferometer.from_fits()`
- `scripts/interferometer/casa_reduction.py` — channel-averaging guidance no longer claims a visibility ceiling; troubleshooting bullet on "n_vis enormous" updated
- `scripts/interferometer/features/pixelization/slam.py` — added `source_lp()`; updated `source_pix_1/2` to take `source_lp_result` (adapt images + position-likelihood derived automatically); replaced the single dataset with `dataset_nufft` + `dataset_dft_sparse`; updated module docstring and pipeline call section
- `scripts/interferometer/features/pixelization/{modeling,fit}.py` — narrative refresh (pixelizations no longer "significantly faster than light profiles" — reframed as morphology + VRAM)
- `scripts/interferometer/features/datacube/data_preparation.py` — transformer docstring no longer references a 10k threshold
- `scripts/interferometer/features/extra_galaxies/slam.py` — same SLaM restructure as pixelization/slam (with extra-galaxy mass chained through); fixed pre-existing typo in the auto-simulation path (was pointing to the imaging simulator)
- `scripts/interferometer/features/subholo/detect/start_here.py` — same SLaM restructure (source_lp + two-dataset transformer pattern), with `dataset_dft_sparse` threaded through SUBHALO PIPELINE stages

## Test Plan

- [x] Smoke tests pass under `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` for `start_here.py`, `modeling.py`, `simulator.py`, `features/pixelization/slam.py`, `features/extra_galaxies/slam.py`, `features/subhalo/detect/start_here.py`
- [x] `scripts/check_sizes.sh` reports all scripts within tolerance (no bulk-edit shrinkage)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)