### PR TITLE
chore(scripts): Phase 3 use_jax=True adoption sweep — 26 scripts

### DIFF
--- a/scripts/group/features/advanced/double_einstein_ring/slam.py
+++ b/scripts/group/features/advanced/double_einstein_ring/slam.py
@@ -206,6 +206,7 @@ def source_lp_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         positions_likelihood_list=[positions_likelihood_source_0],
+        use_jax=True,
     )
 
     lens_dict = {}

--- a/scripts/group/features/linear_light_profiles/slam.py
+++ b/scripts/group/features/linear_light_profiles/slam.py
@@ -84,7 +84,7 @@ def source_lp_0(
     redshift_lens,
     n_batch=50,
 ):
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     # --- main lens light models (linear Sersic, light only) ---
     lens_dict = {}
@@ -179,6 +179,7 @@ def source_lp_1(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         positions_likelihood_list=[al.PositionsLH(positions=positions, threshold=0.3)],
+        use_jax=True,
     )
 
     n_main = sum(
@@ -378,6 +379,7 @@ def source_pix_1(
                 factor=2.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -508,6 +510,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -581,6 +584,7 @@ def light_lp(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -752,6 +756,7 @@ def mass_total(
                 factor=3.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     source = al.util.chaining.source_from(result=source_pix_result_2)

--- a/scripts/group/features/no_lens_light/slam.py
+++ b/scripts/group/features/no_lens_light/slam.py
@@ -96,7 +96,7 @@ def source_lp(
     redshift_source,
     n_batch=50,
 ):
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     # Source MGE
     source_bulge = al.model_util.mge_model_from(
@@ -220,6 +220,7 @@ def source_pix_1(
                 factor=2.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -344,6 +345,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -439,6 +441,7 @@ def mass_total(
                 factor=3.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     source = al.util.chaining.source_from(result=source_pix_result_2)

--- a/scripts/group/features/pixelization/adaptive.py
+++ b/scripts/group/features/pixelization/adaptive.py
@@ -198,7 +198,7 @@ search_1 = af.Nautilus(
     n_like_max=500,
 )
 
-analysis_1 = al.AnalysisImaging(dataset=dataset)
+analysis_1 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
@@ -244,6 +244,7 @@ analysis_2 = al.AnalysisImaging(
     positions_likelihood_list=[
         result_1.positions_likelihood_from(factor=3.0, minimum_threshold=0.2)
     ],
+    use_jax=True,
 )
 
 result_2 = search_2.fit(model=model_2, analysis=analysis_2)
@@ -302,6 +303,7 @@ analysis_3 = al.AnalysisImaging(
     positions_likelihood_list=[
         result_2.positions_likelihood_from(factor=3.0, minimum_threshold=0.2)
     ],
+    use_jax=True,
 )
 
 result_3 = search_3.fit(model=model_3, analysis=analysis_3)
@@ -366,6 +368,7 @@ search_4 = af.Nautilus(
 analysis_4 = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
+    use_jax=True,
 )
 
 result_4 = search_4.fit(model=model_4, analysis=analysis_4)

--- a/scripts/group/features/pixelization/delaunay.py
+++ b/scripts/group/features/pixelization/delaunay.py
@@ -339,6 +339,7 @@ analysis = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
     settings=al.Settings(use_mixed_precision=True),
+    use_jax=True,
 )
 
 """

--- a/scripts/group/features/pixelization/modeling.py
+++ b/scripts/group/features/pixelization/modeling.py
@@ -275,6 +275,7 @@ analysis = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
     settings=al.Settings(use_mixed_precision=True),
+    use_jax=True,
 )
 
 """

--- a/scripts/group/features/pixelization/slam.py
+++ b/scripts/group/features/pixelization/slam.py
@@ -98,7 +98,7 @@ def source_lp_0(
     redshift_lens,
     n_batch=50,
 ):
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     # --- main lens light models (one per centre, light only) ---
     lens_dict = {}
@@ -174,6 +174,7 @@ def source_lp_1(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         positions_likelihood_list=[al.PositionsLH(positions=positions, threshold=0.3)],
+        use_jax=True,
     )
 
     n_main = sum(
@@ -313,6 +314,7 @@ def source_pix_1(
                 factor=3.0, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     n_main = sum(
@@ -405,6 +407,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images_capped,
+        use_jax=True,
     )
 
     n_main = sum(
@@ -467,6 +470,7 @@ def light_lp(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_main = sum(
@@ -566,6 +570,7 @@ def mass_total(
                 factor=3.0, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     n_main = sum(

--- a/scripts/group/slam.py
+++ b/scripts/group/slam.py
@@ -132,7 +132,7 @@ def source_lp_0(
     redshift_lens,
     n_batch=50,
 ):
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     # --- main lens light models (one per centre, light only) ---
     lens_dict = {}
@@ -232,6 +232,7 @@ def source_lp_1(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         positions_likelihood_list=[al.PositionsLH(positions=positions, threshold=0.3)],
+        use_jax=True,
     )
 
     n_main = sum(
@@ -438,6 +439,7 @@ def source_pix_1(
                 factor=2.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -569,6 +571,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -642,6 +645,7 @@ def light_lp(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     n_lenses = sum(
@@ -820,6 +824,7 @@ def mass_total(
                 factor=3.0, positions=positions, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     source = al.util.chaining.source_from(result=source_pix_result_2)

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -265,7 +265,7 @@ The analysis receives a list of `PositionsLH` objects, which allows us to use mu
 penalty, for example if there source has multiple sets of multiple images which we know how they map to one another.
 """
 analysis = al.AnalysisImaging(
-    dataset=dataset, positions_likelihood_list=[positions_likelihood]
+    dataset=dataset, positions_likelihood_list=[positions_likelihood], use_jax=True
 )
 
 """

--- a/scripts/imaging/features/advanced/double_einstein_ring/chaining.py
+++ b/scripts/imaging/features/advanced/double_einstein_ring/chaining.py
@@ -182,7 +182,7 @@ search_1 = af.Nautilus(
     n_live=100,
 )
 
-analysis_1 = al.AnalysisImaging(dataset=dataset)
+analysis_1 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
@@ -289,7 +289,7 @@ search_2 = af.Nautilus(
     n_live=150,
 )
 
-analysis_2 = al.AnalysisImaging(dataset=dataset)
+analysis_2 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_2 = search_2.fit(model=model_2, analysis=analysis_2)
 
@@ -450,7 +450,7 @@ search_1 = af.Nautilus(
     n_live=100,
 )
 
-analysis_1 = al.AnalysisImaging(dataset=dataset)
+analysis_1 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
@@ -498,7 +498,7 @@ search_2 = af.Nautilus(
     n_live=100,
 )
 
-analysis_2 = al.AnalysisImaging(dataset=dataset)
+analysis_2 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_2 = search_2.fit(model=model_2, analysis=analysis_2)
 
@@ -590,7 +590,7 @@ search_3 = af.Nautilus(
     n_live=100,
 )
 
-analysis_3 = al.AnalysisImaging(dataset=dataset)
+analysis_3 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_3 = search_3.fit(model=model_3, analysis=analysis_3)
 
@@ -650,7 +650,7 @@ search_4 = af.Nautilus(
     n_live=100,
 )
 
-analysis_4 = al.AnalysisImaging(dataset=dataset)
+analysis_4 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_4 = search_4.fit(model=model_4, analysis=analysis_4)
 
@@ -704,7 +704,7 @@ model_5 = af.Collection(
 """
 __Analysis__
 """
-analysis_5 = al.AnalysisImaging(dataset=dataset)
+analysis_5 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __Search + Model-Fit__

--- a/scripts/imaging/features/advanced/mass_stellar_dark/chaining.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/chaining.py
@@ -157,7 +157,7 @@ search_1 = af.Nautilus(
     n_live=100,
 )
 
-analysis_1 = al.AnalysisImaging(dataset=dataset)
+analysis_1 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
@@ -227,7 +227,7 @@ search_2 = af.Nautilus(
     n_live=100,
 )
 
-analysis_2 = al.AnalysisImaging(dataset=dataset)
+analysis_2 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_2 = search_2.fit(model=model_2, analysis=analysis_2)
 

--- a/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
+++ b/scripts/imaging/features/advanced/mass_stellar_dark/modeling.py
@@ -216,12 +216,12 @@ __Analysis__
 
 Create the `AnalysisImaging` object defining how the via Nautilus the model is fitted to the data.
 """
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__
 
-The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM 
+The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM
 required by a model.
 
 Deflection angle calculations of stellar mass models and dark matter mass models can use techniques whichs

--- a/scripts/imaging/features/advanced/operated_light_profile/modeling.py
+++ b/scripts/imaging/features/advanced/operated_light_profile/modeling.py
@@ -233,7 +233,7 @@ __Analysis__
 
 Create the `AnalysisImaging` object defining how the via Nautilus the model is fitted to the data.
 """
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__

--- a/scripts/imaging/features/advanced/shapelets/modeling.py
+++ b/scripts/imaging/features/advanced/shapelets/modeling.py
@@ -343,6 +343,7 @@ analysis = al.AnalysisImaging(
     dataset=dataset,
     positions_likelihood_list=[positions_likelihood],
     settings=al.Settings(use_positive_only_solver=False),
+    use_jax=True,
 )
 
 """

--- a/scripts/imaging/features/advanced/sky_background/modeling.py
+++ b/scripts/imaging/features/advanced/sky_background/modeling.py
@@ -214,6 +214,7 @@ Create the `AnalysisImaging` object defining how the model is fitted to the data
 """
 analysis = al.AnalysisImaging(
     dataset=dataset,
+    use_jax=True,
 )
 
 """

--- a/scripts/imaging/features/extra_galaxies/modeling.py
+++ b/scripts/imaging/features/extra_galaxies/modeling.py
@@ -230,7 +230,7 @@ search = af.Nautilus(
     iterations_per_quick_update=20000,
 )
 
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result = search.fit(model=model, analysis=analysis)
 
@@ -413,12 +413,12 @@ search = af.Nautilus(
     iterations_per_quick_update=20000,
 )
 
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__
 
-The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM 
+The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM
 required by a model.
 
 Adding extra galaxies increases VRAM usage because each additional component adds calculations that JAX stores 

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -226,7 +226,7 @@ __Analysis__
 
 Create the `AnalysisImaging` object defining how the via Nautilus the model is fitted to the data.
 """
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -290,12 +290,12 @@ __Analysis__
 
 Create the `AnalysisImaging` object defining how the via Nautilus the model is fitted to the data.
 """
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__
 
-The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM 
+The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM
 required by a model.
 
 For each linear Gaussian light profile, extra VRAM is used. For around 60 linear Gaussians this  typically requires 

--- a/scripts/imaging/features/no_lens_light/modeling.py
+++ b/scripts/imaging/features/no_lens_light/modeling.py
@@ -223,12 +223,12 @@ __Analysis__
 
 Create the `AnalysisImaging` object defining how the via Nautilus the model is fitted to the data.
 """
-analysis = al.AnalysisImaging(dataset=dataset)
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 """
 __VRAM__
 
-The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM 
+The `modeling` example explains how VRAM is used during GPU-based fitting and how to print the estimated VRAM
 required by a model.
 
 Removing lens light from the model reduces VRAM use modestly, but likely wont have a noticeable impact on overall use.

--- a/scripts/imaging/features/no_lens_light/slam.py
+++ b/scripts/imaging/features/no_lens_light/slam.py
@@ -74,7 +74,7 @@ def source_lp(
     redshift_source: float,
     n_batch: int = 50,
 ) -> af.Result:
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     source_bulge = al.model_util.mge_model_from(
         mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
@@ -136,6 +136,7 @@ def source_pix_1(
                 factor=3.0, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     mass = al.util.chaining.mass_from(
@@ -201,6 +202,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     model = af.Collection(
@@ -259,6 +261,7 @@ def mass_total(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     mass = al.util.chaining.mass_from(

--- a/scripts/imaging/features/pixelization/adaptive.py
+++ b/scripts/imaging/features/pixelization/adaptive.py
@@ -199,7 +199,7 @@ search_1 = af.Nautilus(
     n_like_max=500,
 )
 
-analysis_1 = al.AnalysisImaging(dataset=dataset)
+analysis_1 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_1 = search_1.fit(model=model_1, analysis=analysis_1)
 
@@ -288,6 +288,7 @@ analysis_2 = al.AnalysisImaging(
     positions_likelihood_list=[
         result_1.positions_likelihood_from(factor=3.0, minimum_threshold=0.2)
     ],
+    use_jax=True,
 )
 
 """
@@ -306,7 +307,7 @@ search_2 = af.Nautilus(
     n_like_max=500,
 )
 
-analysis_2 = al.AnalysisImaging(dataset=dataset)
+analysis_2 = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result_2 = search_2.fit(model=model_2, analysis=analysis_2)
 
@@ -398,6 +399,7 @@ analysis_3 = al.AnalysisImaging(
     positions_likelihood_list=[
         result_2.positions_likelihood_from(factor=3.0, minimum_threshold=0.2)
     ],
+    use_jax=True,
 )
 
 """
@@ -456,6 +458,7 @@ search_4 = af.Nautilus(
 analysis_4 = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
+    use_jax=True,
 )
 
 result_4 = search_4.fit(model=model_4, analysis=analysis_4)

--- a/scripts/imaging/features/pixelization/delaunay.py
+++ b/scripts/imaging/features/pixelization/delaunay.py
@@ -396,6 +396,7 @@ analysis_1 = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
     positions_likelihood_list=[al.PositionsLH(positions=positions, threshold=0.3)],
+    use_jax=True,
 )
 
 """
@@ -512,6 +513,7 @@ We now create the analysis for the second search.
 analysis_2 = al.AnalysisImaging(
     dataset=dataset,
     adapt_images=adapt_images,
+    use_jax=True,
 )
 
 """
@@ -564,7 +566,7 @@ def source_lp(
     redshift_source: float,
     n_batch: int = 50,
 ) -> af.Result:
-    analysis = al.AnalysisImaging(dataset=dataset)
+    analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
     lens_bulge = al.model_util.mge_model_from(
         mask_radius=mask_radius,
@@ -656,6 +658,7 @@ def source_pix_1(
                 factor=3.0, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     mass = al.util.chaining.mass_from(
@@ -747,6 +750,7 @@ def source_pix_2(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     model = af.Collection(
@@ -813,6 +817,7 @@ def light_lp(
     analysis = al.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
+        use_jax=True,
     )
 
     lens_bulge = al.model_util.mge_model_from(
@@ -887,6 +892,7 @@ def mass_total(
                 factor=3.0, minimum_threshold=0.2
             )
         ],
+        use_jax=True,
     )
 
     mass = al.util.chaining.mass_from(

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -365,6 +365,7 @@ analysis = al.AnalysisImaging(
     dataset=dataset,
     positions_likelihood_list=[positions_likelihood],
     settings=al.Settings(use_mixed_precision=True),
+    use_jax=True,
 )
 
 """

--- a/scripts/imaging/features/pixelization/source_science.py
+++ b/scripts/imaging/features/pixelization/source_science.py
@@ -420,6 +420,7 @@ positions_likelihood = al.PositionsLH(positions=positions, threshold=0.3)
 analysis = al.AnalysisImaging(
     dataset=dataset,
     positions_likelihood_list=[positions_likelihood],
+    use_jax=True,
 )
 
 result = search.fit(model=model, analysis=analysis)

--- a/scripts/interferometer/features/extra_galaxies/modeling.py
+++ b/scripts/interferometer/features/extra_galaxies/modeling.py
@@ -240,7 +240,7 @@ search = af.Nautilus(
     iterations_per_quick_update=20000,
 )
 
-analysis = al.AnalysisInterferometer(dataset=dataset)
+analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
 
 """
 __VRAM__

--- a/scripts/multi/features/one_by_one/modeling.py
+++ b/scripts/multi/features/one_by_one/modeling.py
@@ -158,7 +158,7 @@ We create an `Analysis` object for every dataset.
 
 We do not sum the analyses, like we do in most other example scripts, as we are going to fit each dataset one-by-one.
 """
-analysis_list = [al.AnalysisImaging(dataset=dataset) for dataset in dataset_list]
+analysis_list = [al.AnalysisImaging(dataset=dataset, use_jax=True) for dataset in dataset_list]
 
 """
 __Model__


### PR DESCRIPTION
## Summary
Phase 3 of `z_features/jax_visualization.md` (now archived). Phase 2 (PyAutoFit #1278) made `use_jax=True` sufficient — visualization auto-follows via the new sentinel default. This PR adds `use_jax=True` to 26 tutorial scripts that were missed during the Phase 2 incidental adoption, primarily in pixelization/MGE/group/advanced-feature paths plus slam-vs-modeling consistency mismatches surfaced by the 2026-05-16 audit.

User-visible behaviour change: tutorials with `use_jax=True` now automatically get JIT visualization (no separate flag needed). The API the user wants to maintain is a single explicit flag: presence of `use_jax=True` makes the script's JAX dependence fully visible.

## Scripts Changed

**imaging/features/pixelization** (4):
- `scripts/imaging/features/pixelization/modeling.py` — single Analysis call
- `scripts/imaging/features/pixelization/source_science.py` — single Analysis call
- `scripts/imaging/features/pixelization/delaunay.py` — 7 chained Analysis calls
- `scripts/imaging/features/pixelization/adaptive.py` — 4 chained Analysis calls

**imaging/features/ (other)** (4):
- `scripts/imaging/features/multi_gaussian_expansion/modeling.py`
- `scripts/imaging/features/linear_light_profiles/modeling.py`
- `scripts/imaging/features/no_lens_light/modeling.py`
- `scripts/imaging/features/no_lens_light/slam.py` — 4 multi-stage calls

**imaging/features/extra_galaxies** (1):
- `scripts/imaging/features/extra_galaxies/modeling.py` — both Analysis calls

**imaging/features/advanced** (6):
- `scripts/imaging/features/advanced/double_einstein_ring/chaining.py` — 7 calls
- `scripts/imaging/features/advanced/mass_stellar_dark/modeling.py`
- `scripts/imaging/features/advanced/mass_stellar_dark/chaining.py` — 2 calls
- `scripts/imaging/features/advanced/operated_light_profile/modeling.py`
- `scripts/imaging/features/advanced/shapelets/modeling.py`
- `scripts/imaging/features/advanced/sky_background/modeling.py`

**multi/** (1):
- `scripts/multi/features/one_by_one/modeling.py` — list comprehension

**interferometer/** (1):
- `scripts/interferometer/features/extra_galaxies/modeling.py`

**group/** (1):
- `scripts/group/slam.py` — 6 calls

**group/features/pixelization** (4):
- `scripts/group/features/pixelization/modeling.py`
- `scripts/group/features/pixelization/delaunay.py`
- `scripts/group/features/pixelization/adaptive.py` — 4 calls
- `scripts/group/features/pixelization/slam.py` — 6 calls

**group/features/ (other slams)** (3):
- `scripts/group/features/linear_light_profiles/slam.py` — 6 calls
- `scripts/group/features/no_lens_light/slam.py` — 4 calls
- `scripts/group/features/advanced/double_einstein_ring/slam.py` — 1 call (the other 4 calls in this file already had `use_jax=True`; consistency fix)

**guides** (1):
- `scripts/guides/modeling/customize.py`

## Skip list — files INTENTIONALLY not edited

- `imaging/features/pixelization/cpu_fast_modeling.py` and `group/features/pixelization/cpu_fast_modeling.py` — explicit `use_jax=False` CPU benchmarks
- `imaging/features/advanced/expectation_propagation.py` and `hierarchical.py` — explicit `use_jax=False` on `FactorGraphModel`
- Simulators, `fit.py`, `likelihood_function.py`, aggregator and plot-only scripts — no Analysis fit happens
- `imaging/features/advanced/double_einstein_ring/modeling.py` — already had `use_jax=True` from PR #157

## Roadmap context
Phases 0-2 shipped May 2026. Phase 4 (subprocess visualization) and Phase 5 (live Colab/Jupyter cell) remain explicit stubs.

## Test Plan
- [x] Smoke tests: 7/7 pass on `autolens_workspace` (20/20 across the 3 workspaces in this sweep).
- [x] None of the edited scripts are in `smoke_tests.txt` directly — smoke verifies the edits didn't break the wider workspace parsing/loading.
- [ ] Reviewer note: `PYAUTO_DISABLE_JAX=1` is set in `config/build/env_vars.yaml` defaults, so smoke runs override `use_jax=True` to `False`. Direct JIT-path validation is the job of `autolens_workspace_test/scripts/imaging/visualization_jax.py` etc., not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)