### PR TITLE
refactor: rewrite cluster/modeling.py to pair with multi-plane simulator

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -33,7 +33,6 @@
 - time_delays # Test mode does not support cosmology ift
 - hpc/example_cpu # HPC paths dont exist locally.
 - examples/searches # Test mode breaks search visualization.
-- cluster/modeling # Cluster modeling is not maintained and test mode breaks it.
 - cluster/start_here # Cluster analysis is not maintained and test mode breaks it.
 - mass_stellar_dark/modeling # Requires CSE to be JAX enabled.
 - mass_stellar_dark/slam # Requires CSE to be JAX enabled.

--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -1,74 +1,64 @@
 """
-Modeling: Cluster Start Here
-============================
+Modeling: Cluster
+=================
 
-This script models an example strong lens on the 'cluster' scale, where there is a Brightest Cluster Galaxy (BCG),
-large dark matter halo, 20 extra galaxies in the cluster whose collective mass contributes significantly to the
-ray-tracing and 5 background source galaxies.
+This script models the small multi-plane cluster lens simulated by ``cluster/simulator.py``: a Brightest
+Cluster Galaxy (BCG) plus one satellite member at the lens redshift ``z = 0.5``, a standalone NFW host
+dark matter halo *not* tied to any individual galaxy, and 2 background sources at *different* redshifts
+(``z = 1.0`` and ``z = 2.0``) which the cluster lenses into multiple images.
 
-The primary method for modeling cluster scale strong lenses uses `point` source modeling, where each source is modeled
-as a point source, where the positions of its multiple images are fitted (but not the extended emission observed at a
-pixel level).
+Cluster modeling almost always uses the *point source* API: rather than fitting the extended arc light
+of each lensed source, only the image-plane positions of the brightest pixels of each multiple image are
+fitted. Per-source positions, noise maps, and redshifts are loaded from a single hand-editable CSV that
+the simulator writes (``point_datasets.csv``) via ``al.list_from_csv``.
 
 __Contents__
 
-- **Scaling Relations:** This example models the mass of the cluster galaxies by putting them on a scaling relation which.
-- **Example:** This script fits a `PointDataset` dataset of a 'cluster-scale' strong lens where.
+- **Example:** What this script fits and the underlying simulator.
 - **Simulation:** Overview of how the simulated dataset was generated.
-- **Data Preparation:** Data standards required for fitting with PyAutoLens.
-- **Dataset:** Load and plot the strong lens dataset.
-- **Centres:** The centre of every extra lens galaxy is used to compose the lens model, fixing their mass.
-- **Luminosities:** We also need the luminosity of each galaxy, which in this example is the measured property we.
-- **Point Solver:** For point-source modeling we require a `PointSolver`, which determines the multiple-images of the.
-- **Chi Squared:** For point-source modeling, there are many different ways to define the likelihood function, broadly.
-- **Main Galaxies and Extra Galaxies:** For a cluster-scale lens, we designate there to be the following lensing objects in the system.
-- **Redshifts:** In this example all galaxies are at the same redshift in the image-plane, meaning multi-plane.
+- **Dataset:** Load the CCD image and the per-source point datasets from the combined CSV.
+- **Centres:** Load the main lens centres and the host halo centre written by the simulator.
+- **Point Solver:** Set up the image-plane multiple-image solver.
+- **Chi Squared:** Why this script uses an image-plane chi-squared.
+- **Cluster Components:** The three categories of lensing object — main lens galaxies, host halo, sources.
+- **Redshifts:** Multi-plane redshift handling and the source-redshift / dataset-redshift pairing.
 - **Model:** Compose the lens model fitted to the data.
-- **Name Pairing:** Every point-source dataset in the `PointDataset` has a name, (e.g.
+- **Name Pairing:** How each ``Point`` model component is paired to its ``PointDataset``.
 - **Search:** Configure the non-linear search used to fit the model.
-- **Unique Identifier:** In the path above, the `unique_identifier` appears as a collection of characters, where this.
-- **Iterations Per Update:** Every N iterations, the non-linear search outputs the maximum likelihood model and its best fit.
-- **Analysis:** Create the Analysis object that defines how the model is fitted to the data.
-- **JAX:** JAX acceleration for fast GPU/CPU model-fitting.
-- **Analysis Factor:** Each analysis object is wrapped in an `AnalysisFactor`, which pairs each analysis it with the model.
-- **Factor Graph:** All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global.
+- **Analysis:** Create the ``AnalysisPoint`` objects, one per dataset.
+- **Factor Graph:** Combine per-dataset analyses into one global ``FactorGraphModel``.
 - **Run Times:** Profiling the expected run time of the model-fit.
-- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Output Folder Layout:** Description of the ``output`` folder structure.
 - **Result:** Overview of the results of the model-fit.
-- **HowToLens:** This `start_here.py` script, and the features examples above, do not explain many details of how.
-
-__Scaling Relations__
-
-This example models the mass of the cluster galaxies by putting them on a scaling relation which links light (measured
-luminosity) to mass. This means the number of dimensions of the model does not increase as we add more and more
-galaxies to the cluster lens model. Given the largest clusters have 100+ galaxies, this avoids our model complexity
-blowing up to 100 of free parameter and is therefore key.
 
 __Example__
 
-This script fits a `PointDataset` dataset of a 'cluster-scale' strong lens where:
+This script fits a ``PointDataset`` of a small multi-plane cluster where:
 
- - There is a main Brightest Cluster Galaxy lens whose total mass distribution is an `Isothermal` and `ExternalShear`.
- - There is a large scale dark matter halo modeled as an `NFWSph`.
- - There are ten extra lens galaxies in the cluster whose total mass distributions are `DPIEPotential` models where
-   their mass is linked to their light via a scaling relation.
- - There are 5 source galaxies modeled as point sources.
+ - There are 2 main lens galaxies with ``dPIEMassSph`` total mass distributions, each with their centre
+   fixed to the values written out by the simulator [6 parameters].
+ - There is 1 standalone ``NFWMCRLudlowSph`` host dark matter halo with its centre fixed and a free
+   ``mass_at_200`` [1 parameter].
+ - There are 2 source galaxies modeled as ``Point`` sources, each with its redshift pinned to the value
+   in its ``PointDataset`` row [4 parameters].
 
-The point-source dataset used in this example consists of the positions of every lensed source's multiple images
-(their fluxes are not used).
+The number of free parameters and therefore the dimensionality of non-linear parameter space is N=11.
+
+This is intentionally a *small* cluster: the same simulator + modeling.py will later be extended to
+include a scaling-relation member population. Getting the multi-plane two-source case working first is
+the prerequisite.
 
 __Simulation__
 
-This script fits a simulated cluster dataset of a strong lens, which is produced in the
-script `autolens_workspace/*/cluster/simulator.py`
+This script fits the simulated cluster dataset produced by ``autolens_workspace/*/cluster/simulator.py``.
+That simulator writes:
 
-__Data Preparation__
-
-The `Imaging` dataset fitted in this example confirms to a number of standard that make it suitable to be fitted in
-**PyAutoLens**.
-
-If you are intending to fit your own strong lens data, you will need to ensure it conforms to these standards, which are
-described in the script `autolens_workspace/*/imaging/data_preparation/start_here.ipynb`.
+ - ``data.fits`` / ``noise_map.fits`` / ``psf.fits`` — CCD imaging of the cluster (used for visualization).
+ - ``point_datasets.csv`` — one row per observed multiple image, grouped by source ``name``, with a
+   ``redshift`` column per group. Loaded here with ``al.list_from_csv``.
+ - ``main_lens_centres.json`` — ``Grid2DIrregular`` of the 2 main lens galaxy centres.
+ - ``host_halo_centre.json`` — ``Grid2DIrregular`` of the 1 host halo centre.
+ - ``tracer.json`` / ``source_centres.json`` — true model (used by visualization, not modeling).
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports
@@ -84,19 +74,13 @@ import autolens.plot as aplt
 """
 __Dataset__
 
