### PR TITLE
feat: add interferometer linear_light_profiles feature scripts

### DIFF
--- a/scripts/imaging/features/linear_light_profiles/fit.py
+++ b/scripts/imaging/features/linear_light_profiles/fit.py
@@ -38,7 +38,7 @@ can therefore fit models more reliably and faster!
 
 __Disadvantages__
 
-Althought the computation time of the inversion is small, it is not non-negligable. It is approximately 3-4x slower
+Although the computation time of the inversion is small, it is not non-negligible. It is approximately 3-4x slower
 than using a standard light profile.
 
 The gains in run times due to the simpler non-linear parameter space therefore are somewhat balanced by the slower
@@ -46,7 +46,7 @@ likelihood calculation.
 
 __Positive Only Solver__
 
-Many codes which use linear algebra typically rely on a linear algabra solver which allows for positive and negative
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and negative
 values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
 
 This is problematic, as it means that negative surface brightnesses values can be computed to represent a galaxy's

--- a/scripts/imaging/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/imaging/features/linear_light_profiles/likelihood_function.py
@@ -129,14 +129,15 @@ image = tracer.image_2d_from(grid=masked_dataset.grids.lp)
 """
 __Linear Light Profiles__
 
-To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the `lp_Linear`
+To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the `lp_linear`
 module instead of the `lp` module used throughout other example scripts. 
 
 The `intensity` parameter of the light profile is no longer passed into the light profiles created via the
 `lp_linear` module, as it is inferred via linear algebra.
 
-In this example, we assume our galaxy is composed of two light profiles, an elliptical Sersic and Exponential (a Sersic
-where `sersic_index=4`) which represent the bulge and disk of the galaxy. 
+In this example, the lens galaxy has a linear `Sersic` bulge and the source galaxy has a linear `SersicCore` bulge.
+Both are linear light profiles, so their `intensity` parameters are not free parameters of the model — they are
+solved for via linear algebra.
 """
 bulge = al.lp_linear.Sersic(
     centre=(0.0, 0.0),
@@ -169,29 +170,21 @@ source_galaxy = al.Galaxy(
 Internally in the source code, linear light profiles have an `intensity` parameter, but its value is always set to 
 1.0. It will be clear why this is later in the script.
 """
-print("Bulge Internal Intensity:")
+print("Lens Bulge Internal Intensity:")
 print(lens_galaxy.bulge.intensity)
 
-print("Disk Internal Intensity:")
+print("Source Bulge Internal Intensity:")
 print(source_galaxy.bulge.intensity)
 
 """
 Like standard light profiles, we can compute images of each linear light profile, but their overall
 normalization is arbitrary given that the internal `intensity` value of 1.0 is used.
-"""
-image_2d_bulge = lens_galaxy.bulge.image_2d_from(grid=masked_dataset.grid)
-image_2d_disk = source_galaxy.bulge.image_2d_from(grid=masked_dataset.grid)
 
+Note the source bulge image computed below is its source-plane image (i.e. before lensing); its lensed image
+that contributes to the data is computed inside `LightProfileLinearObjFuncList` further below.
 """
-If we try and plot a linear light profile using a plotter, an exception is raised.
-
-This is to ensure that a user does not plot and interpret the intensity of a linear light profile, as it is not a
-physical quantity. Plotting only works after a linear light profile has had its `intensity` computed via linear
-algebra.
-
-Uncomment and run the code below to see the exception.
-"""
-print("This will raise an exception")
+image_2d_lens_bulge = lens_galaxy.bulge.image_2d_from(grid=masked_dataset.grid)
+image_2d_source_bulge = source_galaxy.bulge.image_2d_from(grid=masked_dataset.grid)
 
 
 """
@@ -249,7 +242,7 @@ Printing the first column of the mapping matrix shows the image of the lens bulg
 """
 bulge_image = mapping_matrix[:, 0]
 print(bulge_image)
-print(image_2d_bulge.slim)
+print(image_2d_lens_bulge.slim)
 
 """
 A 2D plot of the `mapping_matrix` shows each light profile image in 1D, which is a bit odd to look at but
@@ -279,13 +272,15 @@ lp_linear_func_source = al.LightProfileLinearObjFuncList(
 )
 
 """
-Printing the first column of the mapping matrix shows the image of the source bulge light profile.
+Printing the first column of the mapping matrix shows the image of the source bulge light profile (the
+mapping_matrix entry is in the image-plane, after ray-tracing through the lens; the unlensed source-plane
+image is plotted below for comparison).
 """
 mapping_matrix = lp_linear_func_source.mapping_matrix
 
 bulge_image = mapping_matrix[:, 0]
 print(bulge_image)
-print(image_2d_bulge.slim)
+print(image_2d_source_bulge.slim)
 
 """
 __Combining Matrices__

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -44,7 +44,7 @@ can therefore fit models more reliably and faster!
 
 __Disadvantages__
 
-Althought the computation time of the inversion is small, it is not non-negligable. It is approximately 3-4x slower
+Although the computation time of the inversion is small, it is not non-negligible. It is approximately 3-4x slower
 than using a standard light profile.
 
 The gains in run times due to the simpler non-linear parameter space therefore are somewhat balanced by the slower
@@ -52,7 +52,7 @@ likelihood calculation.
 
 __Positive Only Solver__
 
-Many codes which use linear algebra typically rely on a linear algabra solver which allows for positive and negative
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and negative
 values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
 
 This is problematic, as it means that negative surface brightnesses values can be computed to represent a galaxy's
@@ -206,7 +206,7 @@ print(model.info)
 """
 __Search__
 
-The model is fitted to the data using the nested sampling algorithm Nautilus (see `start.here.py` for a 
+The model is fitted to the data using the nested sampling algorithm Nautilus (see `start_here.py` for a
 full description).
 
 In the `start_here.py` example 150 live points (`n_live=150`) were used to sample parameter space. For the linear
@@ -247,7 +247,7 @@ This is still fast, but it does mean that the fit may take around five times lon
 
 However, because two free parameters have been removed from the model (the `intensity` of the lens bulge and 
 source bulge), the total number of likelihood evaluations will reduce. Furthermore, the simpler parameter space
-likely means that the fit will take less than 10000 per free parameter to converge. This is aided further
+likely means that the fit will take less than 10000 likelihood evaluations per free parameter to converge. This is aided further
 by the reduction in `n_live` to 100.
 
 Fits using standard light profiles and linear light profiles therefore take roughly the same time to run. However,
@@ -357,43 +357,43 @@ This `Inversion` can be used to plot the reconstructed image of specifically all
 """
 __Linear Objects (Internal Source Code)__
 
-An `Inversion` contains all of the linear objects used to reconstruct the data in its `linear_obj_list`. 
+An `Inversion` contains all of the linear objects used to reconstruct the data in its `linear_obj_list`.
 
 This list may include the following objects:
 
- - `LightProfileLinearObjFuncList`: This object contains lists of linear light profiles and the functionality used
- by them to reconstruct data in an inversion. For example it may only contain a list with a single light profile
- (e.g. `lp_linear.Sersic`) or many light profiles combined in a `Basis` (e.g. `lp_basis.Basis`).
+ - `LightProfileLinearObjFuncList`: Holds a list of linear light profiles and the functionality used to
+   reconstruct data in an inversion. It may contain a single light profile (e.g. `lp_linear.Sersic`) or
+   many light profiles combined in a `Basis` (e.g. `lp_basis.Basis`).
 
-- `Mapper`: The linear objected used by a `Pixelization` to reconstruct data via an `Inversion`, where the `Mapper` 
-is specific to the `Pixelization`'s `Mesh` (e.g. a `RectnagularMapper` is used for a `RectangularAdaptDensity` mesh).
+ - `Mapper`: The linear object used by a `Pixelization` to reconstruct data via an `Inversion`. The `Mapper`
+   is specific to the `Pixelization`'s `Mesh` (e.g. a `RectangularMapper` is used for a `RectangularAdaptDensity`
+   mesh).
 
-In this example, two linear objects were used to fit the data:
-
- - An `Sersic` linear light profile for the source galaxy.
- ` A `Basis` containing 5 Gaussians for the lens galaxly's light. 
+In this example, the model uses one linear `Sersic` for the lens galaxy's bulge and one linear `SersicCore`
+for the source galaxy's bulge. The inversion therefore has two `LightProfileLinearObjFuncList` entries —
+one for each plane (lens at the image-plane grid, source at the ray-traced source-plane grid).
 """
 print(inversion.linear_obj_list)
 
 """
-To extract results from an inversion many quantities will come in lists or require that we specific the linear object
-we with to use. 
+To extract results from an inversion many quantities come in lists or require us to specify the linear object
+we wish to use. Knowing what linear objects are in the `linear_obj_list`, and what indexes they correspond to,
+is therefore important.
 
-Thus, knowing what linear objects are contained in the `linear_obj_list` and what indexes they correspond to
-is important.
+The lens-plane entry comes first, followed by the source-plane entry.
 """
-print(f"LightProfileLinearObjFuncList (Basis) = {inversion.linear_obj_list[0]}")
-print(f"LightProfileLinearObjFuncList (Sersic) = {inversion.linear_obj_list[1]}")
+print(f"LightProfileLinearObjFuncList (Lens Sersic)       = {inversion.linear_obj_list[0]}")
+print(f"LightProfileLinearObjFuncList (Source SersicCore) = {inversion.linear_obj_list[1]}")
 
 """
-Each of these `LightProfileLinearObjFuncList` objects contains its list of light profiles, which for the
-`Sersic` is a single entry whereas for the `Basis` is 5 Gaussians.
+Each `LightProfileLinearObjFuncList` contains a `light_profile_list`. For both entries in this example the
+list has a single light profile.
 """
 print(
-    f"Linear Light Profile list (Basis -> x5 Gaussians) = {inversion.linear_obj_list[0].light_profile_list}"
+    f"Linear Light Profile list (Lens Sersic)       = {inversion.linear_obj_list[0].light_profile_list}"
 )
 print(
-    f"Linear Light Profile list (Sersic) = {inversion.linear_obj_list[1].light_profile_list}"
+    f"Linear Light Profile list (Source SersicCore) = {inversion.linear_obj_list[1].light_profile_list}"
 )
 
 """

--- a/scripts/interferometer/features/linear_light_profiles/README.md
+++ b/scripts/interferometer/features/linear_light_profiles/README.md
@@ -1,0 +1,28 @@
+The `linear_light_profiles` folder contains example scripts showing how to fit `Interferometer` data using
+**linear light profiles**, whose `intensity` is solved for analytically via a linear inversion instead of
+being a free parameter of the non-linear search.
+
+For interferometer data this is now practical thanks to the JAX-native NUFFT `nufftax`
+(https://github.com/GragasLab/nufftax), which evaluates the image-to-uv Fourier transform of every basis
+component inside the same jit/vmap pipeline as the rest of the model. Older interferometer guidance that
+described light-profile fitting as "slow" pre-dates this change.
+
+# Files
+
+- `modeling`: Lens modeling of an `Interferometer` dataset with a linear `SersicCore` source.
+- `fit`: Fit a linear light profile model to interferometer data and inspect the solved-for intensities.
+- `likelihood_function`: A step-by-step walkthrough of the linear-light-profile interferometer likelihood
+  function (NUFFT of each linear basis image, mapping/curvature matrices, $\chi^2$ in the visibility plane).
+- `slam`: SLaM SOURCE LP / SOURCE PIX / MASS TOTAL pipeline using a linear `Sersic` source in the
+  initialization stage. Light-profile fitting runs on `TransformerNUFFT` and the pixelized stages keep the
+  standard `TransformerDFT` + sparse operator setup.
+
+# Results
+
+These scripts only give a brief overview of how to analyse and interpret the results of a lens model fit.
+
+A full guide to result analysis is given at `autolens_workspace/*/guides/results`.
+
+# Imaging Equivalent
+
+For the CCD-imaging version of these scripts, see `autolens_workspace/scripts/imaging/features/linear_light_profiles`.

--- a/scripts/interferometer/features/linear_light_profiles/fit.py
+++ b/scripts/interferometer/features/linear_light_profiles/fit.py
@@ -1,0 +1,230 @@
+"""
+Modeling Features: Linear Light Profiles Fit (Interferometer)
+==============================================================
+
+A "linear light profile" is a variant of a standard light profile where the `intensity` parameter is solved for
+via linear algebra every time the model is fitted to the data. This uses a process called an "inversion" and it
+always computes the `intensity` values that give the best fit to the data (e.g. maximize the likelihood) given
+the light profile's other parameters.
+
+This script illustrates how to perform a single `FitInterferometer` of a linear light profile model — that is,
+not the full Nautilus model-fit, but a single likelihood evaluation given known light/mass profile parameters.
+This is useful for understanding how the inversion produces the solved-for `intensity`, and how to extract that
+value from the resulting fit.
+
+For an explanation of why linear light profile fits are now practical against visibility data thanks to the
+JAX-native NUFFT `nufftax` (https://github.com/GragasLab/nufftax), see the companion `modeling.py` example.
+
+__Contents__
+
+- **Advantages & Disadvantages:** Benefits and drawbacks of linear light profiles for interferometer data.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** The lens model whose `intensity` we solve for via inversion.
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load the strong lens `Interferometer` dataset using `TransformerNUFFT` (backed by `nufftax`).
+- **Fit:** Perform a single `FitInterferometer` using the model and inspect the inversion.
+- **Intensities:** Extract the solved-for `intensity` via `fit.linear_light_profile_intensity_dict`.
+- **Visualization:** Build the helper tracer where linear light profiles are replaced with ordinary light
+  profiles carrying their solved-for `intensity`, then plot.
+- **Wrap Up:** Summary of the script and next steps.
+
+__Advantages__
+
+The source galaxy's `intensity` parameter is therefore not a free parameter in the model-fit, reducing the
+dimensionality of non-linear parameter space by one. The lens light is already omitted for interferometer data,
+so the saving is smaller than the imaging case (where lens and source both contribute) — but the inversion still
+removes the degeneracies between `intensity` and the source's shape parameters (e.g. `effective_radius`,
+`sersic_index`), which are difficult degeneracies for the non-linear search to map out accurately.
+
+The inversion has a relatively small computational cost on top of the NUFFT, so we reduce the model complexity
+without much slow-down.
+
+__Disadvantages__
+
+Although the computation time of the inversion is small, it is not non-negligible. It is approximately 3-4x
+slower per inversion-only term than using a standard light profile with a fixed `intensity`. The NUFFT typically
+dominates the total per-likelihood cost on interferometer data, so the overall slow-down is usually smaller.
+
+__Positive Only Solver__
+
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and
+negative values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
+
+This is problematic, as it means that negative surface brightnesses values can be computed to represent a
+galaxy's light, which is clearly unphysical.
+
+**PyAutoLens** uses a positive only linear algebra solver which has been extensively optimized to ensure it is
+as fast as positive-negative solvers. This ensures that all light profile intensities are positive and
+therefore physical.
+
+__Model__
+
+This script fits an `Interferometer` dataset of a 'galaxy-scale' strong lens with a model where:
+
+ - The lens galaxy's light is omitted (and is not present in the simulated data). This is the standard
+   convention for interferometer modeling.
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
+ - The source galaxy's light is a linear `SersicCore`.
+
+__Start Here Notebook__
+
+If any code in this script is unclear, refer to the `interferometer/start_here.ipynb` notebook.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+from pathlib import Path
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, using `TransformerNUFFT`
+backed by `nufftax`.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Fit__
+
+We now illustrate how to perform a fit to the dataset using a linear light profile, with the lens mass and the
+source's shape parameters fixed to known values.
+
+The API follows closely the standard use of a `FitInterferometer` object, but simply uses a linear light
+profile (via the `lp_linear` module) instead of a standard light profile.
+
+Note that the linear light profile below does not have an `intensity` parameter input — we let the inversion
+solve for it.
+"""
+lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=1.6,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+    ),
+    shear=al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05),
+)
+
+source = al.Galaxy(
+    redshift=1.0,
+    bulge=al.lp_linear.SersicCore(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+        effective_radius=0.1,
+        sersic_index=1.0,
+    ),
+)
+
+tracer = al.Tracer(galaxies=[lens, source])
+
+fit = al.FitInterferometer(dataset=dataset, tracer=tracer)
+
+"""
+The fit's `subplot_fit_interferometer` shows the visibility-plane fit and dirty-image residuals. Because the
+source bulge is a linear light profile, the inversion has solved for its `intensity` to maximize the fit to
+the observed visibilities.
+"""
+aplt.subplot_fit_interferometer(fit=fit)
+
+"""
+The `subplot_fit_dirty_images` provides a real-space view of the data, model and residuals via inverse-NUFFT
+of the visibility-plane quantities. This is generally more interpretable to the human eye than the uv-plane
+plots above.
+"""
+aplt.subplot_fit_dirty_images(fit=fit)
+
+"""
+__Intensities__
+
+The fit contains the solved-for `intensity` value.
+
+This is computed using a fit's `linear_light_profile_intensity_dict`, which maps each linear light profile in
+the model parameterization above to its `intensity`.
+
+The code below shows how to use this dictionary, as an alternative to using the `max_log_likelihood` quantities
+covered in `modeling.py`.
+"""
+source_bulge = tracer.galaxies[-1].bulge
+
+print(fit.linear_light_profile_intensity_dict)
+
+print(
+    f"\n Intensity of source bulge (lp_linear.SersicCore) = "
+    f"{fit.linear_light_profile_intensity_dict[source_bulge]}"
+)
+
+"""
+A `Tracer` where all linear light profile objects are replaced with ordinary light profiles using the
+solved-for `intensity` values is also accessible from a fit.
+
+For example, the linear `SersicCore` of the source `bulge` component above has a solved-for `intensity` of
+~0.3.
+
+The `tracer` created below instead has an ordinary `SersicCore` light profile with `intensity` ~0.3. The
+benefit of this tracer is that it can be visualised (linear light profiles cannot be plotted by default
+because they do not have `intensity` values).
+"""
+tracer = fit.model_obj_linear_light_profiles_to_light_profiles
+
+print(tracer.galaxies[-1].bulge.intensity)
+
+"""
+__Visualization__
+
+Linear light profiles and objects containing them (e.g. galaxies, a tracer) cannot be plotted because they
+do not have an `intensity` value.
+
+Therefore, the helper-tracer created above (with all linear light profiles replaced by ordinary light profiles
+carrying their solved-for `intensity`) must be used for visualization:
+"""
+aplt.plot_array(array=tracer.image_2d_from(grid=dataset.grid), title="Tracer Image")
+
+
+"""
+__Wrap Up__
+
+Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+"""

--- a/scripts/interferometer/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/interferometer/features/linear_light_profiles/likelihood_function.py
@@ -1,0 +1,532 @@
+"""
+__Log Likelihood Function: Linear Light Profile (Interferometer)__
+
+This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit
+`Interferometer` data with a linear light profile (e.g. a linear `SersicCore` source).
+
+A "linear light profile" is a variant of a standard light profile where the `intensity` parameter is solved for
+via linear algebra every time the model is fitted to the data. This uses a process called an "inversion" and
+it always computes the `intensity` values that give the best fit to the data (e.g. maximize the likelihood)
+given the light profile's other parameters.
+
+For interferometer data this is now practical thanks to the JAX-native NUFFT `nufftax`
+(https://github.com/GragasLab/nufftax) — the image-to-uv Fourier transform of each linear basis component
+happens inside the same jit/vmap pipeline as the rest of the model, so per-iteration NUFFT cost is amortised
+on the GPU.
+
+This script has the following aims:
+
+ - To provide a resource that authors can include in papers using **PyAutoLens**, so that readers can
+   understand the likelihood function (including references to the previous literature from which it is
+   defined) without having to write large quantities of text and equations.
+
+ - To make linear inversions in **PyAutoLens** less of a "black-box" to users.
+
+Accompanying this script is the imaging-version `imaging/features/linear_light_profiles/likelihood_function.py`,
+which walks through the same calculation for CCD imaging data (PSF convolution rather than NUFFT). Most of the
+linear algebra is identical — only the operation that produces the columns of the `operated_mapping_matrix`
+differs.
+
+__Prerequisites__
+
+The likelihood function of a linear light profile builds on the standard parametric likelihood function and on
+the interferometer-specific NUFFT step, so you must read the following notebooks before this script:
+
+ - `interferometer/log_likelihood_function.ipynb` — the standard interferometer parametric likelihood
+   function (NUFFT of a real-space image, visibility-plane $\\chi^2$).
+ - `imaging/features/linear_light_profiles/likelihood_function.ipynb` — the linear-inversion linear algebra
+   (data vector, curvature matrix, positive-only solver) for CCD imaging.
+
+This script repeats just enough setup that you can follow it without rereading those two — but if anything is
+unclear, those are the places to look first.
+
+__Contents__
+
+- **Prerequisites:** Reading order before this script.
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load and plot the strong lens `Interferometer` dataset using `TransformerNUFFT` (nufftax).
+- **Lens Galaxy:** A mass-only lens galaxy (no light — interferometer convention).
+- **Source Galaxy Linear Light Profile:** A linear `SersicCore` source with no `intensity` parameter.
+- **Internal Intensity:** Why the linear light profile carries an internal `intensity=1.0`.
+- **Ray Tracing:** Image-plane to source-plane grid.
+- **Source Image (Internal):** Source-plane image of the linear profile with `intensity=1.0`.
+- **Mapping Matrix:** Real-space mapping matrix — one column per linear profile, equal to the lensed image
+  of each linear basis component evaluated with `intensity=1.0`.
+- **Transformed Mapping Matrix ($f$):** NUFFT each column to give the visibility-space mapping matrix used
+  in the inversion.
+- **Data Vector (D):** Compute $D$ from the transformed mapping matrix, visibilities, and noise map.
+- **Curvature Matrix (F):** Compute $F$ separately for real and imaginary components, then sum.
+- **Reconstruction (Positive-Negative):** Solve $s = F^{-1} D$ via NumPy.
+- **Reconstruction (Positive Only):** Solve with the fast non-negative least squares (`fnnls`) algorithm.
+- **Visibilities Reconstruction:** Map $s$ back to visibility space.
+- **Likelihood Function:** Visibility-plane $\\chi^2$ and noise normalization.
+- **Chi Squared:** Sum chi-squared contributions over real and imaginary components.
+- **Noise Normalization Term:** The fixed noise normalization term.
+- **Calculate The Log Likelihood:** Combine into the final log likelihood.
+- **Fit:** Cross-check via `FitInterferometer`.
+- **Lens Modeling:** How this likelihood is sampled in the full Nautilus fit.
+- **Wrap Up:** Summary and next steps.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, which we will fit with the
+model. We use `TransformerNUFFT` (backed by `nufftax`), the JAX-native NUFFT that makes linear inversions in
+the visibility plane practical at any visibility count.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Lens Galaxy__
+
+For interferometer data the lens galaxy's optical/IR emission is typically below detection, so we model only
+its mass:
+"""
+mass = al.mp.Isothermal(
+    centre=(0.0, 0.0),
+    einstein_radius=1.6,
+    ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+)
+
+shear = al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05)
+
+lens_galaxy = al.Galaxy(redshift=0.5, mass=mass, shear=shear)
+
+"""
+__Source Galaxy Linear Light Profile__
+
+The source galaxy is fitted using a **linear** `SersicCore`. Compared to the standard `SersicCore` of the
+parametric interferometer likelihood guide, we drop the `intensity` argument — it is solved for via the
+inversion below.
+"""
+source_bulge = al.lp_linear.SersicCore(
+    centre=(0.0, 0.0),
+    ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+    effective_radius=0.1,
+    sersic_index=1.0,
+)
+
+source_galaxy = al.Galaxy(redshift=1.0, bulge=source_bulge)
+
+"""
+__Internal Intensity__
+
+Internally in the source code, linear light profiles still have an `intensity` parameter — its value is fixed
+to 1.0. The inversion later rescales the column of the mapping matrix by the solved-for intensity. Without an
+internal value of 1.0 the image evaluated below would be ambiguous in normalisation.
+"""
+print("Source Bulge Internal Intensity:")
+print(source_bulge.intensity)
+
+"""
+__Ray Tracing__
+
+To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\\theta$ from the image-plane to its
+(y,x) source-plane coordinate $\\beta$ using the summed deflection angles $\\alpha$ of the mass profiles:
+
+ $\\beta = \\theta - \\alpha(\\theta)$
+
+For interferometer data the only grid we need to ray-trace is the real-space grid associated with the
+`real_space_mask` — there is no blurring grid (that is an imaging-only concept used to account for flux
+outside the mask convolving into it via the PSF).
+"""
+tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
+
+# A list of every grid (e.g. image-plane, source-plane); we only need the source-plane grid (index -1).
+traced_grid = tracer.traced_grid_2d_list_from(grid=dataset.grids.lp)[-1]
+
+aplt.plot_grid(grid=traced_grid, title="Traced Source-Plane Grid")
+
+"""
+__Source Image (Internal)__
+
+Evaluate the source bulge on the ray-traced source-plane grid. Because the linear profile carries
+`intensity=1.0` internally, the absolute normalization of this image is arbitrary — it represents the
+*shape* of the source's contribution to the model. The inversion will scale it.
+"""
+image_2d_source_bulge_internal = source_galaxy.bulge.image_2d_from(grid=traced_grid)
+
+aplt.plot_array(array=image_2d_source_bulge_internal, title="Source Bulge Image (intensity=1.0)")
+
+"""
+__Mapping Matrix__
+
+For interferometer data the mapping matrix is the same conceptually as for imaging data: each column
+holds the real-space image of one linear basis component, evaluated with `intensity=1.0`. The lensing of
+that image is already baked in (because we evaluated it on the ray-traced source-plane grid).
+
+We have only one linear light profile (the source bulge), so the mapping matrix has dimensions
+`(total_real_space_pixels, 1)`.
+"""
+lp_linear_func_source = al.LightProfileLinearObjFuncList(
+    grid=traced_grid,
+    blurring_grid=None,
+    psf=None,
+    light_profile_list=[source_galaxy.bulge],
+    regularization=None,
+)
+
+mapping_matrix = lp_linear_func_source.mapping_matrix
+
+print("Mapping matrix shape (real-space pixels, linear basis count):")
+print(mapping_matrix.shape)
+
+"""
+A 2D plot of the `mapping_matrix` shows the source bulge image in 1D (column 0). For the single-source case
+the matrix is a single column, so the plot looks like a tall stripe.
+"""
+plt.imshow(mapping_matrix, aspect=(mapping_matrix.shape[1] / mapping_matrix.shape[0]))
+plt.show()
+plt.close()
+
+"""
+__Transformed Mapping Matrix ($f$)__
+
+To fit visibilities, every column of the real-space `mapping_matrix` must be NUFFT'd to the uv-plane. The
+result is the `transformed_mapping_matrix` — a *complex-valued* matrix with dimensions
+`(total_visibilities, total_linear_basis_components)`.
+
+In our case it is a single column: the visibilities the source bulge contributes per unit `intensity`. The
+inversion's job is to find the scalar that, when multiplied by this column, best fits the observed
+visibilities.
+
+The NUFFT here uses `TransformerNUFFT` (nufftax) — this is exactly the operation that used to be slow and
+which nufftax has made fast. The whole pipeline (deflections → ray-trace → source-plane image →
+`transform_mapping_matrix` → linear inversion) is JIT-compilable under JAX.
+"""
+transformed_mapping_matrix = dataset.transformer.transform_mapping_matrix(
+    mapping_matrix=mapping_matrix
+)
+
+print("Transformed mapping matrix shape (visibilities, linear basis count):")
+print(transformed_mapping_matrix.shape)
+
+"""
+Plot the real and imaginary components of the (single column of the) transformed mapping matrix. Each row is
+one observed visibility; the value is the contribution of the source per unit intensity at that uv point.
+"""
+plt.imshow(
+    transformed_mapping_matrix.real,
+    aspect=(transformed_mapping_matrix.shape[1] / transformed_mapping_matrix.shape[0]),
+)
+plt.colorbar()
+plt.title("Re(f) — real component of transformed mapping matrix")
+plt.show()
+plt.close()
+
+plt.imshow(
+    transformed_mapping_matrix.imag,
+    aspect=(transformed_mapping_matrix.shape[1] / transformed_mapping_matrix.shape[0]),
+)
+plt.colorbar()
+plt.title("Im(f) — imaginary component of transformed mapping matrix")
+plt.show()
+plt.close()
+
+"""
+Warren & Dye 2003 (https://arxiv.org/abs/astro-ph/0302587) (hereafter WD03) introduce the linear inversion
+formalism used to compute the intensity values of the linear light profiles. WD03 indexes the transformed
+mapping matrix as $f_{ij}$ where $i$ maps over all $I$ linear basis components and $j$ maps over all $J$
+visibilities.
+
+The indexing of the `transformed_mapping_matrix` array is reversed compared to the WD03 convention (rows are
+visibilities, columns are basis components).
+
+__Data Vector (D)__
+
+To solve for the linear light profile intensities we pose the problem as a linear inversion.
+
+This requires us to convert the `transformed_mapping_matrix` and our `data` and `noise_map` into matrices of
+the right dimensions. The `data_vector`, $D$, has dimensions `(total_linear_basis_components,)`.
+
+In WD03 the data vector is given by:
+
+ $\\vec{D}_{i} = \\sum_{\\rm  j=1}^{J} f_{ij}\\, d_{j} / \\sigma_{j}^2 \\, ,$
+
+where $d_j$ are the observed visibility values, $\\sigma_j^2$ are the visibility variances, and the sum runs
+over real and imaginary components. The interferometer helper handles the real/imaginary split internally.
+
+For a single-basis model $D$ is a length-1 vector — just the noise-weighted overlap of the source's
+contribution with the observed visibilities.
+"""
+data_vector = (
+    al.util.inversion_interferometer.data_vector_via_transformed_mapping_matrix_from(
+        transformed_mapping_matrix=transformed_mapping_matrix,
+        visibilities=dataset.data,
+        noise_map=dataset.noise_map,
+    )
+)
+
+print("Data Vector D:")
+print(data_vector)
+print(data_vector.shape)
+
+"""
+__Curvature Matrix (F)__
+
+The `curvature_matrix` $F$ has dimensions
+`(total_linear_basis_components, total_linear_basis_components)`.
+
+In WD03 the curvature matrix is given by:
+
+ ${F}_{ik} = \\sum_{\\rm  j=1}^{J} f_{ij}\\, f_{kj} / \\sigma_{j}^2 \\, .$
+
+Because visibilities (and therefore $f$) are complex-valued, the curvature is computed separately for the
+real and imaginary parts and summed. For a single-basis model $F$ is a 1x1 matrix.
+"""
+real_curvature_matrix = al.util.inversion.curvature_matrix_via_mapping_matrix_from(
+    mapping_matrix=transformed_mapping_matrix.real,
+    noise_map=dataset.noise_map.real,
+)
+
+imag_curvature_matrix = al.util.inversion.curvature_matrix_via_mapping_matrix_from(
+    mapping_matrix=transformed_mapping_matrix.imag,
+    noise_map=dataset.noise_map.imag,
+)
+
+curvature_matrix = np.add(real_curvature_matrix, imag_curvature_matrix)
+
+print("Curvature Matrix F:")
+print(curvature_matrix)
+
+"""
+__Reconstruction (Positive-Negative)__
+
+The following chi-squared is minimized when we perform the inversion and solve for the source intensity:
+
+$\\chi^2 = \\sum_{\\rm  j=1}^{J} \\bigg[ \\frac{(\\sum_{\\rm  i=1}^{I} s_{i} f_{ij}) - d_{j}}{\\sigma_{j}} \\bigg]^2$
+
+Where $s_i$ is the solved-for `intensity` of the $i$-th linear basis component. The solution is given by
+(equation 5 WD03):
+
+ $s = F^{-1} D$
+
+Computed with NumPy:
+"""
+reconstruction = np.linalg.solve(curvature_matrix, data_vector)
+
+print("Reconstruction s (positive-negative solver):")
+print(reconstruction)
+
+"""
+For linear light profiles fit to a clean dataset like ours, the solved-for `intensity` is positive and the
+positive-negative solution is physical. For more complex models (e.g. many components or noisy data) the
+positive-negative solver can return negative `intensity` values — unphysical for a light profile.
+
+__Reconstruction (Positive Only)__
+
+The linear algebra can be solved with the constraint that all `intensity` values are positive. The naive
+approach is `scipy.optimize.nnls`, which is iterative and works directly on the transformed mapping matrix —
+it does not use `data_vector` or `curvature_matrix`. This is slow, especially with many linear components.
+
+The source code therefore uses a "fast nnls" algorithm — an adaptation of:
+  https://github.com/jvendrow/fnnls
+
+`fnnls` *does* use `data_vector` $D$ and `curvature_matrix` $F$, which is why it is much faster. The function
+`reconstruction_positive_only_from` wraps `fnnls`.
+"""
+reconstruction = al.util.inversion.reconstruction_positive_only_from(
+    data_vector=data_vector,
+    curvature_reg_matrix=curvature_matrix,  # ignore the _reg_ tag in this guide
+)
+
+print("Reconstruction s (positive-only solver):")
+print(reconstruction)
+
+"""
+__Visibilities Reconstruction__
+
+Using the reconstructed `intensity` value(s) we can map the reconstruction back to the visibility plane via
+the `transformed_mapping_matrix`, producing the model visibilities.
+"""
+mapped_reconstructed_visibilities = (
+    al.util.inversion_interferometer.mapped_reconstructed_visibilities_from(
+        transformed_mapping_matrix=transformed_mapping_matrix,
+        reconstruction=reconstruction,
+    )
+)
+
+mapped_reconstructed_visibilities = al.Visibilities(
+    visibilities=mapped_reconstructed_visibilities
+)
+
+aplt.plot_grid(grid=mapped_reconstructed_visibilities.in_grid, title="Model Visibilities")
+
+
+"""
+__Likelihood Function__
+
+We now quantify the goodness-of-fit of our linear-light-profile reconstruction.
+
+The likelihood function for parametric galaxy modeling, even with linear light profiles, consists of two
+terms in the visibility plane:
+
+ $-2 \\mathrm{ln} \\, \\epsilon = \\chi^2 + \\sum_{\\rm  j=1}^{J} { \\mathrm{ln}} \\left [2 \\pi (\\sigma_j)^2 \\right]  \\, .$
+
+We now explain each term.
+
+__Chi Squared__
+
+The first term is a $\\chi^2$ statistic computed in the visibility plane:
+
+ - `model_data` = `mapped_reconstructed_visibilities`
+ - `residual_map` = (`data` - `model_data`)
+ - `normalized_residual_map` = (`data` - `model_data`) / `noise_map`
+ - `chi_squared_map` = `normalized_residual_map` ** 2.0
+ - `chi_squared` = sum(`chi_squared_map`)
+
+Visibilities are complex-valued, so we split into real and imaginary components, compute $\\chi^2$ for each,
+and sum.
+"""
+model_visibilities = mapped_reconstructed_visibilities
+
+residual_map = dataset.data - model_visibilities
+
+chi_squared_map_real = (residual_map.real / dataset.noise_map.real) ** 2
+chi_squared_map_imag = (residual_map.imag / dataset.noise_map.imag) ** 2
+
+chi_squared_real = np.sum(chi_squared_map_real)
+chi_squared_imag = np.sum(chi_squared_map_imag)
+chi_squared = chi_squared_real + chi_squared_imag
+
+print(f"chi_squared (real + imag) = {chi_squared}")
+
+"""
+__Noise Normalization Term__
+
+The likelihood function assumes the visibility data consists of independent Gaussian noise on every
+visibility (real and imaginary parts treated independently).
+
+The `noise_normalization` term is the sum of the log of every noise-map value squared. Because the
+`noise_map` is fixed, this term does not change during modeling and has no impact on the inferred model — it
+is included so that the absolute value of `log_likelihood` has the correct calibration for model comparison.
+"""
+noise_normalization_real = float(np.sum(np.log(2 * np.pi * dataset.noise_map.real ** 2.0)))
+noise_normalization_imag = float(np.sum(np.log(2 * np.pi * dataset.noise_map.imag ** 2.0)))
+noise_normalization = noise_normalization_real + noise_normalization_imag
+
+"""
+__Calculate The Log Likelihood__
+
+Combine the two terms to compute the `log_likelihood`:
+"""
+figure_of_merit = float(-0.5 * (chi_squared + noise_normalization))
+
+print(f"log_likelihood (figure of merit) = {figure_of_merit}")
+
+
+"""
+__Fit__
+
+The exact same likelihood evaluation is performed inside the `FitInterferometer` object. We construct one,
+print its `figure_of_merit`, and confirm it matches the value we computed by hand above.
+"""
+fit = al.FitInterferometer(dataset=dataset, tracer=tracer)
+print(f"FitInterferometer.figure_of_merit = {fit.figure_of_merit}")
+
+aplt.subplot_fit_interferometer(fit=fit)
+
+"""
+The fit contains an `Inversion` object, which handles all the linear algebra we have covered in this script.
+"""
+print(fit.inversion)
+print(fit.inversion.data_vector)
+print(fit.inversion.curvature_matrix)
+print(fit.inversion.reconstruction)
+
+"""
+The `Inversion` can also be computed from the tracer and dataset directly, by passing them to the
+`TracerToInversion` object. This object additionally handles cases where the tracer contains a mix of linear
+light profiles and pixelization-based components.
+"""
+tracer_to_inversion = al.TracerToInversion(
+    tracer=tracer,
+    dataset=dataset,
+)
+
+inversion = tracer_to_inversion.inversion
+
+"""
+__Lens Modeling__
+
+To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using a
+non-linear search algorithm.
+
+The default sampler is the nested sampling algorithm `nautilus`
+(https://github.com/johannesulf/nautilus); multiple MCMC and optimization algorithms are also supported.
+
+For linear light profiles, the reduced number of free parameters (the `intensity` is solved for via the
+inversion instead of being a non-linear search dimension) means that the sampler converges in fewer
+iterations and is less likely to be confused by intensity-shape degeneracies.
+
+__Wrap Up__
+
+We have presented a visual step-by-step guide to the linear light profile interferometer likelihood
+function. The pipeline:
+
+  ray-trace → source-plane image (linear profile, intensity=1) → `mapping_matrix`
+  → NUFFT → `transformed_mapping_matrix` → $D$ and $F$ → solve $s = F^{-1} D$
+  → `mapped_reconstructed_visibilities` → visibility-plane $\\chi^2$ → log likelihood
+
+is the same as for CCD imaging linear light profiles, with the PSF convolution step replaced by the NUFFT
+step. The NUFFT is the operation that nufftax made fast on the GPU, which is why this entire workflow is
+now practical on interferometer data at any visibility count.
+
+There are a number of other inputs which slightly change the behaviour of this likelihood function, which
+are described in additional notebooks found in the `guides` package:
+
+ - `over_sampling`: Not applicable to interferometer data (over-sampling is an imaging-only technique).
+ - `pixelization`: For sources whose morphology cannot be captured by analytic light profiles, see the
+   interferometer pixelization examples in `interferometer/features/pixelization/`.
+"""

--- a/scripts/interferometer/features/linear_light_profiles/modeling.py
+++ b/scripts/interferometer/features/linear_light_profiles/modeling.py
@@ -1,0 +1,419 @@
+"""
+Modeling Features: Linear Light Profiles (Interferometer)
+==========================================================
+
+A "linear light profile" is a variant of a standard light profile where the `intensity` parameter is solved for
+via linear algebra every time the model is fitted to the data. This uses a process called an "inversion" and it
+always computes the `intensity` values that give the best fit to the data (e.g. maximize the likelihood) given
+the light profile's other parameters.
+
+Linear light profiles have been a standard tool for fitting CCD imaging data for a long time. For interferometer
+data they used to be impractical, because every likelihood evaluation has to Fourier-transform each basis component
+into the uv-plane, and prior NUFFT backends were not JAX-friendly. With `nufftax`
+(https://github.com/GragasLab/nufftax) — a JAX-native Non-Uniform Fast Fourier Transform — the image-to-uv
+transform now runs inside the same jit/vmap pipeline as the rest of the model, so the per-iteration overhead of
+NUFFT-ing each basis component is amortised on the GPU. Linear light profile fits are therefore practical for
+interferometer data at any visibility count, including ALMA-class datasets with tens of millions of visibilities.
+
+Based on the advantages below, we recommend you use linear light profiles whenever fitting light profiles to
+interferometer data.
+
+__Contents__
+
+- **Advantages & Disadvantages:** Benefits and drawbacks of linear light profiles, and how they apply to
+  interferometer data specifically.
+- **NUFFT (nufftax):** Why linear light profile fits to visibilities are now practical thanks to nufftax.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model fitted to the data — `Isothermal` + `ExternalShear` lens mass and a
+  linear `SersicCore` source. The lens light is omitted (interferometer convention).
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load the strong lens `Interferometer` dataset, using `TransformerNUFFT` (backed by `nufftax`).
+- **Over Sampling:** Interferometer modeling does not use over-sampling (covered briefly here for users
+  familiar with imaging).
+- **Search:** Configure the non-linear search (Nautilus).
+- **Analysis:** Create the `AnalysisInterferometer` object.
+- **VRAM:** Linear light profiles add negligible VRAM compared to standard light profiles.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Intensities:** How to extract solved-for `intensity` values from the result.
+- **Visualization:** Visualising fits with linear light profiles requires the
+  `model_obj_linear_light_profiles_to_light_profiles` helper.
+- **Max Likelihood Inversion:** Access the `Inversion` object from the result.
+- **Linear Objects (Internal Source Code):** The internal `linear_obj_list` representation used by the
+  inversion.
+- **Wrap Up:** Summary of the script and next steps.
+
+__Advantages__
+
+The source galaxy's `intensity` parameter is therefore not a free parameter in the model-fit, reducing the
+dimensionality of non-linear parameter space by one. The lens light is already omitted for interferometer data,
+so the saving is smaller than the imaging case (where lens and source both contribute) — but the inversion still
+removes the degeneracies between `intensity` and the source's shape parameters (e.g. `effective_radius`,
+`sersic_index`), which are difficult degeneracies for the non-linear search to map out accurately. This produces
+more reliable lens model results and the fit converges in fewer iterations.
+
+The inversion has a relatively small computational cost on top of the NUFFT, so we reduce the model complexity
+without much slow-down.
+
+__Disadvantages__
+
+Although the computation time of the inversion is small, it is not non-negligible. It is approximately 3-4x
+slower per likelihood than using a standard light profile with a fixed `intensity`.
+
+The gains in run times from the simpler parameter space therefore broadly balance the slower per-likelihood
+evaluation. The headline benefit is reliability, not raw speed.
+
+__NUFFT (nufftax)__
+
+The image-to-visibilities Fourier transform is performed by a Non-Uniform Fast Fourier Transform (NUFFT),
+exposed in **PyAutoLens** as `TransformerNUFFT`. The default backend is `nufftax`, a pure-JAX NUFFT that
+jit-compiles and vmap-batches like the rest of the library:
+
+  https://github.com/GragasLab/nufftax
+
+Because `nufftax` is JAX-native, NUFFT-ing each linear basis image happens inside the same compiled likelihood
+that does the inversion, mass model ray-tracing, and chi-squared sum. There is no host round-trip between
+NUFFT calls, so a model with N linear light profiles costs only N forward-NUFFTs per iteration on the GPU —
+fast enough that linear inversions in the visibility plane are now routinely practical.
+
+If `nufftax` is not installed, install it via `pip install nufftax`. A legacy pynufft-backed transformer
+(`TransformerNUFFTPyNUFFT`) is available as a non-JAX fallback but is not recommended for linear light profiles.
+
+__Positive Only Solver__
+
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and
+negative values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
+
+This is problematic, as it means that negative surface brightnesses values can be computed to represent a galaxy's
+light, which is clearly unphysical.
+
+**PyAutoLens** uses a positive only linear algebra solver which has been extensively optimized to ensure it is
+as fast as positive-negative solvers. This ensures that all light profile intensities are positive and therefore
+physical.
+
+For pixelized source reconstructions on interferometer data this solver is often disabled because negative
+visibility-plane noise can pull individual pixels negative without anything being wrong physically. For linear
+*light profiles*, the intensity is a single physical normalisation of an extended profile, so we keep the
+positive-only solver enabled.
+
+__Model__
+
+This script fits an `Interferometer` dataset of a 'galaxy-scale' strong lens with a model where:
+
+ - The lens galaxy's light is omitted (and is not present in the simulated data). This is the standard
+   convention for interferometer modeling, as the lens galaxy's optical/IR emission is typically below the
+   detection threshold of mm/sub-mm interferometers.
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
+ - The source galaxy's light is a linear `SersicCore`.
+
+__Start Here Notebook__
+
+If any code in this script is unclear, refer to the `interferometer/start_here.ipynb` notebook.
+
+__Imaging Equivalent__
+
+For the CCD-imaging version of this script, which also fits a linear `Sersic` for the lens light, see
+`autolens_workspace/*/imaging/features/linear_light_profiles/modeling.py`.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+from pathlib import Path
+import autofit as af
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, which we will fit with
+the lens model.
+
+This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane and
+compare directly to the visibilities. We use `TransformerNUFFT`, the JAX-native Non-Uniform Fast Fourier
+Transform backed by `nufftax`, which is the required choice for fast linear light profile modeling and
+scales efficiently from a few hundred visibilities to tens of millions.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Over Sampling__
+
+If you are familiar with using imaging data, you may have seen that a numerical technique called over sampling
+is used, which evaluates light profiles on a higher resolution grid than the image data to ensure the
+calculation is accurate.
+
+Interferometer data does not observe galaxies in a way where over sampling is necessary, therefore all
+interferometer calculations are performed without over sampling.
+
+__Model__
+
+We compose a lens model where:
+
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear` [7 parameters].
+
+ - The source galaxy's light is a linear `SersicCore` [5 parameters — `intensity` is solved for analytically].
+
+The number of free parameters and therefore the dimensionality of non-linear parameter space is N=12.
+
+Note how the source galaxy uses a linear light profile, meaning that its `intensity` parameter is no longer a
+free parameter in the fit. There is no lens-light component (interferometer convention).
+
+__Model Cookbook__
+
+A full description of model composition is provided by the model cookbook:
+
+https://pyautolens.readthedocs.io/en/latest/general/model_cookbook.html
+"""
+# Lens:
+
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+# Source:
+
+bulge = af.Model(al.lp_linear.SersicCore)
+
+source = af.Model(al.Galaxy, redshift=1.0, bulge=bulge)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format (if this does not display clearly on your screen
+refer to `start_here.ipynb` for a description of how to fix this).
+
+This confirms that the source galaxy's light profile does not include an `intensity` parameter.
+"""
+print(model.info)
+
+"""
+__Search__
+
+The model is fitted to the data using the nested sampling algorithm Nautilus (see `start_here.py` for a
+full description).
+
+In the `interferometer/modeling.py` example 75 live points (`n_live=75`) were used to sample parameter space.
+For this linear light profile fit we keep `n_live=75` — the saving from one fewer free parameter is modest, and
+the run-time benefit on interferometer data comes mostly from the reliability of the linear inversion rather
+than a reduction in live points.
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "features",
+    name="linear_light_profiles",
+    unique_tag=dataset_name,
+    n_live=75,
+    n_batch=20,  # GPU lens model fits are batched and run simultaneously, see VRAM section below.
+)
+
+"""
+__Analysis__
+
+Create the `AnalysisInterferometer` object defining how Nautilus fits the model to the data.
+"""
+analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+"""
+__VRAM__
+
+The `interferometer/modeling.py` example explains how VRAM is used during GPU-based fitting and how to print
+the estimated VRAM required by a model.
+
+For each linear light profile in the model a small additional amount of VRAM is used to store its NUFFT'd
+mapping matrix column. For 1-10 linear light profiles this is a tiny amount of VRAM (e.g. < 10MB per batched
+likelihood). Even for large batch sizes you almost certainly will not use enough VRAM to require monitoring.
+
+VRAM on interferometer datasets is driven primarily by the visibility count and the real-space mask size, not
+the number of linear light profiles in the model.
+
+__Run Time__
+
+For standard light profiles fitting interferometer data, the log likelihood evaluation time is dominated by the
+NUFFT step.
+
+For linear light profiles, the per-evaluation cost is the NUFFT plus a small additional cost from the linear
+inversion. The inversion adds approximately 3-4x the cost of the inversion-only term compared to the
+fixed-intensity case, but because the NUFFT typically dominates the total cost, the overall slow-down per
+likelihood is usually closer to 1.1-1.5x for a model with a single linear source profile.
+
+Because one free parameter has been removed from the model (the source `intensity`) and the parameter-space
+degeneracy between `intensity` and shape parameters is broken, the total number of likelihood evaluations needed
+for convergence is usually reduced. Fits using standard light profiles and linear light profiles therefore take
+roughly the same wall-clock time to run. The simpler parameter space of linear light profiles means the
+model-fit is more reliable, less susceptible to converging to a local maximum, and scales better if more linear
+light profiles are added (e.g. an MGE source).
+
+__Model-Fit__
+
+We begin the model-fit by passing the model and analysis object to the non-linear search (checkout the output
+folder for on-the-fly visualization and results).
+"""
+result = search.fit(model=model, analysis=analysis)
+
+"""
+__Result__
+
+The `info` attribute shows the model in a readable format (if this does not display clearly on your screen
+refer to `start_here.ipynb` for a description of how to fix this).
+
+This confirms that `intensity` parameters are not inferred by the model-fit.
+"""
+print(result.info)
+
+"""
+We plot the maximum likelihood fit, tracer images and posteriors inferred via Nautilus.
+
+The source galaxy appears similar to that in the data, confirming that the `intensity` value inferred by the
+inversion process is accurate.
+"""
+print(result.max_log_likelihood_instance)
+
+aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.lp)
+
+aplt.subplot_fit_interferometer(fit=result.max_log_likelihood_fit)
+
+aplt.corner_anesthetic(samples=result.samples)
+
+"""
+__Intensities__
+
+The intensity of a linear light profile is not part of the model parameterization, and is therefore not
+displayed in the `model.results` file.
+
+To extract the `intensity` value of a specific component in the model, we use the `max_log_likelihood_tracer`,
+which has already performed the inversion and therefore the galaxy light profiles have their solved-for
+`intensity` values associated with them.
+"""
+tracer = result.max_log_likelihood_tracer
+
+# The source is the only galaxy with a light profile in the interferometer model — index -1 grabs it
+# regardless of tracer ordering.
+print(tracer.galaxies[-1].bulge.intensity)
+
+"""
+The `Tracer` contained in the `max_log_likelihood_fit` also has the solved for `intensity` value:
+"""
+fit = result.max_log_likelihood_fit
+
+tracer = fit.tracer
+
+print(tracer.galaxies[-1].bulge.intensity)
+
+"""
+__Visualization__
+
+Linear light profiles and objects containing them (e.g. galaxies, a tracer) cannot be plotted because they do
+not have an `intensity` value.
+
+Therefore, a helper produces an equivalent tracer in which every linear light profile has been replaced with an
+ordinary light profile carrying its solved-for `intensity`. That helper-tracer can then be visualised:
+"""
+tracer = result.max_log_likelihood_tracer
+
+aplt.plot_array(array=tracer.image_2d_from(grid=dataset.grid), title="Tracer Image")
+
+
+"""
+__Wrap Up__
+
+Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+
+__Result (Advanced)__
+
+The code below shows additional results that can be computed from a `Result` object following a fit with a
+linear light profile.
+
+__Max Likelihood Inversion__
+
+As seen elsewhere in the workspace, the result contains a `max_log_likelihood_fit`, which contains the
+`Inversion` object we need.
+"""
+inversion = result.max_log_likelihood_fit.inversion
+
+"""
+This `Inversion` is what handled the linear algebra that produced the source `intensity` value above.
+
+__Linear Objects (Internal Source Code)__
+
+An `Inversion` contains all of the linear objects used to reconstruct the data in its `linear_obj_list`.
+
+This list may include the following objects:
+
+ - `LightProfileLinearObjFuncList`: Holds a list of linear light profiles and the functionality used to
+   reconstruct data in an inversion. It may contain a single light profile (e.g. `lp_linear.SersicCore`) or
+   many light profiles combined in a `Basis` (e.g. `lp_basis.Basis`).
+
+ - `Mapper`: The linear object used by a `Pixelization` to reconstruct data via an `Inversion`. The `Mapper`
+   is specific to the `Pixelization`'s `Mesh` (e.g. a `RectangularMapper` is used for a `RectangularAdaptDensity`
+   mesh).
+
+In this example, the model has one linear `SersicCore` for the source galaxy's bulge and no lens-light
+component. The inversion therefore has a single `LightProfileLinearObjFuncList` entry, which holds the source
+bulge.
+"""
+print(inversion.linear_obj_list)
+
+"""
+To extract results from an inversion many quantities come in lists or require us to specify the linear object
+we wish to use. Knowing what linear objects are in the `linear_obj_list`, and what indexes they correspond to,
+is therefore important.
+
+The single entry in this example is the source bulge.
+"""
+print(f"LightProfileLinearObjFuncList (Source SersicCore) = {inversion.linear_obj_list[0]}")
+
+"""
+The `LightProfileLinearObjFuncList` contains a `light_profile_list`. In this example the list has a single
+light profile.
+"""
+print(
+    f"Linear Light Profile list (Source SersicCore) = {inversion.linear_obj_list[0].light_profile_list}"
+)
+
+"""
+Finish.
+"""

--- a/scripts/interferometer/features/linear_light_profiles/slam.py
+++ b/scripts/interferometer/features/linear_light_profiles/slam.py
@@ -1,0 +1,552 @@
+"""
+Linear Light Profiles: SLaM (Interferometer)
+=============================================
+
+This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`
+data, using a **linear light profile** in the SOURCE LP stage instead of a Multi-Gaussian Expansion (MGE).
+
+A full overview of SLaM is provided in `guides/modeling/slam_start_here`. You should read that guide before
+working through this example.
+
+The interferometer pixelization SLaM pipeline at `interferometer/features/pixelization/slam.py` is the closest
+analogue — this script keeps the same pipeline structure (SOURCE LP → SOURCE PIX 1 → SOURCE PIX 2 → MASS
+TOTAL) and only changes the SOURCE LP source bulge from an MGE to a linear `SersicCore`. The LIGHT LP
+pipeline from `slam_start_here.py` is omitted because interferometer data does not contain lens light
+emission.
+
+The differences from the interferometer pixelization SLaM are:
+
+ - The SOURCE LP PIPELINE uses a single linear `SersicCore` profile (`al.lp_linear.SersicCore`) for the
+   source galaxy's bulge instead of a multi-Gaussian expansion.
+
+Linear light profiles solve for the `intensity` analytically via linear algebra, removing it from the
+non-linear parameter space. This reduces the dimensionality of the SOURCE LP search and eliminates
+intensity-shape degeneracies on the source bulge. The pixelized source-reconstruction stages
+(SOURCE PIX 1 and 2) and the MASS TOTAL stage are unchanged.
+
+The SOURCE LP stage uses `TransformerNUFFT` (backed by JAX-native `nufftax`,
+https://github.com/GragasLab/nufftax). Linear light profile fits to visibilities are now practical at any
+visibility count because the per-iteration NUFFT of each linear basis component is fast on the GPU.
+
+The SOURCE PIX and MASS TOTAL stages switch to `TransformerDFT` combined with the pre-computed sparse
+operator, because pixelized source reconstructions exploit sparsity rather than the NUFFT path.
+
+__Contents__
+
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with `slam_start_here`.
+- **SOURCE LP PIPELINE:** Initializes the mass and source-light model with a linear `SersicCore` profile,
+  fitted via `TransformerNUFFT`.
+- **SOURCE PIX PIPELINE 1:** Initializes a pixelized source using the adapt image from the SOURCE LP result.
+- **SOURCE PIX PIPELINE 2:** Improves the pixelized source using adapt images from `source_pix_result_1`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included
+  (interferometer data).
+- **Two Datasets:** Build one Interferometer with `TransformerNUFFT` (source_lp) and one with
+  `TransformerDFT` + sparse operator (source_pix onwards).
+- **Sparse Operators:** Pre-compute the sparse operator for the pixelized stages.
+- **Settings:** Disable the positive-only solver so the pixelized source reconstruction can have negative
+  pixel values.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization, database
+  use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in `features/pixelization/modeling`, the mesh shape is fixed before modeling.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+
+__Prerequisites__
+
+Before using this SLaM pipeline, you should be familiar with:
+
+- **SLaM Start Here** (`guides/modeling/slam_start_here`)
+  An introduction to the goals, structure, and design philosophy behind SLaM pipelines and how they
+  integrate into strong-lens modeling.
+
+- **Linear Light Profiles** (`interferometer/features/linear_light_profiles/modeling`)
+  How linear light profiles work for interferometer data, why nufftax makes them practical, and what they
+  add over fixed-intensity profiles.
+
+- **Interferometer Pixelization SLaM** (`interferometer/features/pixelization/slam`)
+  The canonical interferometer SLaM pipeline. This script is essentially that pipeline with the SOURCE LP
+  source bulge swapped from an MGE to a linear `SersicCore`.
+
+You can still run the script without fully understanding these guides, but reviewing them later will make
+the structure and choices of the SLaM workflow clearer.
+
+__High Resolution Dataset__
+
+A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts large
+files which are too big to include in the main `autolens_workspace` repository:
+
+  https://github.com/PyAutoLabs/autolens_workspace_large_files
+
+After downloading the file, place it in the directory:
+
+  `autolens_workspace/dataset/interferometer/alma`
+
+You can then perform modeling using this high-resolution dataset by uncommenting the relevant line of code
+below.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import numpy as np
+from pathlib import Path
+import autofit as af
+import autolens as al
+import autolens.plot as aplt
+
+
+"""
+__SOURCE LP PIPELINE__
+
+The SOURCE LP PIPELINE uses one search to initialize a robust model for the source galaxy's light using a
+**linear** `SersicCore` profile. The lens galaxy mass and external shear are fitted at the same time.
+
+The linear `SersicCore` has its `intensity` solved for analytically via the linear inversion rather than as
+a free parameter of the non-linear search. This makes the SOURCE LP search faster and more reliable: the
+intensity-shape degeneracies (between `intensity` and `effective_radius` / `sersic_index`) are eliminated.
+
+This stage uses the `dataset_nufft` Interferometer (built with `TransformerNUFFT`, backed by `nufftax`),
+which makes the per-iteration NUFFT of the linear basis component fast even for ALMA-class datasets with
+millions of visibilities.
+
+The mass and source models from this search initialize the SOURCE PIX PIPELINE searches that follow, and
+the result also provides the adapt image and position likelihood used by those later stages.
+
+Note that no lens light is fitted: interferometer data does not contain lens light emission, so
+`lens.bulge` and `lens.disk` are kept at `None`.
+"""
+
+
+def source_lp(
+    settings_search: af.SettingsSearch,
+    dataset,
+    redshift_lens: float,
+    redshift_source: float,
+    n_batch: int = 50,
+) -> af.Result:
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+    source_bulge = af.Model(al.lp_linear.SersicCore)
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=redshift_lens,
+                # interferometer data does not contain lens light emission
+                bulge=None,
+                disk=None,
+                mass=af.Model(al.mp.Isothermal),
+                shear=af.Model(al.mp.ExternalShear),
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=redshift_source,
+                bulge=source_bulge,
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_lp[1]",
+        **settings_search.search_dict,
+        n_live=150,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 1__
+
+The SOURCE PIX PIPELINE uses two searches to initialize a robust pixelized model of the source galaxy.
+
+The first search fits a pixelization whose purpose is to generate a high-quality adapt image used in
+search 2. It uses the adapt image computed from the SOURCE LP result and the position likelihood is also
+derived automatically from the SOURCE LP result — no manual positions input is required.
+
+This stage uses the `dataset_dft_sparse` Interferometer (built with `TransformerDFT` +
+`apply_sparse_operator`). Pixelizations do not use the NUFFT path; the sparse-operator + DFT combination is
+what keeps pixelized source reconstructions fast and VRAM-efficient on large datasets.
+"""
+
+
+def source_pix_1(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    mesh_init,
+    regularization_init,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_lp_result
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_lp_result.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=source_lp_result.model.galaxies.lens.mass,
+        mass_result=source_lp_result.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+    shear = source_lp_result.model.galaxies.lens.shear
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=mesh_init,
+                    regularization=regularization_init,
+                ),
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_pix[1]",
+        **settings_search.search_dict,
+        n_live=150,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 2__
+
+Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the source
+pixelization and regularization.
+
+Note that the LIGHT LP PIPELINE from `slam_start_here.py` is omitted here, as interferometer data does not
+contain lens light emission.
+
+Like SOURCE PIX PIPELINE 1, this stage uses the `dataset_dft_sparse` Interferometer.
+"""
+
+
+def source_pix_2(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    source_pix_result_1: af.Result,
+    mesh,
+    regularization,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_pix_result_1, use_model_images=True
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+    )
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=source_pix_result_1.instance.galaxies.lens.mass,
+                shear=source_pix_result_1.instance.galaxies.lens.shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=mesh,
+                    regularization=regularization,
+                ),
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_pix[2]",
+        **settings_search.search_dict,
+        n_live=75,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__MASS TOTAL PIPELINE__
+
+Identical to `slam_start_here.py`, except no lens light model is included as interferometer data does not
+contain lens light emission.
+"""
+
+
+def mass_total(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_pix_result_1: af.Result,
+    source_pix_result_2: af.Result,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    # Total mass model for the lens galaxy.
+    mass = af.Model(al.mp.PowerLaw)
+
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_pix_result_1, use_model_images=True
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_pix_result_1.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=mass,
+        mass_result=source_pix_result_1.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+
+    source = al.util.chaining.source_from(result=source_pix_result_2)
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_pix_result_1.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=source_pix_result_1.model.galaxies.lens.shear,
+            ),
+            source=source,
+        ),
+    )
+
+    search = af.Nautilus(
+        name="mass_total[1]",
+        **settings_search.search_dict,
+        n_live=150,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__Dataset + Masking__
+
+Load the `Interferometer` data and define the real-space mask.
+"""
+dataset_name = "simple"
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256), pixel_scales=0.1, radius=mask_radius
+)
+
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+# dataset_name = "alma"
+#
+# if dataset_name == "alma":
+#
+#     real_space_mask = al.Mask2D.circular(
+#         shape_native=(800, 800),
+#         pixel_scales=0.01,
+#         radius=mask_radius,
+#     )
+
+
+"""
+__Two Datasets__
+
+The SLaM pipeline runs in two phases that prefer different transformers:
+
+- `dataset_nufft` uses `TransformerNUFFT` (backed by JAX-native `nufftax`) for the `source_lp` stage. With
+  the linear `SersicCore` source bulge this is the fast path at any visibility count.
+- `dataset_dft_sparse` uses `TransformerDFT` combined with `apply_sparse_operator(...)` for
+  `source_pix_1`, `source_pix_2`, and `mass_total`. Pixelized source reconstructions exploit sparsity in
+  the linear inversion rather than the NUFFT, so this combination is the right choice for the pixelized
+  stages.
+
+Both datasets are built from the same FITS files; only the transformer (and sparse-operator preload) differ.
+"""
+dataset_nufft = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+dataset_dft_sparse = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+"""
+__Sparse Operators__
+
+The `pixelization/modeling` example describes how the sparse operator formalism speeds up interferometer
+pixelized source modeling, especially for many visibilities.
+
+We use a try / except to load the pre-computed curvature preload, which is necessary to use the sparse
+operator formalism. If this file does not exist (e.g. you have not made it manually via the
+`many_visibilities_preparation` example) it is made here.
+
+The sparse operator is applied only to `dataset_dft_sparse` — the NUFFT-backed `dataset_nufft` used by
+`source_lp` does not need it.
+"""
+try:
+    nufft_precision_operator = np.load(
+        file=dataset_path / "nufft_precision_operator.npy",
+    )
+except FileNotFoundError:
+    nufft_precision_operator = None
+
+dataset_dft_sparse = dataset_dft_sparse.apply_sparse_operator(
+    nufft_precision_operator=nufft_precision_operator, use_jax=True, show_progress=True
+)
+
+"""
+__Settings__
+
+Disable the default positive-only linear algebra solver so the pixelized source reconstruction can have
+negative pixel values. (The linear `SersicCore` in SOURCE LP is still constrained to positive `intensity`
+internally because that is a physical normalization.)
+"""
+settings = al.Settings(use_positive_only_solver=False)
+
+"""
+__Settings AutoFit__
+
+The settings of autofit, which controls the output paths, parallelization, database use, etc.
+"""
+settings_search = af.SettingsSearch(
+    path_prefix=Path("interferometer") / "slam_linear_light_profiles",
+    unique_tag=dataset_name,
+    info=None,
+    session=None,
+)
+
+"""
+__Redshifts__
+
+The redshifts of the lens and source galaxies.
+"""
+redshift_lens = 0.5
+redshift_source = 1.0
+
+"""
+__Mesh Shape__
+
+As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before modeling.
+"""
+mesh_pixels_yx = 28
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+"""
+__SLaM Pipeline__
+
+The code below calls the full SLaM PIPELINE. See the documentation string above each Python function for a
+description of each pipeline step.
+
+Note the transformer split: `source_lp` is passed `dataset_nufft` (TransformerNUFFT), while every later
+stage is passed `dataset_dft_sparse` (TransformerDFT + sparse operator).
+"""
+source_lp_result = source_lp(
+    settings_search=settings_search,
+    dataset=dataset_nufft,
+    redshift_lens=redshift_lens,
+    redshift_source=redshift_source,
+)
+
+source_pix_result_1 = source_pix_1(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    mesh_init=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
+    regularization_init=al.reg.Adapt,
+    settings=settings,
+)
+
+source_pix_result_2 = source_pix_2(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    source_pix_result_1=source_pix_result_1,
+    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
+    regularization=al.reg.Adapt,
+    settings=settings,
+)
+
+mass_result = mass_total(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_pix_result_1=source_pix_result_1,
+    source_pix_result_2=source_pix_result_2,
+    settings=settings,
+)
+
+"""
+Finish.
+"""


### PR DESCRIPTION
## Summary

Adds `scripts/interferometer/features/linear_light_profiles/` mirroring the imaging-equivalent folder, plus a sanity sweep of the imaging versions that surfaced wrong-content sections from before the model was simplified.

Linear light profile fits to visibility data are now practical thanks to `nufftax` (https://github.com/GragasLab/nufftax) — the per-iteration NUFFT of each linear basis component runs inside the JAX jit/vmap pipeline alongside the rest of the model, so this used-to-be-slow approach is now fast enough for routine use.

Closes #162

## Scripts Changed

New scripts in `scripts/interferometer/features/linear_light_profiles/`:

- `__init__.py`, `README.md` — package + folder docs.
- `modeling.py` — full Nautilus model-fit using a linear `SersicCore` source, `Isothermal + ExternalShear` mass, `TransformerNUFFT`, `AnalysisInterferometer`.
- `fit.py` — single `FitInterferometer` call with known parameters, showing how the inversion solves for the source `intensity` and how to access it via `linear_light_profile_intensity_dict`.
- `likelihood_function.py` — step-by-step walkthrough of the visibility-plane linear inversion: ray-trace → source-plane image → `mapping_matrix` → NUFFT → `transformed_mapping_matrix` → `D` and `F` → solve → visibility-plane chi-squared. By-hand `figure_of_merit` reproduces `FitInterferometer.figure_of_merit` to 4-5 decimal places.
- `slam.py` — SLaM pipeline (SOURCE LP → SOURCE PIX 1 → SOURCE PIX 2 → MASS TOTAL) using a linear `SersicCore` source in the SOURCE LP stage. SOURCE LP runs on `TransformerNUFFT`; the pixelized stages switch to `TransformerDFT` + sparse operator.

Sweep of existing `scripts/imaging/features/linear_light_profiles/`:

- `modeling.py` — rewrite the "Linear Objects (Internal Source Code)" section to describe the actual model (`Sersic` lens + `SersicCore` source) instead of a now-stale `Basis`/5-Gaussians model; fix `start.here.py` → `start_here.py`, `RectnagularMapper` → `RectangularMapper`, "10000 per free parameter" → "10000 likelihood evaluations per free parameter", `Althought` → `Although`, `algabra` → `algebra`, `non-negligable` → `non-negligible`, broken backtick on the Basis list item, "lens galaxly's" → "lens galaxy's".
- `fit.py` — the same typos.
- `likelihood_function.py` — fix the bulge/disk-vs-lens/source wording confusion (the model is lens + source, not bulge + disk of one galaxy), rename `image_2d_bulge`/`image_2d_disk` to `image_2d_lens_bulge` / `image_2d_source_bulge`, point the second `print(image_2d_bulge.slim)` at the source-bulge variable, remove the misleading "this will raise an exception" block that no longer raised anything.

## Test Plan

- [x] Smoke tests pass for all 4 new interferometer scripts (modeling, fit, likelihood_function, slam) via `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_FAST_PLOTS=1`.
- [x] `likelihood_function.py` by-hand `figure_of_merit` matches `FitInterferometer.figure_of_merit` to 4-5 decimal places.
- [x] SLaM pipeline completes all 4 stages (SOURCE LP, SOURCE PIX 1, SOURCE PIX 2, MASS TOTAL) in `PYAUTO_TEST_MODE=2`.
- [x] `scripts/check_sizes.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)