### PR TITLE
feat: add interferometer multi_gaussian_expansion feature scripts

### DIFF
--- a/scripts/imaging/features/multi_gaussian_expansion/fit.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/fit.py
@@ -51,7 +51,7 @@ times (although the simpler non-linear parameter space will speed up the fit ove
 
 __Positive Only Solver__
 
-Many codes which use linear algebra typically rely on a linear algabra solver which allows for positive and negative
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and negative
 values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
 
 This is problematic, as it means that negative surface brightnesses values can be computed to represent a galaxy's
@@ -88,7 +88,7 @@ __Model__
 
 This script fits an `Imaging` dataset of a 'galaxy-scale' strong lens with a model where:
 
- - The lens galaxy's bulge is a super position of 60 `Gaussian`` profiles.
+ - The lens galaxy's bulge is a super position of 60 `Gaussian` profiles.
  - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
  - The source galaxy's light is a Multi Gaussian Expansion.
 

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -153,7 +153,7 @@ image = tracer.image_2d_from(grid=masked_dataset.grids.lp)
 """
 __Multiple Gaussians & Linear Light Profiles__
 
-To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the `lp_Linear`
+To use a linear light profile, whose `intensity` is computed via linear algebra, we simply use the `lp_linear`
 module instead of the `lp` module used throughout other example scripts. 
 
 The `intensity` parameter of the light profile is no longer passed into the light profiles created via the

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -6,7 +6,7 @@ A multi Gaussian expansion (MGE) decomposes the lens light into ~15-100 Gaussian
 Gaussian is solved for via a linear algebra using a process called an "inversion" (see the `linear_light_profiles.py`
 feature for a full description of this).
 
-This script peforms lensing modeling using a lens light model which uses an MGE consisting of 60 Gaussians. It is
+This script performs lensing modeling using a lens light model which uses an MGE consisting of 60 Gaussians. It is
 fitted to simulated data where the lens galaxy's light has asymmetric and irregular features, which fitted poorly by symmetric light
 profiles like the `Sersic`.
 
@@ -54,7 +54,7 @@ times (although the simpler non-linear parameter space will speed up the fit ove
 
 __Positive Only Solver__
 
-Many codes which use linear algebra typically rely on a linear algabra solver which allows for positive and negative
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and negative
 values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
 
 This is problematic, as it means that negative surface brightnesses values can be computed to represent a galaxy's
@@ -91,7 +91,7 @@ __Model__
 
 This script fits an `Imaging` dataset of a 'galaxy-scale' strong lens with a model where:
 
- - The lens galaxy's bulge is a super position of 60 `Gaussian`` profiles.
+ - The lens galaxy's bulge is a super position of 60 `Gaussian` profiles.
  - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
  - The source galaxy's light is a linear `SersicCore`.
 
@@ -193,7 +193,7 @@ We compose a lens model where:
 The number of free parameters and therefore the dimensionality of non-linear parameter space is N=19.
 
 Unlike the examples above, our MGE now comprises 2 * 30 Gaussians (instead of 1 * 30). Each group of 30
-have their own elliptical components meaning the lens's light is descomposed into two distinct elliptical components,
+have their own elliptical components meaning the lens's light is decomposed into two distinct elliptical components,
 which could be viewed as a bulge and disk.
 
 Note that above we combine the MGE for the lens light with a linear light profile for the source, meaning these two
@@ -270,7 +270,7 @@ print(model.info)
 """
 __Search__
 
-The model is fitted to the data using the nested sampling algorithm Nautilus (see `start.here.py` for a 
+The model is fitted to the data using the nested sampling algorithm Nautilus (see `start_here.py` for a
 full description).
 
 Owing to the simplicity of fitting an MGE we an use even fewer live points than other examples, reducing it to

--- a/scripts/interferometer/features/multi_gaussian_expansion/README.md
+++ b/scripts/interferometer/features/multi_gaussian_expansion/README.md
@@ -1,0 +1,38 @@
+The `multi_gaussian_expansion` folder contains example scripts showing how to fit `Interferometer` data
+using a **multi-Gaussian expansion (MGE)** — a decomposition of a galaxy's light into many linear Gaussian
+components whose `intensity` values are solved for analytically via a linear inversion.
+
+A key difference vs the imaging MGE examples: those fit the *lens* galaxy's complex morphology with the MGE.
+For interferometer data the lens light is omitted (no detection in mm/sub-mm), so the MGE is instead
+applied to the **source** galaxy. The MGE source captures the asymmetric morphology of typical
+sub-mm/radio-selected lensed sources better than a single Sersic, while keeping the non-linear parameter
+space small (only Gaussian centres and ellipticities are free).
+
+This used to be impractical because every likelihood evaluation had to NUFFT each of the ~15-100 Gaussians
+in the basis, and prior NUFFT backends were not JAX-friendly. With nufftax
+(https://github.com/GragasLab/nufftax) the full MGE basis is transformed inside the same jit/vmap pipeline
+as the rest of the model, so MGE fits to visibilities are now routine even at ALMA-class visibility counts.
+
+# Files
+
+- `modeling`: Lens modeling of an `Interferometer` dataset with an MGE source bulge built from 30
+  linear `Gaussian` profiles arranged in two groups of 15 (each group shares a centre and ell_comps;
+  sigmas are fixed to log-spaced values).
+- `fit`: Fit a known-parameter MGE source and inspect the per-Gaussian solved-for `intensity` values.
+- `likelihood_function`: Step-by-step walkthrough of the visibility-plane MGE linear inversion — each
+  Gaussian is one column of the real-space mapping matrix, NUFFT'd to the uv-plane, then the standard
+  `D`/`F` solve over the joint complex visibility data.
+- `slam`: SLaM pipeline (SOURCE LP → SOURCE PIX 1 → SOURCE PIX 2 → MASS TOTAL) using an MGE source in
+  the SOURCE LP stage via `al.model_util.mge_model_from`. SOURCE LP runs on `TransformerNUFFT`; the
+  pixelized stages switch to `TransformerDFT` + sparse operator.
+
+# Results
+
+These scripts only give a brief overview of how to analyse and interpret the results of a lens model fit.
+
+A full guide to result analysis is given at `autolens_workspace/*/guides/results`.
+
+# Imaging Equivalent
+
+For the CCD-imaging version of these scripts (MGE on the lens galaxy, not the source), see
+`autolens_workspace/scripts/imaging/features/multi_gaussian_expansion`.

--- a/scripts/interferometer/features/multi_gaussian_expansion/fit.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/fit.py
@@ -1,0 +1,227 @@
+"""
+Modeling Features: Multi Gaussian Expansion Fit (Interferometer)
+=================================================================
+
+A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity`
+of every Gaussian is solved for via linear algebra using a process called an "inversion".
+
+This script illustrates how to perform a single `FitInterferometer` of an MGE source model — that is, not
+the full Nautilus model-fit, but a single likelihood evaluation given known basis parameters. This is
+useful for understanding how the inversion produces the per-Gaussian solved-for `intensity` values, and
+how to extract them from the resulting fit.
+
+**Role swap vs the imaging MGE example:** the imaging script fits the *lens* galaxy's complex morphology
+with the MGE. For interferometer data the lens light is omitted (no detection in mm/sub-mm), so the MGE is
+instead applied to the *source* galaxy.
+
+For an explanation of why MGE fits to visibility data are now practical thanks to the JAX-native NUFFT
+`nufftax` (https://github.com/GragasLab/nufftax), see the companion `modeling.py` example.
+
+__Contents__
+
+- **Advantages & Disadvantages:** Benefits and drawbacks of an MGE source for interferometer data.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** The lens model whose `intensity` values we solve for via inversion — `Isothermal +
+  ExternalShear` mass with a 30-Gaussian MGE source bulge.
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load the strong lens `Interferometer` dataset using `TransformerNUFFT` (backed by `nufftax`).
+- **Basis:** Build the linear Gaussian basis used as the source bulge.
+- **Fit:** Perform a single `FitInterferometer` and inspect the inversion.
+- **Intensities:** Extract the per-Gaussian solved-for `intensity` values via
+  `fit.linear_light_profile_intensity_dict`.
+- **Visualization:** Build the helper tracer where linear light profiles are replaced with ordinary light
+  profiles carrying their solved-for `intensity`, then plot.
+- **Wrap Up:** Summary of the script and next steps.
+
+__Positive Only Solver__
+
+**PyAutoLens** uses a positive only linear algebra solver for the MGE inversion which has been extensively
+optimized to ensure it is as fast as positive-negative solvers. This ensures that all Gaussian intensities
+are positive and therefore physical — without it, an unconstrained MGE inversion can produce a
+positive-negative "ringing" pattern across the basis.
+
+__Model__
+
+This script fits an `Interferometer` dataset of a 'galaxy-scale' strong lens with a model where:
+
+ - The lens galaxy's light is omitted (and is not present in the simulated data). Interferometer
+   convention.
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
+ - The source galaxy's bulge is a multi-Gaussian expansion of 30 linear `Gaussian` profiles, all sharing
+   the same centre and `ell_comps`, with `sigma` values spanning 0.01" to the mask radius in log-spaced
+   increments.
+
+__Start Here Notebook__
+
+If any code in this script is unclear, refer to the `interferometer/start_here.ipynb` notebook.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import numpy as np
+from pathlib import Path
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, using `TransformerNUFFT`
+backed by `nufftax`.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Basis__
+
+We build a `Basis` of 30 linear `Gaussian` profiles, all sharing the same centre and `ell_comps`, with
+`sigma` values spanning 0.01" to the mask radius in log-spaced increments.
+
+We use linear light profile Gaussians (`lp_linear.Gaussian`), which solve for each Gaussian's `intensity`
+analytically via the inversion. This is essential for MGE — a wide range of positive `intensity` values
+are needed to decompose the source's morphology, and we cannot guess them by eye.
+
+Linear light profiles are described in detail in the `linear_light_profiles.py` example; you should
+familiarize yourself with that example before using the multi-Gaussian expansion.
+"""
+total_gaussians = 30
+
+# The sigma values of the Gaussians will be fixed to values spanning 0.01 to the mask radius.
+log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+bulge_gaussian_list = []
+for i in range(total_gaussians):
+    gaussian = al.lp_linear.Gaussian(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+        sigma=10 ** log10_sigma_list[i],
+    )
+    bulge_gaussian_list.append(gaussian)
+
+source_bulge = al.lp_basis.Basis(profile_list=bulge_gaussian_list)
+
+"""
+__Fit__
+
+We now illustrate the API for performing a single MGE fit using standard `Galaxy`, `Tracer` and
+`FitInterferometer` objects. Once we have a `Basis`, we can treat it like any other light profile.
+"""
+lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=1.6,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+    ),
+    shear=al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05),
+)
+
+source = al.Galaxy(
+    redshift=1.0,
+    bulge=source_bulge,
+)
+
+tracer = al.Tracer(galaxies=[lens, source])
+
+fit = al.FitInterferometer(dataset=dataset, tracer=tracer)
+
+"""
+The fit's `subplot_fit_interferometer` shows the visibility-plane fit and dirty-image residuals. Because
+the source bulge is a Basis of linear light profiles, the inversion has solved for each Gaussian's
+`intensity` to maximize the fit to the observed visibilities.
+"""
+aplt.subplot_fit_interferometer(fit=fit)
+
+"""
+The `subplot_fit_dirty_images` provides a real-space view of the data, model and residuals via inverse-NUFFT
+of the visibility-plane quantities. This is generally more interpretable to the human eye than the uv-plane
+plots above.
+"""
+aplt.subplot_fit_dirty_images(fit=fit)
+
+"""
+__Intensities__
+
+The fit contains the solved-for `intensity` value of every Gaussian in the MGE basis.
+
+These are computed via `fit.linear_light_profile_intensity_dict`, which maps each linear light profile in
+the model to its inferred `intensity`.
+
+The code below prints the first five Gaussian intensities for brevity — for an MGE of N Gaussians the full
+dict has N entries.
+"""
+print(fit.linear_light_profile_intensity_dict)
+
+for gaussian in bulge_gaussian_list[:5]:
+    print(
+        f"  sigma = {gaussian.sigma:.4f}  "
+        f"intensity = {fit.linear_light_profile_intensity_dict[gaussian]:.6e}"
+    )
+
+"""
+A `Tracer` where all linear light profile objects are replaced with ordinary light profiles using the
+solved-for `intensity` values is also accessible from a fit.
+
+The benefit of this helper-tracer is that it can be visualised (linear light profiles cannot be plotted by
+default because they do not have `intensity` values).
+"""
+tracer = fit.model_obj_linear_light_profiles_to_light_profiles
+
+"""
+__Visualization__
+
+Linear light profiles and objects containing them (e.g. galaxies, a tracer) cannot be plotted because they
+do not have an `intensity` value.
+
+The helper-tracer created above replaces every linear `Gaussian` with an ordinary `Gaussian` carrying its
+solved-for `intensity` — that tracer can be plotted directly.
+"""
+aplt.plot_array(array=tracer.image_2d_from(grid=dataset.grid), title="Tracer Image (MGE source)")
+
+
+"""
+__Wrap Up__
+
+Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+"""