-Load the strong lens dataset `cluster`, which is the dataset we will use to perform lens modeling.
+Load the strong lens dataset ``cluster``, which is the dataset we will use to perform lens modeling.
 
-We begin by loading a CCD image of the dataset. Although we perform point-source modeling and will not use this data in 
-the model-fit, it is useful to load it for visualization. By passing this dataset to the model-fit at the
-end of the script it will be used when visualizing the results. 
+We begin by loading a CCD image of the dataset. Although we perform point-source modeling and will not
+use the imaging data in the model-fit, it is useful to load it for visualization.
 
-The use of an image in this way is entirely optional, and if it were not included in the model-fit visualization would 
-performed without the image.
-
-This is loaded via .fits files, which is a data format used by astronomers to store images.
-
-The `pixel_scales` define the arc-second to pixel conversion factor of the image, which for the dataset we are using 
-is 0.1" / pixel.
+The ``pixel_scales`` define the arc-second to pixel conversion factor of the image, which for the
+dataset we are using is 0.1" / pixel.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset", "cluster", dataset_name)
@@ -107,7 +91,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_path.exists():
+if not (dataset_path / "data.fits").exists():
     import subprocess
     import sys
 
@@ -119,131 +103,85 @@ if not dataset_path.exists():
 data = al.Array2D.from_fits(file_path=dataset_path / "data.fits", pixel_scales=0.1)
 
 """
-We now load the point source datasets we will fit using point source modeling. 
+__Point Datasets__
 
-We load this data as a list of `PointDataset` object, which contains the positions of every point source. 
+We load the point datasets from the combined ``point_datasets.csv`` written by the simulator. This
+returns a ``List[PointDataset]`` where each entry carries:
+
+ - ``positions``: the image-plane (y, x) positions of that source's multiple images.
+ - ``positions_noise_map``: the per-position positional uncertainty.
+ - ``redshift``: the source redshift (different for each source — this is a multi-plane system).
+
+The CSV is the recommended hand-editable input for cluster datasets: a user can edit positions, noise
+values, or per-source redshifts directly in a spreadsheet rather than by writing Python.
 """
-dataset_list = []
-
-for i in range(5):
-
-    dataset = al.from_json(
-        file_path=Path(dataset_path, f"point_dataset_{i}.json"),
-    )
-
-    dataset_list.append(dataset)
-
-"""
-__CSV Loading__
-
-The ``dataset_list`` above is equivalent to a single CSV loaded in one call.  If the
-simulator also wrote ``point_datasets.csv`` (see ``cluster/simulator.py``), the same
-``dataset_list`` can be recovered with::
-
-    dataset_list = al.list_from_csv(file_path=dataset_path / "point_datasets.csv")
-
-This is the recommended form for hand-edited cluster datasets with tens of sources.
-"""
+dataset_list = al.list_from_csv(file_path=dataset_path / "point_datasets.csv")
 
 """
-We can print this dictionary to see the dataset's `name` and `positions` and noise-map values.
+We can print each dataset's name, positions, noise, and redshift.
 """
 for dataset in dataset_list:
 
     print("Point Dataset Info:")
     print(dataset.info)
+    print(f"Redshift: {dataset.redshift}")
 
 """
-We can plot the positions of each dataset over the observed image.
+We can plot the cluster image with each source's positions overlaid.
+
+Cluster-scale visualization (per-source colouring, per-image-group zoom panels, kpc scale bars) is
+prototyped in ``autolens_workspace_test/scripts/imaging/visualization_cluster.py``; the default
+``aplt`` helpers below are sufficient for this script.
 """
-positions_list = []
-
-for dataset in dataset_list:
-
-    positions_list.append(dataset.positions)
-
-
 aplt.plot_array(array=data, title="")
 
