### PR TITLE
ci(smoke): install nufftax on Python 3.13

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -78,7 +78,7 @@ jobs:
           pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         else
           pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
-          pip install numba
+          pip install numba nufftax
         fi
         pip install tensorflow-probability==0.25.0
         pip install jupyter nbconvert ipynb-py-convert


### PR DESCRIPTION
## Summary

Adds `nufftax` to the Python 3.13 install step in `.github/workflows/smoke_tests.yml`.

## Why

`scripts/interferometer/*.py` smoke jobs have been failing on Python 3.13 with `ModuleNotFoundError: nufftax`. The 3.13 install branch deliberately skipped the `[optional]` extras (to dodge deps that lacked a 3.13 wheel at the time) and only installed `numba`. But `nufftax` is now the default JAX-native interferometer transformer, so any script that constructs `al.SimulatorInterferometer(...)` or `al.AnalysisInterferometer(...)` immediately raises on 3.13.

The 3.12 path is unaffected — `[optional]` covers it there.

## Test plan

- [x] CI re-runs on this branch with `nufftax` installed should turn `smoke (3.13)` green.

Pre-existing failure surfaced during the `feature/dataset-model-grid-rotation` cascade; flagged separately rather than bundled with that work because it's an independent CI-environment fix.