--- a/scripts/interferometer/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/likelihood_function.py
@@ -1,0 +1,491 @@
+"""
+__Log Likelihood Function: Multi Gaussian Expansion (Interferometer)__
+
+This script provides a step-by-step guide of the `log_likelihood_function` which is used to fit
+`Interferometer` data with a multi-Gaussian expansion (MGE) source: a `Basis` of many linear `Gaussian`
+profiles whose `intensity` values are solved for analytically via a linear inversion.
+
+The visibility-plane linear inversion is **mathematically identical** to the single-component linear light
+profile case (see `interferometer/features/linear_light_profiles/likelihood_function.py`). The only
+difference is the number of columns in the mapping matrix — one column per Gaussian in the basis instead
+of one column total. The data vector `D` and curvature matrix `F` therefore have dimensions equal to the
+basis size, and the solved `s = F^{-1} D` gives one `intensity` per Gaussian.
+
+**Role swap vs the imaging MGE example:** the imaging script's basis is on the lens galaxy. Here it's on
+the source galaxy, because interferometer data does not contain lens light. The source bulge image is
+evaluated on the *ray-traced* source-plane grid; the rest of the inversion machinery is unchanged.
+
+For interferometer data this is now practical thanks to the JAX-native NUFFT `nufftax`
+(https://github.com/GragasLab/nufftax) — every Gaussian's NUFFT happens inside the same jit/vmap pipeline
+as the rest of the model, so the per-iteration NUFFT cost scales linearly with the basis size and is
+amortised on the GPU.
+
+__Prerequisites__
+
+The MGE likelihood function builds on:
+
+ - `interferometer/log_likelihood_function.ipynb` — the standard interferometer parametric likelihood
+   function (NUFFT of a real-space image, visibility-plane $\\chi^2$).
+ - `interferometer/features/linear_light_profiles/likelihood_function.ipynb` — the single-component
+   visibility-plane linear inversion (data vector, curvature matrix, positive-only solver). The MGE is
+   a direct generalisation to N-component bases.
+
+This script repeats just enough setup that you can follow it without rereading those two — but if anything
+is unclear, those are the places to look first.
+
+__Contents__
+
+- **Prerequisites:** Reading order before this script.
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load and plot the strong lens `Interferometer` dataset using `TransformerNUFFT` (nufftax).
+- **Lens Galaxy:** A mass-only lens galaxy (no light — interferometer convention).
+- **Source Galaxy MGE Basis:** Build the linear `Gaussian` basis used as the source bulge.
+- **Ray Tracing:** Image-plane to source-plane grid.
+- **Mapping Matrix:** Real-space mapping matrix — one column per Gaussian in the basis.
+- **Transformed Mapping Matrix ($f$):** NUFFT each column to give the visibility-space mapping matrix.
+- **Data Vector (D):** Compute $D$ from the transformed mapping matrix, visibilities, and noise map.
+- **Curvature Matrix (F):** Compute $F$ separately for real and imaginary components, then sum.
+- **Reconstruction (Positive-Negative):** Solve $s = F^{-1} D$ via NumPy.
+- **Reconstruction (Positive Only):** Solve with the fast non-negative least squares (`fnnls`) algorithm.
+- **Visibilities Reconstruction:** Map $s$ back to visibility space.
+- **Likelihood Function:** Visibility-plane $\\chi^2$ and noise normalization.
+- **Chi Squared:** Sum chi-squared contributions over real and imaginary components.
+- **Noise Normalization Term:** The fixed noise normalization term.
+- **Calculate The Log Likelihood:** Combine into the final log likelihood.
+- **Fit:** Cross-check via `FitInterferometer`.
+- **Lens Modeling:** How this likelihood is sampled in the full Nautilus fit.
+- **Wrap Up:** Summary and next steps.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files using `TransformerNUFFT`
+backed by `nufftax`.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Lens Galaxy__
+
+For interferometer data the lens galaxy's optical/IR emission is typically below detection, so we model
+only its mass:
+"""
+mass = al.mp.Isothermal(
+    centre=(0.0, 0.0),
+    einstein_radius=1.6,
+    ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+)
+
+shear = al.mp.ExternalShear(gamma_1=0.05, gamma_2=0.05)
+
+lens_galaxy = al.Galaxy(redshift=0.5, mass=mass, shear=shear)
+
+"""
+__Source Galaxy MGE Basis__
+
+We build a `Basis` of 15 linear `Gaussian` profiles for the source bulge, all sharing the same centre and
+`ell_comps`, with `sigma` values spanning 0.01" to the mask radius in log-spaced increments.
+
+Each Gaussian is a linear light profile — its `intensity` is solved for analytically via the inversion
+below. Internally each linear profile carries `intensity=1.0`, which the inversion later rescales.
+"""
+total_gaussians = 15
+log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+bulge_gaussian_list = []
+for i in range(total_gaussians):
+    gaussian = al.lp_linear.Gaussian(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+        sigma=10 ** log10_sigma_list[i],
+    )
+    bulge_gaussian_list.append(gaussian)
+
+source_bulge = al.lp_basis.Basis(profile_list=bulge_gaussian_list)
+source_galaxy = al.Galaxy(redshift=1.0, bulge=source_bulge)
+
+"""
+__Ray Tracing__
+
+To perform lensing calculations we ray-trace every 2d (y,x) coordinate $\\theta$ from the image-plane to
+its (y,x) source-plane coordinate $\\beta$ using the summed deflection angles $\\alpha$ of the mass
+profiles:
+
+ $\\beta = \\theta - \\alpha(\\theta)$
+
+For interferometer data the only grid we need to ray-trace is the real-space grid associated with the
+`real_space_mask`.
+"""
+tracer = al.Tracer(galaxies=[lens_galaxy, source_galaxy])
+
+# A list of every grid (e.g. image-plane, source-plane); we only need the source-plane grid (index -1).
+traced_grid = tracer.traced_grid_2d_list_from(grid=dataset.grids.lp)[-1]
+
+aplt.plot_grid(grid=traced_grid, title="Traced Source-Plane Grid")
+
+"""
+__Mapping Matrix__
+
+For interferometer MGE modeling, the mapping matrix has one column per Gaussian in the basis. Each column
+holds the real-space image of one Gaussian, evaluated on the ray-traced source-plane grid with
+`intensity=1.0` internally. The lensing is already baked in because we evaluated on the traced grid.
+
+The dimensions are `(total_real_space_pixels, total_gaussians)`.
+"""
+lp_linear_func_source = al.LightProfileLinearObjFuncList(
+    grid=traced_grid,
+    blurring_grid=None,
+    psf=None,
+    light_profile_list=bulge_gaussian_list,
+    regularization=None,
+)
+
+mapping_matrix = lp_linear_func_source.mapping_matrix
+
+print("Mapping matrix shape (real-space pixels, total Gaussians):")
+print(mapping_matrix.shape)
+
+"""
+A 2D plot of the `mapping_matrix` shows each Gaussian's lensed source-plane image as one column.
+"""
+plt.imshow(mapping_matrix, aspect=(mapping_matrix.shape[1] / mapping_matrix.shape[0]))
+plt.colorbar()
+plt.title("Real-space mapping matrix — one column per Gaussian")
+plt.show()
+plt.close()
+
+"""
+__Transformed Mapping Matrix ($f$)__
+
+Every column of the real-space `mapping_matrix` must be NUFFT'd to the uv-plane. The result is the
+`transformed_mapping_matrix` — a *complex-valued* matrix with dimensions
+`(total_visibilities, total_gaussians)`.
+
+For an N-Gaussian MGE this matrix has N columns. The inversion's job is to find the N scalars that, when
+multiplied by their respective columns and summed, best fit the observed visibilities.
+
+This NUFFT-each-column operation is exactly what nufftax made fast. The whole pipeline (ray-trace →
+source-plane Gaussian images → `transform_mapping_matrix` → linear inversion) is JIT-compilable under JAX.
+"""
+transformed_mapping_matrix = dataset.transformer.transform_mapping_matrix(
+    mapping_matrix=mapping_matrix
+)
+
+print("Transformed mapping matrix shape (visibilities, total Gaussians):")
+print(transformed_mapping_matrix.shape)
+
+"""
+Plot the real and imaginary components of the transformed mapping matrix. Each row is one observed
+visibility; the values across that row are the per-unit-intensity contributions of each Gaussian at that
+uv point.
+"""
+plt.imshow(
+    transformed_mapping_matrix.real,
+    aspect=(transformed_mapping_matrix.shape[1] / transformed_mapping_matrix.shape[0]),
+)
+plt.colorbar()
+plt.title("Re(f) — real component of transformed mapping matrix")
+plt.show()
+plt.close()
+
+plt.imshow(
+    transformed_mapping_matrix.imag,
+    aspect=(transformed_mapping_matrix.shape[1] / transformed_mapping_matrix.shape[0]),
+)
+plt.colorbar()
+plt.title("Im(f) — imaginary component of transformed mapping matrix")
+plt.show()
+plt.close()
+
+"""
+Warren & Dye 2003 (https://arxiv.org/abs/astro-ph/0302587) (hereafter WD03) introduce the linear inversion
+formalism used to compute the intensity values of the linear light profiles. WD03 indexes the transformed
+mapping matrix as $f_{ij}$ where $i$ maps over all $I$ linear basis components and $j$ maps over all $J$
+visibilities. For our MGE, $I = $ `total_gaussians`.
+
+The indexing of the `transformed_mapping_matrix` array is reversed compared to the WD03 convention (rows
+are visibilities, columns are basis components).
+
+__Data Vector (D)__
+
+To solve for the per-Gaussian intensities we pose the problem as a linear inversion.
+
+The `data_vector`, $D$, has dimensions `(total_gaussians,)`. In WD03 the data vector is given by:
+
+ $\\vec{D}_{i} = \\sum_{\\rm  j=1}^{J} f_{ij}\\, d_{j} / \\sigma_{j}^2 \\, ,$
+
+where $d_j$ are the observed visibility values, $\\sigma_j^2$ are the visibility variances, and the sum
+runs over real and imaginary components. The interferometer helper handles the real/imaginary split
+internally.
+"""
+data_vector = (
+    al.util.inversion_interferometer.data_vector_via_transformed_mapping_matrix_from(
+        transformed_mapping_matrix=transformed_mapping_matrix,
+        visibilities=dataset.data,
+        noise_map=dataset.noise_map,
+    )
+)
+
+print("Data Vector D shape:")
+print(data_vector.shape)
+
+"""
+__Curvature Matrix (F)__
+
+The `curvature_matrix` $F$ has dimensions `(total_gaussians, total_gaussians)`.
+
+In WD03 the curvature matrix is given by:
+
+ ${F}_{ik} = \\sum_{\\rm  j=1}^{J} f_{ij}\\, f_{kj} / \\sigma_{j}^2 \\, .$
+
+Because visibilities (and therefore $f$) are complex-valued, the curvature is computed separately for the
+real and imaginary parts and summed.
+
+For an N-Gaussian MGE $F$ is an NxN matrix; the off-diagonal entries $F_{ik}$ quantify how much Gaussians
+$i$ and $k$ overlap in the visibility plane. Adjacent Gaussians (similar sigma) have large overlaps; very
+different sigmas overlap less.
+"""
+real_curvature_matrix = al.util.inversion.curvature_matrix_via_mapping_matrix_from(
+    mapping_matrix=transformed_mapping_matrix.real,
+    noise_map=dataset.noise_map.real,
+)
+
+imag_curvature_matrix = al.util.inversion.curvature_matrix_via_mapping_matrix_from(
+    mapping_matrix=transformed_mapping_matrix.imag,
+    noise_map=dataset.noise_map.imag,
+)
+
+curvature_matrix = np.add(real_curvature_matrix, imag_curvature_matrix)
+
+print("Curvature Matrix F shape:")
+print(curvature_matrix.shape)
+
+plt.imshow(curvature_matrix)
+plt.colorbar()
+plt.title("Curvature Matrix F")
+plt.show()
+plt.close()
+
+"""
+__Reconstruction (Positive-Negative)__
+
+The chi-squared minimised by the inversion is:
+
+$\\chi^2 = \\sum_{\\rm  j=1}^{J} \\bigg[ \\frac{(\\sum_{\\rm  i=1}^{I} s_{i} f_{ij}) - d_{j}}{\\sigma_{j}} \\bigg]^2$
+
+Where $s_i$ is the solved-for `intensity` of the $i$-th Gaussian. The solution is given by (equation 5
+WD03):
+
+ $s = F^{-1} D$
+
+For an MGE this often returns negative `intensity` values for some Gaussians — the "ringing" pattern
+where alternating Gaussians take large positive/negative values. This is unphysical.
+"""
+reconstruction_positive_negative = np.linalg.solve(curvature_matrix, data_vector)
+
+print("Reconstruction s (positive-negative solver, first 5):")
+print(reconstruction_positive_negative[:5])
+print(f"  number of negative entries: {(reconstruction_positive_negative < 0).sum()} / {total_gaussians}")
+
+"""
+__Reconstruction (Positive Only)__
+
+The linear algebra can be solved with the constraint that all `intensity` values are positive. The naive
+approach is `scipy.optimize.nnls`, which is iterative and works directly on the transformed mapping matrix
+— slow for many Gaussians.
+
+The source code therefore uses a "fast nnls" algorithm — an adaptation of:
+  https://github.com/jvendrow/fnnls
+
+`fnnls` uses `data_vector` $D$ and `curvature_matrix` $F$ (not the full mapping matrix), which makes it
+much faster than scipy's nnls. This is essential for MGE because the basis size can be large.
+"""
+reconstruction = al.util.inversion.reconstruction_positive_only_from(
+    data_vector=data_vector,
+    curvature_reg_matrix=curvature_matrix,  # ignore the _reg_ tag in this guide
+)
+
+print("Reconstruction s (positive-only solver, first 5):")
+print(reconstruction[:5])
+print(f"  number of zero entries: {(reconstruction == 0).sum()} / {total_gaussians}")
+
+"""
+__Visibilities Reconstruction__
+
+Using the reconstructed `intensity` values we can map the reconstruction back to the visibility plane via
+the `transformed_mapping_matrix`, producing the model visibilities.
+
+This sums the per-Gaussian visibility-plane contributions weighted by their solved-for intensities.
+"""
+mapped_reconstructed_visibilities = (
+    al.util.inversion_interferometer.mapped_reconstructed_visibilities_from(
+        transformed_mapping_matrix=transformed_mapping_matrix,
+        reconstruction=reconstruction,
+    )
+)
+
+mapped_reconstructed_visibilities = al.Visibilities(
+    visibilities=mapped_reconstructed_visibilities
+)
+
+aplt.plot_grid(grid=mapped_reconstructed_visibilities.in_grid, title="Model Visibilities (MGE source)")
+
+
+"""
+__Likelihood Function__
+
+We now quantify the goodness-of-fit of our MGE source reconstruction.
+
+The likelihood function for parametric galaxy modeling, even with linear light profile bases, consists of
+two terms in the visibility plane:
+
+ $-2 \\mathrm{ln} \\, \\epsilon = \\chi^2 + \\sum_{\\rm  j=1}^{J} { \\mathrm{ln}} \\left [2 \\pi (\\sigma_j)^2 \\right]  \\, .$
+
+(Note: for a *pixelization* there are additional regularisation terms. The MGE inversion does not use
+regularisation — its smoothness comes from the basis-function form, not from a regularisation matrix.)
+
+__Chi Squared__
+
+The first term is a $\\chi^2$ statistic computed in the visibility plane:
+
+ - `model_data` = `mapped_reconstructed_visibilities`
+ - `residual_map` = (`data` - `model_data`)
+ - `normalized_residual_map` = (`data` - `model_data`) / `noise_map`
+ - `chi_squared_map` = `normalized_residual_map` ** 2.0
+ - `chi_squared` = sum(`chi_squared_map`)
+
+Visibilities are complex-valued, so we split into real and imaginary components, compute $\\chi^2$ for
+each, and sum.
+"""
+model_visibilities = mapped_reconstructed_visibilities
+
+residual_map = dataset.data - model_visibilities
+
+chi_squared_map_real = (residual_map.real / dataset.noise_map.real) ** 2
+chi_squared_map_imag = (residual_map.imag / dataset.noise_map.imag) ** 2
+
+chi_squared_real = np.sum(chi_squared_map_real)
+chi_squared_imag = np.sum(chi_squared_map_imag)
+chi_squared = chi_squared_real + chi_squared_imag
+
+print(f"chi_squared (real + imag) = {chi_squared}")
+
+"""
+__Noise Normalization Term__
+
+The likelihood function assumes the visibility data consists of independent Gaussian noise on every
+visibility (real and imaginary parts treated independently).
+"""
+noise_normalization_real = float(np.sum(np.log(2 * np.pi * dataset.noise_map.real ** 2.0)))
+noise_normalization_imag = float(np.sum(np.log(2 * np.pi * dataset.noise_map.imag ** 2.0)))
+noise_normalization = noise_normalization_real + noise_normalization_imag
+
+"""
+__Calculate The Log Likelihood__
+
+Combine the two terms to compute the `log_likelihood`:
+"""
+figure_of_merit = float(-0.5 * (chi_squared + noise_normalization))
+
+print(f"log_likelihood (figure of merit) = {figure_of_merit}")
+
+
+"""
+__Fit__
+
+The exact same likelihood evaluation is performed inside the `FitInterferometer` object. We construct one,
+print its `figure_of_merit`, and confirm it matches the value we computed by hand above.
+"""
+fit = al.FitInterferometer(dataset=dataset, tracer=tracer)
+print(f"FitInterferometer.figure_of_merit = {fit.figure_of_merit}")
+
+aplt.subplot_fit_interferometer(fit=fit)
+
+"""
+The fit contains an `Inversion` object, which handles all the linear algebra we have covered in this
+script.
+"""
+print(fit.inversion)
+print(f"data_vector shape:    {fit.inversion.data_vector.shape}")
+print(f"curvature_matrix shape: {fit.inversion.curvature_matrix.shape}")
+print(f"reconstruction shape:   {fit.inversion.reconstruction.shape}")
+
+"""
+__Lens Modeling__
+
+To fit a lens model to data, the likelihood function illustrated in this tutorial is sampled using a
+non-linear search algorithm.
+
+The default sampler is the nested sampling algorithm `nautilus`
+(https://github.com/johannesulf/nautilus); multiple MCMC and optimization algorithms are also supported.
+
+For an MGE source, the reduced number of free parameters (intensities are solved analytically, sigmas are
+fixed, centres and ell_comps are shared) means that the sampler converges in fewer iterations than a
+free-intensity Sersic source — even though each likelihood evaluation is slower per-iteration because of
+the larger basis.
+
+__Wrap Up__
+
+We have presented a visual step-by-step guide to the multi-Gaussian expansion interferometer likelihood
+function. The pipeline:
+
+  ray-trace → source-plane Gaussian images (intensity=1 each) → `mapping_matrix` (N columns)
+  → NUFFT → `transformed_mapping_matrix` → $D$ (length N) and $F$ (NxN) → solve $s = F^{-1} D$
+  → `mapped_reconstructed_visibilities` → visibility-plane $\\chi^2$ → log likelihood
+
+is the same as for the single-component linear light profile case
+(`features/linear_light_profiles/likelihood_function.py`), just generalised to N basis components. The
+NUFFT is the operation that nufftax made fast on the GPU, which is why this entire workflow is now
+practical even for large MGE bases on visibility data.
+"""