-"""
-We can also just plot the positions, omitting the image.
-"""
-import numpy as np
-
-for positions in positions_list:
-    aplt.plot_grid(grid=al.Grid2DIrregular(np.atleast_2d(positions)), title="")
+for dataset in dataset_list:
+    aplt.plot_grid(
+        grid=al.Grid2DIrregular(np.atleast_2d(dataset.positions)),
+        title=dataset.name,
+    )
 
 """
 __Centres__
 
-The centre of every extra lens galaxy is used to compose the lens model, fixing their mass distributions
-to their centres of light.
+The centres of the main lens galaxies and the host halo are loaded from the JSON files written by the
+simulator. They are fixed in the model below — for cluster-scale point-source modeling we treat the
+observed centres of light as ground truth, since they remove a large block of degenerate parameters that
+the multiple-image positions alone cannot constrain.
 
-We load these centres below and plot them on the image to confirm they are located correctly and
-cover all galaxies.
+In a real analysis, the centres come from light-profile fits to the imaging data or from external source
+catalogues (e.g. Source Extractor).
 """
-extra_galaxies_centre_list = al.Grid2DIrregular(
-    al.from_json(file_path=Path(dataset_path, "extra_galaxies_centre_list.json"))
-)
-
-
-aplt.plot_array(array=data, title="")
-
-"""
-__Luminosities__
-
-We also need the luminosity of each galaxy, which in this example is the measured property we relate to mass via
-the scaling relation.
-
-We again uses the true values of the luminosities from the simulated dataset, but in a real analysis we would have
-to determine these luminosities beforehand (see discussion above).
-
-This could be other measured properties, like stellar mass or velocity dispersion.
-"""
-extra_galaxies_luminosity_list = al.from_json(
-    file_path=Path(dataset_path, "extra_galaxies_luminosities.json")
-)
+main_lens_centres = al.from_json(file_path=dataset_path / "main_lens_centres.json")
+host_halo_centre = al.from_json(file_path=dataset_path / "host_halo_centre.json")[0]
 
 """
 __Point Solver__
 
-For point-source modeling we require a `PointSolver`, which determines the multiple-images of the mass model for a 
-point source at location (y,x) in the source plane. 
+For point-source modeling we require a ``PointSolver``, which determines the multiple images of the mass
+model for a point source at (y, x) in the source plane.
 
-It does this by ray tracing triangles from the image-plane to the source-plane and calculating if the 
-source-plane (y,x) centre is inside the triangle. The method gradually ray-traces smaller and smaller triangles so 
-that the multiple images can be determine with sub-pixel precision.
+It does this by ray-tracing triangles from the image plane to the source plane and checking whether each
+source-plane (y, x) point lies inside the traced triangle. The method gradually refines smaller and
+smaller triangles so multiple images are computed with sub-pixel precision.
 
-The `PointSolver` requires an initial grid of (y, x) coordinates in the image plane (defined above), which defines the 
-first set of triangles to ray trace spanning the whole cluster.It also requires that a `pixel_scale_precision` is input, 
-which is the resolution up to which the multiple images are computed. The lower the `pixel_scale_precision`, the
-longer the calculation, with the value of 0.001 below balancing efficiency with precision.
+The ``PointSolver`` needs an initial image-plane grid (defined below) and a ``pixel_scale_precision``
+controlling resolution — smaller values are more accurate but slower; 0.001 balances the two.
 
-Strong lens mass models have a multiple image called the "central image". However, the image is nearly always 
-significantly demagnified, meaning that it is not observed and cannot constrain the lens model. As this image is a
-valid multiple image, the `PointSolver` will locate it irrespective of whether its so demagnified it is not observed.
-To ensure this does not occur, we set a `magnification_threshold=0.1`, which discards this image because its
-magnification will be well below this threshold.
-
-If your dataset contains a central image that is observed you should reduce to include it in
-the analysis.
+Strong-lens mass models have a "central image" which is nearly always so demagnified it cannot be
+observed. We discard it via ``magnification_threshold=0.1``; raise/lower this if your dataset does/does
+not include a central image.
 
 __Chi Squared__
 
-For point-source modeling, there are many different ways to define the likelihood function, broadly referred to a
-an `image-plane chi-squared` or `source-plane chi-squared`. This determines whether the multiple images of the point
-source are used to compute the likelihood in the source-plane or image-plane.
-
-We will use an "image-plane chi-squared", which uses the `PointSolver` to determine the multiple images of the point
-source in the image-plane for the given mass model and compares the positions of these model images to the observed
-images to compute the chi-squared and likelihood.
-
-The `point_source` package provides full details of how the `PointSolver` works and the different
-chi squared definitions available.
+For point-source modeling, the likelihood can be defined in the *image plane* (compare model
+multiple-image positions to observed positions) or the *source plane* (collapse observed positions back
+to a common source-plane location). This script uses the image-plane chi-squared via the ``PointSolver``;
+see ``autolens_workspace/*/point_source/log_likelihood_function`` for a full walkthrough.
 """
 grid = al.Grid2D.uniform(
     shape_native=(100, 100),
-    pixel_scales=1.0,  # <- The pixel-scale describes the conversion from pixel units to arc-seconds.
+    pixel_scales=1.0,  # The pixel-scale converts pixel units to arc-seconds.
 )
 
 solver = al.PointSolver.for_grid(
@@ -251,348 +189,256 @@ solver = al.PointSolver.for_grid(
 )
 
 """
-__Main Galaxies and Extra Galaxies__
+__Cluster Components__
 
-For a cluster-scale lens, we designate there to be the following lensing objects in the system:
+For this small cluster, we organise the lensing objects into three distinct categories that map directly
+onto the simulator:
 
- - `main_galaxies`: The main lens galaxies which are the brightest and highest mass galaxies in the lens system. In
- clusters they are often BCGs. These are modeled individually with a unique name for each, with their mass distributions 
- modeled using parametric models. The cluster scale dark matter halo is also tied to the BCG.
- 
- - `extra_galaxies`: The extra galaxies which make up the cluster, whose masses individually don't contirbute too much
- lensing but they collectively contribute to the lensing of the source galaxies a lot. These are modeled with a
-  more restrictive model, for example with their centres fixed to the observed centre of light and their mass 
-  distributions modeled using a scaling relation. These are grouped into a single  `extra_galaxies` collection.
-  
-In this simple example cluster scale lens, there is one main lens galaxy and ten extra galaxies. 
+ - ``main_lens_galaxies``: The 2 cluster member galaxies (BCG + satellite). Each is modeled with a
+   ``dPIEMassSph`` total mass profile and its centre fixed to ``main_lens_centres[i]``.
 
-for point source modeling, we do not model the light of the lens galaxies, as it is not necessary when only the 
-positions of the multiple images are used to fit the model.
+ - ``host_halo``: A single standalone ``Galaxy`` carrying the cluster's ``NFWMCRLudlowSph`` dark matter
+   halo. The halo is *not* tied to any individual member — it sits "on top of" the members and
+   dominates the large-scale lensing.
 
-__Centres__
+ - ``source_galaxies``: 2 background sources, *at different redshifts* (so this is a genuine multi-plane
+   lens). Each is modeled as a ``Point`` source whose redshift is pinned to the value in its
+   ``PointDataset``.
 
-If the centres of the extra galaxies are treated as free parameters, there are too many 
-parameters and the model may not be fitted accurately.
-
-For cluster-scale lenses we therefore manually specify the centres of the extra galaxies (which we loaded above) which 
-are fixed to the observed centres of light of the galaxies.
-
-In a real analysis, one must determine the centres of the galaxies before modeling them, which can be done as follows:
-
- - Use the GUI tool in the `data_preparation/point_source/gui/extra_galaxies_centre_list.py` script to determine the centres
-   of the extra galaxies. 
-
- - Use image processing software like Source Extractor (https://sextractor.readthedocs.io/en/latest/).
-
- - Fit every galaxy individually with a light profile (e.g. an `Sersic`).
+There is no scaling-relation member population in this script — that's a follow-up extension. The
+existing scaling-relation API is demonstrated for the galaxy-scale group case in
+``scripts/imaging/features/scaling_relation/modeling.py``.
 
 __Redshifts__
 
-In this example all galaxies are at the same redshift in the image-plane, meaning multi-plane lensing is not used.
+The two sources sit at *different* redshifts (``z = 1.0`` and ``z = 2.0``), so the ``Tracer`` ray-traces
+through both planes when solving for the multiple images of the further source. The lens galaxies and
+host halo all sit at ``z = 0.5``.
 
-If you have redshift information on the line of sight galaxies and some of their redshifts are different to the lens
-galaxy, you can easily extend this example below to perform multi-plane lensing.
+We pin each source's ``Galaxy.redshift`` to the redshift carried by its ``PointDataset`` — that's the
+whole point of the CSV ``redshift`` column. Hardcoding ``redshift=1.0`` here would silently produce the
+wrong multi-plane geometry.
 
-You would simply define a `redshift_list` and use this to set up the extra `Galaxy` redshifts.
+For the host halo, ``NFWMCRLudlowSph`` requires ``redshift_object`` and ``redshift_source`` to evaluate
+the Ludlow et al. (2016) concentration-mass relation. We anchor ``redshift_source`` to the *furthest*
+source redshift (matching the convention used by the simulator), so the concentration is computed
+against the deepest light cone in the system.
 
 __Model__
 
 We compose a lens model where:
 
- - The main lens galaxy's total mass distribution is an `Isothermal` and `ExternalShear`  with a large
- - `NFWSph` dark matter halo [9 parameters].
- 
- - There are ten extra lens galaxies with `DPIEPotentialSph` total mass distributions, with centres fixed to the 
-   observed centres of light and masses linked to light via a scaling relation whose parameters are fitted 
-   for [3 parameters].
- 
- - There are five source galaxies whose light is a `Point` [10 parameters].
+ - The 2 main lens galaxies each have a ``dPIEMassSph`` mass profile with centre fixed and free
+   ``ra``, ``rs``, ``b0`` — 3 free parameters per galaxy [6 parameters].
+ - The host halo has an ``NFWMCRLudlowSph`` mass profile with centre fixed and a free ``mass_at_200``
+   [1 parameter].
+ - Each source has a ``Point`` model with free ``centre_0`` / ``centre_1`` priors initialised from the
+   mean of that source's observed positions [4 parameters].
 
-The number of free parameters and therefore the dimensionality of non-linear parameter space is N=22.
+The number of free parameters and therefore the dimensionality of non-linear parameter space is N=11.
 """
-# Main Lens:
+redshift_lens = 0.5
+source_redshifts = [dataset.redshift for dataset in dataset_list]
 
-lens_centre = (0.0, 0.0)
+# Main Lens Galaxies (dPIEMassSph, centre fixed)
 
-mass = af.Model(al.mp.Isothermal)
+main_lens_dict = {}
 
-mass.centre.centre_0 = af.GaussianPrior(mean=lens_centre[0], sigma=0.3)
-mass.centre.centre_1 = af.GaussianPrior(mean=lens_centre[1], sigma=0.3)
-
-shear = af.Model(al.mp.ExternalShear)
-dark = af.Model(al.mp.NFWSph)
-
-dark.centre.centre_0 = af.GaussianPrior(mean=lens_centre[0], sigma=0.3)
-dark.centre.centre_1 = af.GaussianPrior(mean=lens_centre[1], sigma=0.3)
-
-lens = af.Model(al.Galaxy, redshift=0.5, mass=mass, shear=shear, dark=dark)
-
-# Extra Galaxies
-
-ra_star = af.LogUniformPrior(lower_limit=1e8, upper_limit=1e11)
-rs_star = af.UniformPrior(lower_limit=-1.0, upper_limit=1.0)
-b0_star = af.LogUniformPrior(lower_limit=1e5, upper_limit=1e7)
-luminosity_star = 1e9
-
-extra_galaxies_dict = {}
-
-for i, extra_galaxy_centre, extra_galaxy_luminosity in enumerate(
-    zip(extra_galaxies_centre_list, extra_galaxies_luminosity_list)
-):
+for i, centre in enumerate(main_lens_centres):
 
     mass = af.Model(al.mp.dPIEMassSph)
-    mass.centre = extra_galaxy_centre
-    mass.ra = ra_star * (extra_galaxy_luminosity / luminosity_star) ** 0.5
-    mass.rs = rs_star * (extra_galaxy_luminosity / luminosity_star) ** 0.5
-    mass.b0 = b0_star * (extra_galaxy_luminosity / luminosity_star) ** 0.25
+    mass.centre = tuple(centre)
+    mass.ra = af.UniformPrior(lower_limit=1.0, upper_limit=15.0)
+    mass.rs = af.UniformPrior(lower_limit=5.0, upper_limit=40.0)
+    mass.b0 = af.UniformPrior(lower_limit=0.1, upper_limit=10.0)
 
-    extra_galaxy = af.Model(al.Galaxy, redshift=0.5, mass=mass)
+    main_lens_dict[f"lens_{i}"] = af.Model(
+        al.Galaxy, redshift=redshift_lens, mass=mass
+    )
 
-    extra_galaxies_dict[f"extra_galaxy_{i}"] = extra_galaxy
+# Host Dark Matter Halo (NFWMCRLudlowSph, centre fixed, mass_at_200 free)
 
-# Source:
+host_halo_mass = af.Model(al.mp.NFWMCRLudlowSph)
+host_halo_mass.centre = tuple(host_halo_centre)
+host_halo_mass.redshift_object = redshift_lens
+host_halo_mass.redshift_source = max(source_redshifts)
+host_halo_mass.mass_at_200 = af.LogUniformPrior(
+    lower_limit=10**14.5, upper_limit=10**16.0
+)
 
-source_galaxies_dict = {}
+host_halo = af.Model(al.Galaxy, redshift=redshift_lens, dark=host_halo_mass)
 
-for i, positions in enumerate(positions_list):
+# Source Galaxies (Point, redshift pinned to per-dataset redshift)
 
-    positions_array = np.atleast_2d(positions)
-    positions_centre_y = np.mean(positions_array[:, 0])
-    positions_centre_x = np.mean(positions_array[:, 1])
+source_dict = {}
+
+for i, dataset in enumerate(dataset_list):
+
+    positions = np.atleast_2d(dataset.positions)
 
     point = af.Model(al.ps.Point)
-    point.centre_0 = af.GaussianPrior(mean=positions_centre_y, sigma=3.0)
-    point.centre_1 = af.GaussianPrior(mean=positions_centre_x, sigma=3.0)
+    point.centre_0 = af.GaussianPrior(mean=float(np.mean(positions[:, 0])), sigma=3.0)
+    point.centre_1 = af.GaussianPrior(mean=float(np.mean(positions[:, 1])), sigma=3.0)
 
-    source = af.Model(al.Galaxy, redshift=1.0, **{f"point_{i}": point})
-
-    source_galaxies_dict[f"source_{i}"] = source
+    source_dict[f"source_{i}"] = af.Model(
+        al.Galaxy, redshift=dataset.redshift, **{f"point_{i}": point}
+    )
 
 # Overall Lens Model:
 
 model = af.Collection(
-    galaxies=af.Collection(lens=lens, **source_galaxies_dict),
-    extra_galaxies=af.Collection(**extra_galaxies_dict),
+    galaxies=af.Collection(host_halo=host_halo, **main_lens_dict, **source_dict),
 )
 
 """
-The `info` attribute shows the model in a readable format.
+The ``info`` attribute shows the model in a readable format. This prints the main lens galaxies, the
+host halo, and the source galaxies, each with its free / fixed parameters.
 
-This shows the cluster scale model, with separate entries for the main lens galaxy, the source galaxies and the 
-extra galaxies.
-
-The `info` below may not display optimally on your computer screen, for example the whitespace between parameter
-names on the left and parameter priors on the right may lead them to appear across multiple lines. This is a
-common issue in Jupyter notebooks.
-
-The`info_whitespace_length` parameter in the file `config/general.yaml` in the [output] section can be changed to 
-increase or decrease the amount of whitespace (The Jupyter notebook kernel will need to be reset for this change to 
-appear in a notebook).
+The ``info`` below may not display optimally on your computer screen — for example whitespace between
+parameter names on the left and parameter priors on the right may break across multiple lines. The
+``info_whitespace_length`` parameter in ``config/general.yaml`` controls this; reset the Jupyter
+kernel after changing it.
 """
 print(model.info)
 
 """
 __Name Pairing__
 
-Every point-source dataset in the `PointDataset` has a name, (e.g. `point_0`, `point_1`). This `name` pairs 
-the dataset to the `Point` in the model below. Because the name of the dataset is `point_0`, the 
-only `Point` object that is used to fit it must have the name `point_0`.
+Every ``PointDataset`` has a ``name`` (e.g. ``point_0``, ``point_1``). This pairs the dataset to the
+``Point`` model component with the same name. Above, the ``af.Model(al.ps.Point)`` for source ``i`` is
+attached to its ``af.Model(al.Galaxy)`` under the key ``point_i`` — that's what the ``**{f"point_{i}":
+point}`` expansion does.
 
-If there is no point-source in the model that has the same name as a `PointDataset`, that data is not used in
-the model-fit. If a point-source is included in the model whose name has no corresponding entry in 
-the `PointDataset` **PyAutoLens** will raise an error.
+If a dataset has no matching ``Point`` in the model, that dataset is ignored. If a ``Point`` exists with
+no matching dataset, **PyAutoLens** raises an error.
 
-In cluster lenses, point-source datasets may have many source galaxies in them, and name pairing is necessary to 
-ensure every point source in the lens model is  fitted to its particular lensed images in the `PointDataset`!
-
-The model fitting default settings assume that the BCG lens galaxy centre is near the coordinates (0.0", 0.0"). 
-
-If for your dataset the  lens is not centred at (0.0", 0.0"), we recommend that you either: 
-
- - Reduce your data so that the centre is (`autolens_workspace/*/data_preparation`). 
- - Manually override the lens model priors (`autolens_workspace/*/guides/modeling/customize`).
+In multi-source cluster lenses, this name pairing is what ensures every source's positions are fitted by
+the correct model component.
 """
 print(model)
 
 """
 __Search__
 
-The lens model is fitted to the data using the nested sampling algorithm Nautilus (see `start.here.py` for a 
-full description).
+The lens model is fitted to the data using the nested sampling algorithm Nautilus (see
+``point_source/start_here.py`` for a full description).
 
-The folders: 
+The folders ``autolens_workspace/*/guides/modeling/searches`` and ``customize`` give overviews of the
+non-linear searches PyAutoLens supports and how to customize the fit, including the priors.
 
- - `autolens_workspace/*/guides/modeling/searches`.
- - `autolens_workspace/*/guides/modeling/customize`
-  
-Give overviews of the non-linear searches **PyAutoLens** supports and more details on how to customize the
-model-fit, including the priors on the model.
+Results are output to::
 
-The `name` and `path_prefix` below specify the path where results ae stored in the output folder:  
-
- `/autolens_workspace/output/group/simple/mass[sie]_source[point]/unique_identifier`.
+    /autolens_workspace/output/cluster/simple/modeling/<unique_identifier>/
 
 __Unique Identifier__
 
-In the path above, the `unique_identifier` appears as a collection of characters, where this identifier is generated 
-based on the model, search and dataset that are used in the fit.
-
-An identical combination of model, search and dataset generates the same identifier, meaning that rerunning the
-script will use the existing results to resume the model-fit. In contrast, if you change the model, search or dataset,
-a new unique identifier will be generated, ensuring that the model-fit results are output into a separate folder. 
+The ``unique_identifier`` is generated from the model, search, and dataset, so re-running with the same
+configuration resumes the existing fit. Changing any of the three regenerates the identifier.
 
 __Iterations Per Update__
 
-Every N iterations, the non-linear search outputs the maximum likelihood model and its best fit image to the 
-Notebook visualizer and to hard-disk.
-
-This process takes around ~10 seconds, so we don't want it to happen too often so as to slow down the overall
-fit, but we also want it to happen frequently enough that we can track the progress.
-
-On GPU, a value of ~2500 will see this output happens every minute, a good balance. On CPU it'll be a little
-longer, but still a good balance.
+Every N iterations the search prints the max-likelihood model and best-fit image. On GPU ~2500 keeps the
+output cadence around once per minute; on CPU a similar cadence is reached at lower N.
 """
 search = af.Nautilus(
-    path_prefix=Path("cluster"),  # The path where results and output are stored.
-    name="modeling",  # The name of the fit and folder results are output to.
-    unique_tag=dataset_name,  # A unique tag which also defines the folder.
-    n_live=100,  # The number of Nautilus "live" points, increase for more complex models.
-    n_batch=50,  # GPU lens model fits are batched and run simultaneously, see VRAM section below.
-    iterations_per_quick_update=10000,  # Every N iterations the max likelihood model is visualized in the Jupter Notebook and output to hard-disk.
+    path_prefix=Path("cluster"),
+    name="modeling",
+    unique_tag=dataset_name,
+    n_live=100,
+    n_batch=50,
+    iterations_per_quick_update=10000,
 )
 
 """
 __Analysis__
 
-We next create  `AnalysisPoint` objects, which can be given many inputs customizing how the lens model is 
-fitted to the data (in this example they are omitted for simplicity).
+We create one ``AnalysisPoint`` per dataset. Each defines the ``log_likelihood_function`` Nautilus uses
+to fit the model to that dataset's multiple-image positions.
 
-Internally, this object defines the `log_likelihood_function` used by the non-linear search to fit the model to 
-the `Imaging` dataset. 
-
-We create a list of analysis objects, one for each dataset, which means that the lens modeling will fit each
-set of multiple images one-by-one and then sum their likelihoods. 
-
-It is not vital that you as a user understand the details of how the `log_likelihood_function` fits a lens model to 
-data, but interested readers can find a step-by-step guide of the likelihood 
-function at ``autolens_workspace/*/point/log_likelihood_function`
+We then wrap each analysis in an ``AnalysisFactor`` pairing it to the *shared* lens model, and combine
+all factors into a single ``FactorGraphModel``. The total log likelihood is the sum of the per-dataset
+log likelihoods; each dataset gets its own output subdirectory for visualization.
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+PyAutoLens uses JAX under the hood for GPU/CPU acceleration. With a GPU, fits run much faster (around
+10 minutes vs an hour); on CPU JAX still helps via multithreading (20–30 minutes typical). Google Colab
+offers free GPUs.
 """
 analysis_list = [
-    al.AnalysisPoint(
-        dataset=dataset,
-        solver=solver,
-        use_jax=True,  # JAX will use GPUs for acceleration if available, else JAX will use multithreaded CPUs.
-    )
+    al.AnalysisPoint(dataset=dataset, solver=solver, use_jax=True)
     for dataset in dataset_list
 ]
 
 """
 __Analysis Factor__
 
-Each analysis object is wrapped in an `AnalysisFactor`, which pairs each analysis it with the model.
-
-For this simple cluster examples, the API below in a very simple way. However, the factor graph API below is used for
-many advanced lens modeling tasks elsewhere in the workspace.
+Each analysis is wrapped in an ``AnalysisFactor`` paired with the shared model. The factor-graph API is
+used heavily for advanced multi-dataset lens modeling — multi-wavelength imaging, joint
+imaging+interferometer fits, multiple-source cluster fits like this one.
 """
-analysis_factor_list = []
-
-for analysis in analysis_list:
-
-    analysis_factor = af.AnalysisFactor(prior_model=model, analysis=analysis)
-
-    analysis_factor_list.append(analysis_factor)
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=model, analysis=analysis) for analysis in analysis_list
+]
 
 """
 __Factor Graph__
 
-All `AnalysisFactor` objects are combined into a `FactorGraphModel`, which represents a global model fit to 
-multiple datasets using a graphical model structure.
-
-The key outcomes of this setup are:
-
- - The individual log likelihoods from each `Analysis` object are summed to form the total log likelihood 
-   evaluated during the model-fitting process.
-
- - Results from all datasets are output to a unified directory, with subdirectories for visualizations 
-   from each analysis object, as defined by their `visualize` methods.
+All ``AnalysisFactor`` objects combine into one ``FactorGraphModel``. The per-dataset log likelihoods
+are summed; results land in a unified directory with per-dataset visualization subdirs.
 """
 factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
 
 """
-To inspect this new model, with extra parameters for each dataset created, we 
-print `factor_graph.global_prior_model.info`.
+Print the global model the factor graph fits.
 """
 print(factor_graph.global_prior_model.info)
 
 """
 __Run Times__
 
-Lens modeling can be a computationally expensive process. When fitting complex models to high resolution datasets 
-run times can be of order hours, days, weeks or even months.
+Cluster lens modeling is computationally expensive — full Nautilus runs are typically hours on CPU,
+minutes on GPU. Run times scale with (a) the log-likelihood evaluation time of a single sample and
+(b) the number of iterations Nautilus needs to converge.
 
-Run times are dictated by two factors:
-
- - The log likelihood evaluation time: the time it takes for a single `instance` of the lens model to be fitted to 
-   the dataset such that a log likelihood is returned.
- 
- - The number of iterations (e.g. log likelihood evaluations) performed by the non-linear search: more complex lens
-   models require more iterations to converge to a solution.
-   
-For this analysis, the log likelihood evaluation time is < 1 seconds on CPU, < 0.02 seconds on GPU, which is 
-fast for cluster scale lens modeling. 
-
-To estimate the expected overall run time of the model-fit we multiply the log likelihood evaluation time by an 
-estimate of the number of iterations the non-linear search will perform. 
-
-For this model, this is typically around > iterations, meaning that this script takes < ? seconds, 
-or ? minutes on CPU, or < ? seconds, or ? minute on GPU.
+For this 2-main + halo + 2-source model the log-likelihood evaluation is < 1 second on CPU and < 0.02 s
+on GPU. A converged fit typically takes a few thousand iterations.
 
 __Model-Fit__
 
-We begin the model-fit by passing the model and analysis object to the non-linear search (checkout the output folder
-for on-the-fly visualization and results).
+Pass the factor-graph model and the factor graph itself (as the analysis) to ``search.fit``. Watch
+``autolens_workspace/output`` for on-the-fly visualization while the fit runs.
 
-**Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce 
-an error. If this occurs, see the `autolens_workspace/guides/modeling/bug_fix` example for a fix.
+**Run Time Error:** On certain operating systems and Python versions, the code below may produce an
+error. If this occurs, see ``autolens_workspace/guides/modeling/bug_fix``.
 """
 print(
     """
     The non-linear search has begun running.
 
-    This Jupyter notebook cell with progress once the search has completed - this could take a few minutes!
+    This Jupyter notebook cell will progress once the search has completed — this could take a few minutes!
 
     On-the-fly updates every iterations_per_quick_update are printed to the notebook.
     """
 )
 
