### PR TITLE
chore: remove fit_quantity config entry

### DIFF
--- a/config/visualize/plots.yaml
+++ b/config/visualize/plots.yaml
@@ -61,9 +61,6 @@ fit_ellipse:                               # Settings for plots of ellipse fitti
   data : true                              # Plot the data of the ellipse fit?
   data_no_ellipse: true                    # Plot the data without the black data ellipses, which obscure noisy data?
 
-fit_quantity:                              # Settings for plots of fit quantities (e.g. FitQuantityPlotter).
-  subplot_fit: true
-
 galaxies:                                  # Settings for plots of galaxies (e.g. GalaxiesPlotter).
   subplot_galaxies: false                  # Plot subplot of all quantities in each galaxies group (e.g. images, convergence)?
   subplot_galaxy_images: false             # Plot subplot of the image of each galaxy in the model?


### PR DESCRIPTION
## Summary

The `FitQuantity` / `AnalysisQuantity` stack has been archived in [PyAutoLens](https://github.com/PyAutoLabs/PyAutoLens)'s `feature/archive-quantity-package` PR. This workspace's `config/visualize/plots.yaml` carried a `fit_quantity: subplot_fit: true` stanza that referenced the deleted library section.

## Changes

- `config/visualize/plots.yaml` — removed the `fit_quantity:` block

## Test plan

- [x] `grep -rE 'fit_quantity' config/` returns zero hits
- [ ] After library PR merges, workspace smoke tests are expected to remain green (no script in this workspace used quantity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)