### PR TITLE
triage 2026-05-20 cleanup: park group/double_einstein_ring/slam

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -47,5 +47,6 @@
 - imaging/features/pixelization/delaunay # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in Delaunay pixelization fit
 - imaging/features/pixelization/slam # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in SLaM pixelization pipeline
 - imaging/features/advanced/double_einstein_ring/slam # NEEDS_FIX 2026-05-07 - autofit.exc.FitException in SLaM bypass mode (same family as imaging/features/pixelization/slam — Adapt regularization needs adapt_data which the synthetic samples_summary doesn't carry; cascade goes deep, fixing in one PR isn't tractable)
+- group/features/advanced/double_einstein_ring/slam # NEEDS_FIX 2026-05-20 - same cascade as imaging variant — synthetic samples_summary lacks adapt_data; parking pattern of the imaging entry didn't cover this group/ twin
 - interferometer/features/pixelization/delaunay # NEEDS_FIX 2026-04-10 - broadcast shape mismatch (2,2) vs (1032,1032) in Delaunay interferometer
 - multi/features/wavelength_dependence/modeling # NEEDS_FIX 2026-04-10 - autofit.exc.FitException in multi-wavelength modeling


### PR DESCRIPTION
## Summary
**Cluster D** from the 2026-05-20T18-55-23Z release-prep triage — `group/features/advanced/double_einstein_ring/slam.py` was failing with the same `autofit.exc.FitException` in SLaM bypass mode as the imaging variant parked back on 2026-05-07. The original parking pattern (`imaging/features/advanced/double_einstein_ring/slam`) didn't substring-match the group/ twin.

Add a matching NEEDS_FIX entry. Root cause is unchanged from the imaging variant: synthetic samples_summary lacks `adapt_data`; Adapt regularization needs that data; the cascade is deep and not tractable in one PR.

Note on Cluster A (autolens aggregator `mask_header_from` NoneType — the 2 scripts originally bundled with this PR): verified self-resolves on a clean rerun. The autolens `start_here.py` already has the HDU shift (1/2/3) that the autogalaxy side received on 2026-05-08 (commit `c2902672`); the failure in the T18-55-23Z run was a stale-output cascade from a prior broken run. The next `run_all` rewrites clean output via the simulator-and-start_here-first ordering, so no code change is needed.

## API Changes
None — single line in `config/build/no_run.yaml` only.
See full details below.

## Test Plan
- [ ] Next `autobuild run_all` no longer lists `group/.../double_einstein_ring/slam.py` as a failure.
- [x] Cluster A verified: re-running `scripts/guides/results/aggregator/data_fitting.py` from a clean output exits 0.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed
- `config/build/no_run.yaml` — one new NEEDS_FIX entry for the group/ variant of double_einstein_ring/slam.

### Migration
None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)