-result = search.fit(model=model, analysis=analysis)
+result_list = search.fit(model=factor_graph.global_prior_model, analysis=factor_graph)
 
-print("The search has finished run - you may now continue the notebook.")
+print("The search has finished run — you may now continue the notebook.")
 
 """
 __Output Folder Layout__
 
-Now the fit is running you should checkout the `autolens_workspace/output` folder. This is where results are
-written to hard-disk in human-readable formats — `.json`, `.csv`, `.fits`, `.png` and plain text.
+Now the fit is running you should checkout the ``autolens_workspace/output`` folder. Results are written
+to hard-disk on the fly in human-readable formats — ``.json``, ``.csv``, ``.fits``, ``.png`` and plain
+text — using the highest-likelihood model found so far.
 
-As the fit progresses, results are written on the fly using the highest likelihood model found by the
-non-linear search so far. This means you can inspect the model-fit as it runs, without waiting for the
-non-linear search to terminate.
-
-Each completed fit lives at a path like::
+Each completed fit lives at::
 
     output/cluster/<dataset_name>/modeling/<unique_hash>/
         files/                         <- JSON + CSV: loadable Python objects
-            tracer.json                <- max log likelihood Tracer (full cluster lens model)
-            model.json                 <- fitted af.Collection model (scaling-relation parameters)
+            tracer.json                <- max log likelihood Tracer
+            model.json                 <- fitted af.Collection model
             samples.csv                <- full Nautilus samples
             samples_summary.json       <- max log likelihood parameter values + errors
             samples_info.json          <- metadata about the samples
@@ -603,83 +449,50 @@ Each completed fit lives at a path like::
         image/                         <- FITS + PNG: imaging + point-source products
             dataset.fits               <- data, noise-map and PSF
             fit.fits                   <- model image, residuals, chi-squared map
-            tracer.fits                <- tracer image-plane images per cluster galaxy
-            source_plane_images.fits   <- source plane reconstructions
-            galaxy_images.fits         <- per-galaxy images
-            positions.png              <- observed vs model-predicted multiple-image positions
+            tracer.fits                <- per-galaxy image-plane images
+            source_plane_images.fits   <- source-plane reconstructions
+            positions.png              <- observed vs model multiple-image positions
             dataset.png, fit.png, tracer.png   <- visualisations
         model.info                     <- human-readable model summary
         model.results                  <- human-readable fit summary
         search.summary                 <- search run summary
-        search_internal/               <- internal files used to resume / visualise the search
+        search_internal/               <- files used to resume / visualise the search
         metadata                       <- run metadata
 
-The `<unique_hash>` is a 32-character identifier derived from the model, search and dataset, so re-running the
-same configuration resumes from the existing fit automatically.
+The ``<unique_hash>`` is a 32-character identifier derived from the model, search and dataset.
 
 __Result__
 
-The search returns a result object, which whose `info` attribute shows the result in a readable format.
+``search.fit`` on a factor-graph returns a list of ``Result`` objects, one per ``AnalysisFactor`` (i.e.
+one per dataset). Each carries the same ``max_log_likelihood_instance`` (since they share the global
+model) but its own per-dataset visualization and ``FitPoint`` object.
 
-[Above, we discussed that the `info_whitespace_length` parameter in the config files could b changed to make 
-the `model.info` attribute display optimally on your computer. This attribute also controls the whitespace of the
-`result.info` attribute.]
+[The ``info_whitespace_length`` config setting also controls whitespace in ``result.info``.]
 """