--- a/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
@@ -1,0 +1,358 @@
+"""
+Modeling Features: Multi Gaussian Expansion (Interferometer)
+=============================================================
+
+A multi-Gaussian expansion (MGE) decomposes a galaxy's light into ~15-100 Gaussians, where the `intensity` of
+every Gaussian is solved for via linear algebra using a process called an "inversion" (see the
+`linear_light_profiles` feature for a full description of this).
+
+This script performs lens modeling of an `Interferometer` dataset using an MGE source bulge consisting of
+30 Gaussians arranged in two groups of 15. Each group has its own elliptical components, so the source's
+light is decomposed into two distinct elliptical components — which could be viewed as a bulge and a disk
+of the source galaxy.
+
+**Role swap vs the imaging MGE example:** the imaging script fits the *lens* galaxy's complex morphology
+with an MGE. For interferometer data the lens light is omitted (no detection in mm/sub-mm), so the MGE is
+instead applied to the *source* galaxy. This is the standard convention for interferometer modeling.
+
+MGE fits to interferometer data were previously impractical because every likelihood evaluation has to
+Fourier-transform each Gaussian basis component into the uv-plane. With `nufftax`
+(https://github.com/GragasLab/nufftax) — a JAX-native NUFFT — the full basis is transformed inside the same
+jit/vmap pipeline as the rest of the model, amortising the per-iteration NUFFT cost on the GPU. MGE source
+fits are now routine even at ALMA-class visibility counts.
+
+__Contents__
+
+- **Advantages & Disadvantages:** Benefits and drawbacks of an MGE source for interferometer data.
+- **NUFFT (nufftax):** Why MGE-on-visibilities is now practical thanks to nufftax.
+- **Positive Only Solver:** Ensuring positive-only solutions for linear light profile intensities.
+- **Model:** Compose the lens model — `Isothermal` + `ExternalShear` lens mass and a 30-Gaussian MGE
+  source bulge. Lens light omitted (interferometer convention).
+- **Mask:** Define the `real_space_mask` which sets the grid the strong lens is evaluated on.
+- **Dataset:** Load the strong lens `Interferometer` dataset using `TransformerNUFFT` (backed by `nufftax`).
+- **Over Sampling:** Interferometer modeling does not use over-sampling.
+- **Search:** Configure the non-linear search (Nautilus).
+- **Analysis:** Create the `AnalysisInterferometer` object.
+- **VRAM:** Memory budget for a multi-component linear basis on GPU.
+- **Run Time:** Profiling the expected run time of the model-fit.
+- **Result:** Overview of the results of the model-fit.
+- **Wrap Up:** Summary of the script and next steps.
+
+__Advantages__
+
+Symmetric light profiles (e.g. elliptical Sersics) may leave significant residuals when fitting the source
+galaxy of a strong lens — they fail to capture irregular and asymmetric morphology (e.g. isophotal twists,
+multi-component source emission). An MGE fully captures these features and can therefore much better
+represent the emission of complex source galaxies.
+
+The MGE model is composed such that the `intensity` parameters and the `sigma` parameters controlling the
+Gaussian sizes are *not* sampled by Nautilus. Centres and elliptical components are shared across each
+group of Gaussians. This removes the most significant degeneracies in parameter space, making the model
+much more reliable and efficient to fit than a free-intensity Sersic.
+
+Therefore, not only does an MGE source fit more complex source morphologies, it does so using fewer
+non-linear parameters in a much simpler non-linear parameter space which has far less significant parameter
+degeneracies.
+
+__Disadvantages__
+
+To fit an MGE model, the light of the ~15-100 Gaussians must be evaluated and NUFFT'd to the uv-plane per
+likelihood evaluation. This is slower than evaluating a single `SersicCore`. With `nufftax` the per-NUFFT
+cost is small enough that the total slow-down per likelihood evaluation is typically 2-5x for a 30-Gaussian
+MGE — paid back in fewer iterations because the parameter space is simpler.
+
+The MGE source can also be less intuitive to interpret physically than a Sersic. The Sersic `effective_radius`
+and `sersic_index` map directly to galaxy size and concentration; an MGE's solved-for Gaussian intensities
+require an extra processing step to compute equivalent physical quantities.
+
+__NUFFT (nufftax)__
+
+The image-to-visibilities Fourier transform is performed by a Non-Uniform Fast Fourier Transform (NUFFT),
+exposed in **PyAutoLens** as `TransformerNUFFT`. The default backend is `nufftax`, a pure-JAX NUFFT that
+jit-compiles and vmap-batches like the rest of the library:
+
+  https://github.com/GragasLab/nufftax
+
+Because `nufftax` is JAX-native, NUFFT-ing every Gaussian in the MGE basis happens inside the same compiled
+likelihood that does the inversion, mass model ray-tracing, and chi-squared sum. There is no host round-trip
+between NUFFT calls, so a model with N Gaussians costs only N forward-NUFFTs per iteration on the GPU —
+fast enough that MGE-on-visibilities is now routinely practical.
+
+If `nufftax` is not installed, install it via `pip install nufftax`.
+
+__Positive Only Solver__
+
+Many codes which use linear algebra typically rely on a linear algebra solver which allows for positive and
+negative values of the solution (e.g. `np.linalg.solve`), because they are computationally fast.
+
+This is problematic, as it means that negative surface brightnesses values can be computed to represent a
+galaxy's light, which is clearly unphysical. For an MGE, this produces a positive-negative "ringing", where
+the Gaussians alternate between large positive and negative values. This is clearly undesirable and
+unphysical.
+
+**PyAutoLens** uses a positive only linear algebra solver which has been extensively optimized to ensure it
+is as fast as positive-negative solvers. This ensures that all Gaussian intensities are positive and
+therefore physical.
+
+__Model__
+
+This script fits an `Interferometer` dataset of a 'galaxy-scale' strong lens with a model where:
+
+ - The lens galaxy's light is omitted (and is not present in the simulated data). This is the standard
+   convention for interferometer modeling, as the lens galaxy's optical/IR emission is typically below the
+   detection threshold of mm/sub-mm interferometers.
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`.
+ - The source galaxy's bulge is a multi-Gaussian expansion of 30 linear `Gaussian` profiles, arranged in
+   two groups of 15 (each group shares a centre and ell_comps).
+
+__Start Here Notebook__
+
+If any code in this script is unclear, refer to the `interferometer/start_here.ipynb` notebook.
+
+__Imaging Equivalent__
+
+For the CCD-imaging version of this script (MGE on the lens galaxy, not the source), see
+`autolens_workspace/*/imaging/features/multi_gaussian_expansion/modeling.py`.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import numpy as np
+from pathlib import Path
+import autofit as af
+import autolens as al
+import autolens.plot as aplt
+
+"""
+__Mask__
+
+We define the `real_space_mask` which defines the grid the image of the strong lens is evaluated on.
+"""
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the strong lens `Interferometer` dataset `simple` from .fits files, which we will fit with
+the lens model.
+
+This includes the method used to Fourier transform the real-space image of the strong lens to the uv-plane
+and compare directly to the visibilities. We use `TransformerNUFFT`, the JAX-native Non-Uniform Fast Fourier
+Transform backed by `nufftax`, which is required for fast MGE modeling and scales efficiently from a few
+hundred visibilities to tens of millions.
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+aplt.subplot_interferometer_dirty_images(dataset=dataset)
+
+"""
+__Over Sampling__
+
+If you are familiar with using imaging data, you may have seen that a numerical technique called over
+sampling is used, which evaluates light profiles on a higher resolution grid than the image data to ensure
+the calculation is accurate.
+
+Interferometer data does not observe galaxies in a way where over sampling is necessary, therefore all
+interferometer calculations are performed without over sampling.
+
+__Model__
+
+We compose a lens model where:
+
+ - The lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear` [7 parameters].
+
+ - The source galaxy's bulge is 30 linear `Gaussian` profiles [6 parameters total].
+   - The centres and elliptical components of the Gaussians are linked together in two groups of 15.
+   - The `sigma` size of the Gaussians increases in log10 increments from 0.01 to the mask radius.
+
+The number of free parameters and therefore the dimensionality of non-linear parameter space is N=13.
+
+The MGE comprises 2 groups of 15 Gaussians. Each group has its own elliptical components, so the source's
+light is decomposed into two distinct elliptical components which could be viewed as a bulge and a disk of
+the source.
+
+__Model Cookbook__
+
+A full description of model composition is provided by the model cookbook:
+
+https://pyautolens.readthedocs.io/en/latest/general/model_cookbook.html
+"""
+total_gaussians = 15
+gaussian_per_basis = 2
+
+# The sigma values of the Gaussians will be fixed to values spanning 0.01 to the mask radius, 3.5".
+log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+# By defining the centre here, it creates two free parameters that are assigned below to all Gaussians.
+
+centre_0 = af.UniformPrior(lower_limit=-0.3, upper_limit=0.3)
+centre_1 = af.UniformPrior(lower_limit=-0.3, upper_limit=0.3)
+
+bulge_gaussian_list = []
+
+for j in range(gaussian_per_basis):
+    # A list of Gaussian model components whose parameters are customized below.
+
+    gaussian_list = af.Collection(
+        af.Model(al.lp_linear.Gaussian) for _ in range(total_gaussians)
+    )
+
+    # Iterate over every Gaussian and customize its parameters.
+
+    for i, gaussian in enumerate(gaussian_list):
+        gaussian.centre.centre_0 = centre_0  # All Gaussians have same y centre.
+        gaussian.centre.centre_1 = centre_1  # All Gaussians have same x centre.
+        gaussian.ell_comps = gaussian_list[0].ell_comps  # All Gaussians in this group share ell_comps.
+        gaussian.sigma = 10 ** log10_sigma_list[i]  # All Gaussian sigmas are fixed to values above.
+
+    bulge_gaussian_list += gaussian_list
+
+# The Basis object groups many light profiles together into a single model component.
+source_bulge = af.Model(al.lp_basis.Basis, profile_list=bulge_gaussian_list)
+
+# Lens:
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear)
+
+# Source:
+source = af.Model(al.Galaxy, redshift=1.0, bulge=source_bulge)
+
+# Overall Lens Model:
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format (if this does not display clearly on your screen
+refer to `start_here.ipynb` for a description of how to fix this).
+
+This shows every single Gaussian light profile in the model, which is a lot of parameters! However, the
+vast majority of these parameters are fixed to the values we set above, so the model actually has far fewer
+free parameters than it looks!
+"""
+print(model.info)
+
+"""
+__Search__
+
+The model is fitted to the data using the nested sampling algorithm Nautilus (see `start_here.py` for a
+full description).
+
+Owing to the simplicity of fitting an MGE (no intensity or sigma free parameters), we use fewer live points
+than the `interferometer/modeling.py` example: 75 live points speeds up convergence.
+"""
+search = af.Nautilus(
+    path_prefix=Path("interferometer") / "features",
+    name="mge",
+    unique_tag=dataset_name,
+    n_live=75,
+    n_batch=20,  # GPU lens model fits are batched and run simultaneously, see VRAM section below.
+)
+
+"""
+__Analysis__
+
+Create the `AnalysisInterferometer` object defining how Nautilus fits the model to the data.
+"""
+analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+"""
+__VRAM__
+
+The `interferometer/modeling.py` example explains how VRAM is used during GPU-based fitting and how to
+print the estimated VRAM required by a model.
+
+For each linear `Gaussian` profile, extra VRAM is used to store its NUFFT'd mapping matrix column. For
+around 30 linear Gaussians this typically requires a modest amount of VRAM (e.g. 10-50 MB per batched
+likelihood). Models that use hundreds of Gaussians, especially in combination with a large batch size, may
+therefore exceed GBs of VRAM and require you to adjust the batch size to fit within your GPU's VRAM.
+
+VRAM on interferometer datasets is driven primarily by the visibility count and the real-space mask size,
+not the number of Gaussians in the MGE basis.
+
+__Run Time__
+
+The likelihood evaluation time for an MGE is slower than a single linear `SersicCore` source, because the
+image of every Gaussian must be evaluated and NUFFT'd to the uv-plane. With `nufftax`, the per-NUFFT cost
+is small enough that the total slow-down per likelihood is typically 2-5x for a 30-Gaussian MGE compared
+to a one-component source — paid back in fewer iterations because the parameter space is simpler.
+
+Because the MGE has no free `intensity` or `sigma` parameters and shares centres/ell_comps across groups,
+Nautilus converges significantly faster than for a free-intensity Sersic source. We also use fewer live
+points (75 vs the 100 used in `interferometer/modeling.py`), further speeding up the model-fit.
+
+__Model-Fit__
+
+We begin the model-fit by passing the model and analysis object to the non-linear search (checkout the
+output folder for on-the-fly visualization and results).
+"""
+result = search.fit(model=model, analysis=analysis)
+
+"""
+__Result__
+
+The search returns a result object, which whose `info` attribute shows the result in a readable format (if
+this does not display clearly on your screen refer to `start_here.ipynb` for a description of how to fix
+this):
+
+This confirms there are many `Gaussian`s in the source light model and it lists their inferred parameters.
+"""
+print(result.info)
+
+"""
+We plot the maximum likelihood fit, tracer images and posteriors inferred via Nautilus.
+
+Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+
+In particular, checkout the results example `linear.py` which details how to extract all information about
+linear light profiles from a fit.
+"""
+print(result.max_log_likelihood_instance)
+
+aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.lp)
+
+aplt.subplot_fit_interferometer(fit=result.max_log_likelihood_fit)
+
+aplt.corner_anesthetic(samples=result.samples)
+
+"""
+__Wrap Up__
+
+Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
+
+To further showcase MGE source modeling, see the SLaM pipeline at
+`autolens_workspace/scripts/interferometer/features/multi_gaussian_expansion/slam.py`, which uses the
+`al.model_util.mge_model_from` helper to compose an MGE source in the SOURCE LP stage before chaining
+to a pixelized source reconstruction.
+"""

--- a/scripts/interferometer/features/multi_gaussian_expansion/slam.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/slam.py
@@ -1,0 +1,551 @@
+"""
+Multi Gaussian Expansion: SLaM (Interferometer)
+================================================
+
+This script provides an example of the Source, (Lens) Light, and Mass (SLaM) pipelines for `Interferometer`
+data, using a **multi-Gaussian expansion (MGE)** for the source galaxy in the SOURCE LP stage.
+
+A full overview of SLaM is provided in `guides/modeling/slam_start_here`. You should read that guide
+before working through this example.
+
+The interferometer pixelization SLaM pipeline at `interferometer/features/pixelization/slam.py` is the
+closest analogue — this script keeps the same pipeline structure (SOURCE LP → SOURCE PIX 1 → SOURCE PIX 2
+→ MASS TOTAL) and only differs in the size of the MGE source basis used in SOURCE LP. The LIGHT LP
+pipeline from `slam_start_here.py` is omitted because interferometer data does not contain lens light
+emission.
+
+The MGE captures the asymmetric morphology of typical sub-mm/radio-selected lensed sources better than a
+single `Sersic`, while keeping the non-linear parameter space small (only the shared Gaussian centre and
+elliptical components are free; the per-Gaussian intensities are solved analytically and the sigmas are
+fixed). This makes SOURCE LP fast, robust, and a better initialiser for the pixelized stages that follow.
+
+The SOURCE LP stage uses `TransformerNUFFT` (backed by JAX-native `nufftax`,
+https://github.com/GragasLab/nufftax). MGE fits to visibilities are practical at any visibility count
+because the per-iteration NUFFT of every Gaussian basis component runs inside the same compiled likelihood
+as the rest of the model.
+
+The SOURCE PIX and MASS TOTAL stages switch to `TransformerDFT` combined with the pre-computed sparse
+operator, because pixelized source reconstructions exploit sparsity rather than the NUFFT path.
+
+__Contents__
+
+- **Prerequisites:** Before using this SLaM pipeline, you should be familiar with `slam_start_here`.
+- **SOURCE LP PIPELINE:** Initializes the mass and source-light model with an MGE source bulge, fitted
+  via `TransformerNUFFT`.
+- **SOURCE PIX PIPELINE 1:** Initializes a pixelized source using the adapt image from the SOURCE LP
+  result.
+- **SOURCE PIX PIPELINE 2:** Improves the pixelized source using adapt images from `source_pix_result_1`.
+- **MASS TOTAL PIPELINE:** Identical to `slam_start_here.py`, except no lens light model is included.
+- **Two Datasets:** Build one Interferometer with `TransformerNUFFT` (source_lp) and one with
+  `TransformerDFT` + sparse operator (source_pix onwards).
+- **Sparse Operators:** Pre-compute the sparse operator for the pixelized stages.
+- **Settings:** Disable the positive-only solver so the pixelized source reconstruction can have negative
+  pixel values.
+- **Settings AutoFit:** The settings of autofit, which controls the output paths, parallelization,
+  database use, etc.
+- **Redshifts:** The redshifts of the lens and source galaxies.
+- **Mesh Shape:** As discussed in `features/pixelization/modeling`, the mesh shape is fixed before
+  modeling.
+- **SLaM Pipeline:** The code below calls the full SLaM PIPELINE.
+
+__Prerequisites__
+
+Before using this SLaM pipeline, you should be familiar with:
+
+- **SLaM Start Here** (`guides/modeling/slam_start_here`)
+  An introduction to the goals, structure, and design philosophy behind SLaM pipelines and how they
+  integrate into strong-lens modeling.
+
+- **Multi Gaussian Expansion** (`interferometer/features/multi_gaussian_expansion/modeling`)
+  How an MGE source basis is composed for interferometer data, and why nufftax makes large-N MGE bases
+  practical.
+
+- **Interferometer Pixelization SLaM** (`interferometer/features/pixelization/slam`)
+  The canonical interferometer SLaM pipeline. This script is essentially that pipeline with a larger MGE
+  source basis in SOURCE LP.
+
+__High Resolution Dataset__
+
+A high-resolution `uv_wavelengths` file for ALMA is available in a separate repository that hosts large
+files which are too big to include in the main `autolens_workspace` repository:
+
+  https://github.com/PyAutoLabs/autolens_workspace_large_files
+
+After downloading the file, place it in the directory:
+
+  `autolens_workspace/dataset/interferometer/alma`
+
+You can then perform modeling using this high-resolution dataset by uncommenting the relevant line of code
+below.
+"""
+
+from autoconf import jax_wrapper  # Sets JAX environment before other imports
+
+# from autoconf import setup_notebook; setup_notebook()
+
+import numpy as np
+from pathlib import Path
+import autofit as af
+import autolens as al
+import autolens.plot as aplt
+
+
+"""
+__SOURCE LP PIPELINE__
+
+The SOURCE LP PIPELINE uses one search to initialize a robust model for the source galaxy's light using a
+multi-Gaussian expansion (MGE). The lens galaxy mass and external shear are fitted at the same time.
+
+The MGE source is built via the `al.model_util.mge_model_from` helper, which constructs a basis of N
+linear `Gaussian` profiles arranged in two groups (each sharing a centre and ell_comps; sigmas fixed to
+log-spaced values). For interferometer data we use `total_gaussians=20`, which is enough to capture the
+source morphology while keeping per-iteration cost manageable.
+
+This stage uses the `dataset_nufft` Interferometer (built with `TransformerNUFFT`, backed by `nufftax`),
+which makes the per-iteration NUFFT of every Gaussian fast even for ALMA-class datasets with millions of
+visibilities.
+
+The mass and source models from this search initialize the SOURCE PIX PIPELINE searches that follow, and
+the result also provides the adapt image and position likelihood used by those later stages.
+
+Note that no lens light is fitted: interferometer data does not contain lens light emission, so
+`lens.bulge` and `lens.disk` are kept at `None`.
+"""
+
+
+def source_lp(
+    settings_search: af.SettingsSearch,
+    dataset,
+    mask_radius: float,
+    redshift_lens: float,
+    redshift_source: float,
+    n_batch: int = 50,
+) -> af.Result:
+    analysis = al.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+    source_bulge = al.model_util.mge_model_from(
+        mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
+    )
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=redshift_lens,
+                # interferometer data does not contain lens light emission
+                bulge=None,
+                disk=None,
+                mass=af.Model(al.mp.Isothermal),
+                shear=af.Model(al.mp.ExternalShear),
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=redshift_source,
+                bulge=source_bulge,
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_lp[1]",
+        **settings_search.search_dict,
+        n_live=200,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 1__
+
+The SOURCE PIX PIPELINE uses two searches to initialize a robust pixelized model of the source galaxy.
+
+The first search fits a pixelization whose purpose is to generate a high-quality adapt image used in
+search 2. It uses the adapt image computed from the SOURCE LP result and the position likelihood is also
+derived automatically from the SOURCE LP result — no manual positions input is required.
+
+This stage uses the `dataset_dft_sparse` Interferometer (built with `TransformerDFT` +
+`apply_sparse_operator`). Pixelizations do not use the NUFFT path; the sparse-operator + DFT combination
+is what keeps pixelized source reconstructions fast and VRAM-efficient on large datasets.
+"""
+
+
+def source_pix_1(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    mesh_init,
+    regularization_init,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_lp_result
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_lp_result.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=source_lp_result.model.galaxies.lens.mass,
+        mass_result=source_lp_result.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+    shear = source_lp_result.model.galaxies.lens.shear
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=mesh_init,
+                    regularization=regularization_init,
+                ),
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_pix[1]",
+        **settings_search.search_dict,
+        n_live=150,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__SOURCE PIX PIPELINE 2__
+
+Identical to `slam_start_here.py`, using adapt images from `source_pix_result_1` to improve the source
+pixelization and regularization.
+
+The LIGHT LP PIPELINE from `slam_start_here.py` is omitted here, as interferometer data does not contain
+lens light emission.
+
+Like SOURCE PIX PIPELINE 1, this stage uses the `dataset_dft_sparse` Interferometer.
+"""
+
+
+def source_pix_2(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_lp_result: af.Result,
+    source_pix_result_1: af.Result,
+    mesh,
+    regularization,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_pix_result_1, use_model_images=True
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+    )
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=source_pix_result_1.instance.galaxies.lens.mass,
+                shear=source_pix_result_1.instance.galaxies.lens.shear,
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=source_lp_result.instance.galaxies.source.redshift,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=mesh,
+                    regularization=regularization,
+                ),
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        name="source_pix[2]",
+        **settings_search.search_dict,
+        n_live=75,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__MASS TOTAL PIPELINE__
+
+Identical to `slam_start_here.py`, except no lens light model is included as interferometer data does not
+contain lens light emission.
+"""
+
+
+def mass_total(
+    settings_search: af.SettingsSearch,
+    dataset,
+    source_pix_result_1: af.Result,
+    source_pix_result_2: af.Result,
+    settings,
+    n_batch: int = 20,
+) -> af.Result:
+    # Total mass model for the lens galaxy.
+    mass = af.Model(al.mp.PowerLaw)
+
+    galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
+        result=source_pix_result_1, use_model_images=True
+    )
+
+    adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_image_name_dict)
+
+    analysis = al.AnalysisInterferometer(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=[
+            source_pix_result_1.positions_likelihood_from(
+                factor=3.0, minimum_threshold=0.2
+            )
+        ],
+        settings=settings,
+    )
+
+    mass = al.util.chaining.mass_from(
+        mass=mass,
+        mass_result=source_pix_result_1.model.galaxies.lens.mass,
+        unfix_mass_centre=True,
+    )
+
+    source = al.util.chaining.source_from(result=source_pix_result_2)
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=source_pix_result_1.instance.galaxies.lens.redshift,
+                bulge=None,
+                disk=None,
+                mass=mass,
+                shear=source_pix_result_1.model.galaxies.lens.shear,
+            ),
+            source=source,
+        ),
+    )
+
+    search = af.Nautilus(
+        name="mass_total[1]",
+        **settings_search.search_dict,
+        n_live=150,
+        n_batch=n_batch,
+    )
+
+    return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
+
+
+"""
+__Dataset + Masking__
+
+Load the `Interferometer` data and define the real-space mask.
+"""
+dataset_name = "simple"
+mask_radius = 3.5
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256), pixel_scales=0.1, radius=mask_radius
+)
+
+dataset_path = Path("dataset") / "interferometer" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+# dataset_name = "alma"
+#
+# if dataset_name == "alma":
+#
+#     real_space_mask = al.Mask2D.circular(
+#         shape_native=(800, 800),
+#         pixel_scales=0.01,
+#         radius=mask_radius,
+#     )
+
+
+"""
+__Two Datasets__
+
+The SLaM pipeline runs in two phases that prefer different transformers:
+
+- `dataset_nufft` uses `TransformerNUFFT` (backed by JAX-native `nufftax`) for the `source_lp` stage. With
+  an MGE source bulge this is the fast path at any visibility count, because each Gaussian's NUFFT runs
+  inside the same compiled likelihood.
+- `dataset_dft_sparse` uses `TransformerDFT` combined with `apply_sparse_operator(...)` for `source_pix_1`,
+  `source_pix_2`, and `mass_total`. Pixelized source reconstructions exploit sparsity in the linear
+  inversion rather than the NUFFT, so this combination is the right choice for the pixelized stages.
+
+Both datasets are built from the same FITS files; only the transformer (and sparse-operator preload)
+differ.
+"""
+dataset_nufft = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerNUFFT,
+)
+
+dataset_dft_sparse = al.Interferometer.from_fits(
+    data_path=dataset_path / "data.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+"""
+__Sparse Operators__
+
+The `pixelization/modeling` example describes how the sparse operator formalism speeds up interferometer
+pixelized source modeling, especially for many visibilities.
+
+We use a try / except to load the pre-computed curvature preload, which is necessary to use the sparse
+operator formalism. If this file does not exist it is made here.
+
+The sparse operator is applied only to `dataset_dft_sparse` — the NUFFT-backed `dataset_nufft` used by
+`source_lp` does not need it.
+"""
+try:
+    nufft_precision_operator = np.load(
+        file=dataset_path / "nufft_precision_operator.npy",
+    )
+except FileNotFoundError:
+    nufft_precision_operator = None
+
+dataset_dft_sparse = dataset_dft_sparse.apply_sparse_operator(
+    nufft_precision_operator=nufft_precision_operator, use_jax=True, show_progress=True
+)
+
+"""
+__Settings__
+
+Disable the default positive-only linear algebra solver so the pixelized source reconstruction can have
+negative pixel values. (The MGE source bulge in SOURCE LP is still constrained to positive intensities
+internally because each Gaussian's intensity is a physical normalization.)
+"""
+settings = al.Settings(use_positive_only_solver=False)
+
+"""
+__Settings AutoFit__
+
+The settings of autofit, which controls the output paths, parallelization, database use, etc.
+"""
+settings_search = af.SettingsSearch(
+    path_prefix=Path("interferometer") / "slam_multi_gaussian_expansion",
+    unique_tag=dataset_name,
+    info=None,
+    session=None,
+)
+
+"""
+__Redshifts__
+
+The redshifts of the lens and source galaxies.
+"""
+redshift_lens = 0.5
+redshift_source = 1.0
+
+"""
+__Mesh Shape__
+
+As discussed in the `features/pixelization/modeling` example, the mesh shape is fixed before modeling.
+"""
+mesh_pixels_yx = 28
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+"""
+__SLaM Pipeline__
+
+The code below calls the full SLaM PIPELINE. See the documentation string above each Python function for
+a description of each pipeline step.
+
+Note the transformer split: `source_lp` is passed `dataset_nufft` (TransformerNUFFT), while every later
+stage is passed `dataset_dft_sparse` (TransformerDFT + sparse operator).
+"""
+source_lp_result = source_lp(
+    settings_search=settings_search,
+    dataset=dataset_nufft,
+    mask_radius=mask_radius,
+    redshift_lens=redshift_lens,
+    redshift_source=redshift_source,
+)
+
+source_pix_result_1 = source_pix_1(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    mesh_init=af.Model(al.mesh.RectangularAdaptDensity, shape=mesh_shape),
+    regularization_init=al.reg.Adapt,
+    settings=settings,
+)
+
+source_pix_result_2 = source_pix_2(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_lp_result=source_lp_result,
+    source_pix_result_1=source_pix_result_1,
+    mesh=af.Model(al.mesh.RectangularAdaptImage, shape=mesh_shape),
+    regularization=al.reg.Adapt,
+    settings=settings,
+)
+
+mass_result = mass_total(
+    settings_search=settings_search,
+    dataset=dataset_dft_sparse,
+    source_pix_result_1=source_pix_result_1,
+    source_pix_result_2=source_pix_result_2,
+    settings=settings,
+)
+
+"""
+Finish.
+"""


### PR DESCRIPTION
## Summary

Adds `scripts/interferometer/features/multi_gaussian_expansion/` mirroring the imaging-equivalent folder, plus a sanity sweep of the imaging MGE scripts.

A key adaptation: the imaging MGE example fits the *lens* galaxy's complex morphology. For interferometer data the lens light is omitted (no detection in mm/sub-mm), so the MGE is instead applied to the *source* galaxy. The new scripts call this role swap out explicitly in their headers.

MGE fits to visibility data were previously impractical because every iteration has to NUFFT each Gaussian in the basis, and prior NUFFT backends were not JAX-friendly. With nufftax (https://github.com/GragasLab/nufftax) the full basis is transformed inside the same JIT'd likelihood as the rest of the model, so MGE-on-visibilities is now routinely practical at any visibility count.

Closes #166

## Scripts Changed

New scripts in `scripts/interferometer/features/multi_gaussian_expansion/`:

- `__init__.py`, `README.md` — package + folder docs.
- `modeling.py` — full Nautilus model-fit. Lens: `Isothermal + ExternalShear` (no light). Source: 30-Gaussian MGE basis built from `al.lp_linear.Gaussian` in two groups of 15 (shared centre and ell_comps per group, sigmas fixed to log-spaced values). `TransformerNUFFT`, `AnalysisInterferometer`. N=13 free non-linear parameters.
- `fit.py` — single `FitInterferometer` with a 30-Gaussian MGE source at known mass-model parameters; demonstrates `fit.linear_light_profile_intensity_dict` access for per-Gaussian intensities.
- `likelihood_function.py` — step-by-step walkthrough of the visibility-plane MGE inversion: ray-trace → source-plane Gaussian images → `mapping_matrix` (one column per Gaussian) → `transform_mapping_matrix` (NUFFT each column) → `D`/`F` solve → visibility-plane chi-squared. Reproduces `FitInterferometer.figure_of_merit` to a few decimal places; explicitly demonstrates the positive-negative solver returning unphysical "ringing" intensities, which the positive-only fnnls solver replaces with a sparse physical solution.
- `slam.py` — SLaM pipeline (SOURCE LP → SOURCE PIX 1 → SOURCE PIX 2 → MASS TOTAL) using an MGE source bulge via `al.model_util.mge_model_from(total_gaussians=20)` in the SOURCE LP stage. SOURCE LP runs on `TransformerNUFFT`; the pixelized stages switch to `TransformerDFT` + sparse operator.

Sweep of existing `scripts/imaging/features/multi_gaussian_expansion/`:

- `modeling.py` — fix `peforms` → `performs`, `algabra` → `algebra`, `descomposed` → `decomposed`, `start.here.py` → `start_here.py`, broken double-backtick on `` `Gaussian`` `` profile list item.
- `fit.py` — same typos (algabra, double-backtick).
- `likelihood_function.py` — `lp_Linear` → `lp_linear`.

## Test Plan

- [x] Smoke tests pass for all 4 new interferometer scripts (modeling, fit, likelihood_function, slam) via `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_FAST_PLOTS=1`.
- [x] `likelihood_function.py` by-hand `figure_of_merit` matches `FitInterferometer.figure_of_merit` to a few decimal places (positive-negative solver returns 7/15 negative entries on this dataset, positive-only solver converges to a sparse 2-Gaussian solution).
- [x] SLaM pipeline completes all 4 stages in `PYAUTO_TEST_MODE=2` (~30 seconds end-to-end).
- [x] `scripts/check_sizes.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)