### PR TITLE
docs(multi/dataset_offsets): demonstrate grid_rotation_angle

### DIFF
--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -13,13 +13,14 @@ These offsets are often accounted for during the data reduction process, which a
  - Even if the reduction process does align the images, there is still a small uncertainty in the offset due to the
    precision of the telescope pointing which for detailed lens models must be accounted for.
 
-This script shows how to include an offset in the model, which is two free parameters, the y and x offsets, for every
-additional dataset after the first dataset. The offset therefore describes the offset of each dataset in the
-multi-wavelength dataset relative to the first dataset.
+This script shows how to include both an offset (two free parameters: y and x shifts) and a rotation (one free
+parameter: roll angle in degrees) in the model for every additional dataset after the first. Together these
+describe the rigid-body misalignment of each dataset relative to the reference (first) dataset, which is the
+common pattern for multi-band space-telescope data (e.g. JWST NIRCam frames at slightly different roll angles).
 
-To apply the offset, the code simply subtracts the offset from the grids aligned to the dataset pixels before performing
-lensing calculations. This means that the light and mass model centres do not change when the offset is applied, only
-the coordinates of the image pixels which are input into these profiles to compute the images.
+To apply the misalignment, the code subtracts the offset from the grids aligned to the dataset pixels and then
+rotates them about the offset point before performing lensing calculations. The light and mass model centres
+do not change; only the coordinates of the image pixels input into these profiles are transformed.
 
 __Contents__
 
@@ -171,8 +172,8 @@ __Model__
 
 We compose a lens model where:
 
- - Parameters which shift the second dataset's image (y_offset_0, x_offset_0) relative to the first dataset's image
- are included via the `DatasetModel` object [2 parameters].
+ - Parameters which shift (y_offset_0, x_offset_0) and rotate (grid_rotation_angle) the second dataset's image
+ relative to the first dataset's image are included via the `DatasetModel` object [3 parameters].
 
  - The lens galaxy's light is an MGE with 1 x 20 Gaussians [6 parameters].
 
@@ -180,7 +181,7 @@ We compose a lens model where:
 
  - The source galaxy's light is an MGE with 1 x 20 Gaussians [4 parameters].
 
-The number of free parameters and therefore the dimensionality of non-linear parameter space is N=23.
+The number of free parameters and therefore the dimensionality of non-linear parameter space is N=24.
 """
 bulge = al.model_util.mge_model_from(
     mask_radius=mask_radius,
@@ -235,6 +236,10 @@ for i, analysis in enumerate(analysis_list):
         )
         model_analysis.dataset_model.grid_offset.grid_offset_1 = af.UniformPrior(
             lower_limit=-1.0, upper_limit=1.0
+        )
+        # Roll-angle misalignment between exposures (degrees, CCW about the offset point).
+        model_analysis.dataset_model.grid_rotation_angle = af.UniformPrior(
+            lower_limit=-5.0, upper_limit=5.0
         )
 
     analysis_factor = af.AnalysisFactor(prior_model=model, analysis=analysis)

--- a/scripts/multi/features/dataset_offsets/simulator.py
+++ b/scripts/multi/features/dataset_offsets/simulator.py
@@ -13,9 +13,9 @@ These offsets are often accounted for during the data reduction process, which a
  - Even if the reduction process does align the images, there is still a small uncertainty in the offset due to the
    precision of the telescope pointing which for detailed lens models must be accounted for.
 
-This script simulate a multi-wavelength `Imaging` dataset where the two images have a small offset between them. This
-offset impacts the lensing calculation and modeling if not accounted for. It is used in the `modeling` examples to show
-how to include the offset as a free parameter in the model-fit.
+This script simulates a multi-wavelength `Imaging` dataset where the two images have a small offset and a small
+relative rotation between them. Both impact the lensing calculation and modeling if not accounted for. The
+`modeling` examples show how to include both as free parameters of a `DatasetModel`.
 
 __Contents__
 
@@ -103,6 +103,16 @@ __Offset__
 Offset the second grid from the first grid by the pixel scale in both the y and x directions.
 """
 grid_list[1] -= pixel_scales_list[1]
+
+"""
+__Rotation__
+
+In addition to the small offset, rotate the second grid by 1.5 degrees counter-clockwise about its
+offset point. This emulates a small roll-angle difference between two multi-band exposures (e.g. JWST
+NIRCam frames acquired at slightly different telescope orientations). The modeling script recovers this
+via the `DatasetModel.grid_rotation_angle` parameter alongside `grid_offset`.
+"""
+grid_list[1] = grid_list[1].subtracted_and_rotated_from(offset=(0.0, 0.0), angle=1.5)
 
 """
 Simulate simple Gaussian PSFs for the images in the r and g bands.


### PR DESCRIPTION
## Summary

Extends the existing multi-band `dataset_offsets` example to demonstrate the new `DatasetModel.grid_rotation_angle` parameter alongside `grid_offset`:

- **simulator.py**: rotates the second band's grid by 1.5 degrees CCW (via `Grid2D.subtracted_and_rotated_from`) on top of the existing half-pixel offset, emulating a JWST-style roll-angle misalignment.
- **modeling.py**: adds a `UniformPrior(-5.0, 5.0)` on `dataset_model.grid_rotation_angle` for every dataset after the first, mirroring the existing per-dataset offset priors.

## Depends on

PyAutoArray#312, PyAutoGalaxy#416, PyAutoLens#512. CI/smoke will be red on this PR until all three merge.

## Scripts Changed

- `scripts/multi/features/dataset_offsets/simulator.py` — adds `__Rotation__` section and grid-rotation call.
- `scripts/multi/features/dataset_offsets/modeling.py` — adds `grid_rotation_angle` prior and updates the `__Model__` docstring to describe the new free parameter (N=24 now).

## Test plan

- [x] `PYAUTO_TEST_MODE=2 ... python scripts/multi/features/dataset_offsets/simulator.py` — completes without errors.
- [x] `PYAUTO_TEST_MODE=2 ... python scripts/multi/features/dataset_offsets/modeling.py` — completes one full likelihood evaluation cleanly.
- [x] `scripts/check_sizes.sh` — no shrinkage flagged.

Refs PyAutoLens#511.