-print(result_list[0].info)
+for result in result_list:
+    print(result.max_log_likelihood_instance)
 
-"""
-The `Result` object also contains:
-
- - The model corresponding to the maximum log likelihood solution in parameter space.
- - The corresponding maximum log likelihood `Tracer` and `FitImaging` objects.
-
-Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.
-"""
-print(result_list[0].max_log_likelihood_instance)
-
-aplt.subplot_tracer(
-    tracer=result_list[0].max_log_likelihood_tracer, grid=result_list[0].grids.lp
-)
+    aplt.subplot_tracer(
+        tracer=result.max_log_likelihood_tracer,
+        grid=grid,
+    )
 
 """
-It also contains information on the posterior as estimated by the non-linear search (in this example `Nautilus`). 
-
-Below, we make a corner plot of the "Probability Density Function" of every parameter in the model-fit.
-
-The plot is labeled with short hand parameter names (e.g. `sersic_index` is mapped to the short hand 
-parameter `n`). These mappings ate specified in the `config/notation.yaml` file and can be customized by users.
-
-The superscripts of labels correspond to the name each component was given in the model (e.g. for the `Isothermal`
-mass its name `mass` defined when making the `Model` above is used).
+The ``Samples`` are identical across results (the model is global), so a single corner plot from the
+first result is enough.
 """
 aplt.corner_anesthetic(samples=result_list[0].samples)
 
 """
-This script gives a concise overview of the basic cluster modeling API, fitting one the simplest lens models possible.
-
-Lets now consider what features you should read about to improve your cluster lens modeling, especially if you are aiming
-to fit more complex models to your data.
+This script gives a concise overview of the basic cluster modeling API for a small multi-plane cluster.
 
 __Data Preparation__
 
-If you are looking to fit your own point source data of a strong lens, checkout  
-the `autolens_workspace/*/data_preparation/point_source/README.md` script for an overview of how data should be 
-prepared before being modeled.
+If you are looking to fit your own point-source cluster data, see
+``autolens_workspace/*/data_preparation/point_source/README.md`` for the input-data standards.
 
 __HowToLens__
 
-This `start_here.py` script, and the features examples above, do not explain many details of how lens modeling is 
-performed, for example:
-
- - How does PyAutoLens perform ray-tracing and lensing calculations in order to fit a lens model?
- - How is a lens model fitted to data? What quantifies the goodness of fit (e.g. how is a log likelihood computed?).
- - How does Nautilus find the highest likelihood lens models? What exactly is a "non-linear search"?
-
-You do not need to be able to answer these questions in order to fit lens models with PyAutoLens and do science.
-However, having a deeper understanding of how it all works is both interesting and will benefit you as a scientist
-
-This deeper insight is offered by the **HowToLens** Jupyter notebook lectures, which live in their own repository:
-https://github.com/PyAutoLabs/HowToLens.
-
-I recommend that you check them out if you are interested in more details!
+For a deeper understanding of how lens modeling, ray-tracing, and non-linear searches actually work, see
+the **HowToLens** Jupyter notebook lectures at https://github.com/PyAutoLabs/HowToLens.
 """


### PR DESCRIPTION
## Summary

Rewrites `autolens_workspace/scripts/cluster/modeling.py` to pair with the current `cluster/simulator.py` — which was updated months ago to a small multi-plane cluster (2 main lens galaxies + standalone NFW host halo + 2 sources at distinct redshifts) but whose paired modeling script was never updated. A 2026-05-06 hygiene sweep wrongly logged this work as done because `al.list_from_csv` appeared inside a docstring example block, not the real code path.

## Scripts Changed

- `scripts/cluster/modeling.py` — full rewrite to pair to the simulator:
  - Load datasets via `al.list_from_csv` so per-source `dataset.redshift` is the real code path (was inside a docstring before)
  - Load `main_lens_centres.json` + `host_halo_centre.json` (the JSONs the simulator actually writes); drop the defunct `extra_galaxies_centre_list.json` + `extra_galaxies_luminosities.json` loads
  - Compose 2 `dPIEMassSph` main lenses (centres fixed, free `ra`/`rs`/`b0`), 1 `NFWMCRLudlowSph` host halo galaxy (free `mass_at_200`, `redshift_source` anchored to `max(source_redshifts)`), 2 `Point` source galaxies whose redshifts come from `dataset.redshift`
  - Drop the entire `extra_galaxies` + scaling-relation block — mismatched to the current simulator; scaling-relation members are a future prompt
  - Switch `search.fit` to the factor-graph pattern (returns `result_list`, not a single `result`; also fixes the latent `result_list[0]` reference the old code had)
  - Loosen the auto-sim guard from `dataset_path.exists()` to `(dataset_path / "data.fits").exists()` — the dataset directory already held viz prototype PNGs, which made the old guard silently skip simulator regeneration
- `config/build/no_run.yaml` — remove the `cluster/modeling` entry; the script now runs under test mode. `cluster/start_here` remains parked (separate follow-up).

## Test Plan

- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 python scripts/cluster/modeling.py` runs end-to-end — likelihood function evaluated once, `FactorGraphModel` returns 2 `Result` objects (one per source)
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)