### PR TITLE
docs: __JAX__ sections in per-dataset scripts (imaging + interferometer + point_source)

### DIFF
--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -26,6 +26,21 @@ __Contents__
 - **Pixel Counting:** An alternative way to quantify residuals like the lens light residuals is pixel counting.
 - **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
 
+__JAX__
+
+This script constructs a `FitImaging` directly from a tracer and dataset
+(no Analysis / no non-linear search). The fit itself is JAX-friendly:
+any quantities it computes (`fit.model_image`, `fit.residual_map`,
+`fit.log_likelihood`, etc.) work on either backend and return arrays
+backed by `numpy.ndarray` on the default path or `jax.Array` if you
+constructed the upstream objects with `xp=jnp`.
+
+For the standard analysis-driven modeling path — where `AnalysisImaging`
+auto-enables `use_jax=True` and the search driver handles the JIT
+internally — see `start_here.py` / `modeling.py`. For the advanced path
+where you wrap your own `@jax.jit` around `FitImaging` construction, see
+`likelihood_function.py`'s `__JAX__` section and the `lens_calc.py` guide.
+
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -503,6 +503,51 @@ light profiles to fit the lens and source light.
 There are a number of other inputs features which slightly change the behaviour of this likelihood function, which
 are described in additional notebooks found in this package. In brief, these describe:
 
- - **Sub-gridding**: Oversampling the image grid into a finer grid of sub-pixels, which are all individually 
+ - **Sub-gridding**: Oversampling the image grid into a finer grid of sub-pixels, which are all individually
  ray-traced to the source-plane and used to evaluate the light profile more accurately.
+
+__JAX__
+
+The step-by-step likelihood you've just walked through can be JAX-
+accelerated by wrapping the whole construction in `@jax.jit`. The
+pattern:
+
+```python
+import jax
+import jax.numpy as jnp
+from autolens.jax import register_tracer_classes
+
+# One-time setup: register Tracer + Galaxy + profile classes as JAX
+# pytrees so the tracer can cross the @jax.jit boundary as an argument.
+register_tracer_classes(tracer)
+
+@jax.jit
+def my_log_likelihood(instance):
+    tracer = al.Tracer(galaxies=instance.galaxies)
+    fit = al.FitImaging(dataset=dataset, tracer=tracer)
+    return fit.log_likelihood
+```
+
+To validate the JAX path matches the NumPy chi-squared you just
+computed, use `Fitness._vmap` (the production validation pattern —
+single `jax.jit(fn)(concrete)` hides un-threaded `xp` sites that
+`vmap(jit(call))` exposes):
+
+```python
+from autofit.non_linear.fitness import Fitness
+
+fitness = Fitness(
+    model=model,
+    analysis=al.AnalysisImaging(dataset=dataset),
+    fom_is_log_likelihood=True,
+)
+log_l_jax = fitness._vmap(jnp.array([instance_parameters]))[0]
+assert np.isclose(log_l_jax, log_l_numpy_from_walkthrough)
+```
+
+For the canonical Analysis-driven modeling path (where you write zero
+JAX code), see `start_here.py` / `modeling.py`. For JIT-ing library
+methods directly (`tracer.image_2d_from`, `LensCalc.magnification_2d_via_hessian_from`,
+etc.) without going through `FitImaging`, see
+`scripts/guides/lens_calc.py`.
 """

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -293,4 +293,48 @@ al.output_to_json(
 
 """
 The dataset can be viewed in the folder `autolens_workspace/imaging/simple`.
+
+__JAX Variant__
+
+For an order-of-magnitude speedup on large or repeated simulations
+(parameter sweeps, mock-data studies, batch figure generation), construct
+the simulator with `use_jax=True` and wrap your call in `@jax.jit`. The
+simulator handles pytree registration internally — you write nothing
+JAX-specific beyond the decorator.
+
+```python
+import jax
+
+simulator_jax = al.SimulatorImaging(
+    exposure_time=300.0,
+    psf=psf,
+    background_sky_level=0.1,
+    add_poisson_noise_to_data=True,
+    use_jax=True,
+)
+
+@jax.jit
+def simulate(tracer):
+    return simulator_jax.via_tracer_from(tracer=tracer, grid=grid)
+
+dataset_jax = simulate(tracer)   # Imaging with jax.Array data
+```
+
+The `dataset_jax.data.array` is a `jax.Array`; `aplt.fits_imaging` and the
+plotters call `numpy.asarray()` internally, so saving / plotting works
+without manual conversion.
+
+Two notes:
+
+- Eager `simulator_jax.via_tracer_from(tracer, grid)` (no `@jax.jit`)
+  already runs on JAX and is sufficient for one-off simulations. The
+  `@jax.jit` wrap is only beneficial when you call the function many times.
+- `@jax.jit` wrap is currently blocked by a pre-existing `Array2D.native`
+  jit-incompatibility in autoarray's slim/native reshape. Eager JAX works
+  today; the `@jax.jit` shown above will work once a separate refactor
+  task lands.
+
+See `scripts/guides/lens_calc.py` for the advanced "JIT-it-yourself"
+pattern that wraps individual library methods like `tracer.image_2d_from`
+directly.
 """

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -32,14 +32,18 @@ __Contents__
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoLens runs imaging model-fits on JAX by default. If you installed
+`autolens[jax]`, the `al.AnalysisImaging(dataset=dataset)` line below
+auto-enables `use_jax=True`; expect 10-30 minutes on CPU, 1-10 minutes on
+GPU, vs 1-2 hours on pure NumPy for a typical lens. If you do not have a
+GPU locally, Google Colab provides free GPUs.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate strong lens imaging. This is useful for building machine learning training datasets,
-or for investigating lensing effects in a controlled way.
+For the broader JAX principles (when you write `@jax.jit` yourself, the
+return-type contract, how to opt out for debugging), see the `__JAX__`
+section of the top-level `autolens_workspace/start_here.py`. For a
+runnable example of the user-written `@jax.jit + SimulatorImaging(use_jax=True)`
+pattern, see the `__JAX Variant__` section at the end of
+`scripts/imaging/simulator.py`.
 
 __Google Colab Setup__
 
@@ -239,11 +243,16 @@ the model to the imaging data.
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+`AnalysisImaging` defaults to `use_jax=True` when JAX is installed (set
+explicitly below for clarity). The search driver wraps the likelihood in
+`jax.vmap(jax.jit(...))` internally — batches of parameter vectors
+evaluate in parallel on a single GPU call. Watch for `JAX: Applying vmap
+and jit to likelihood function -- may take a few seconds.` in the log;
+that's the JIT compile starting, after which evaluations re-use the
+compiled trace.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+Force NumPy with `use_jax=False` (or `PYAUTO_DISABLE_JAX=1`) when
+debugging — NumPy stack traces are easier to read than JAX traces.
 
 __Iterations Per Update__
 

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -24,6 +24,14 @@ __Contents__
 - **Plane Quantities:** The `FitInterferometer` object has specific quantities which break down each image of each plane.
 - **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
 
+__JAX__
+
+`FitInterferometer` runs on either NumPy or JAX. For the standard
+analysis-driven path — where `AnalysisInterferometer` auto-enables
+`use_jax=True` and the search driver handles the JIT — see `start_here.py`
+/ `modeling.py`. For the JIT-it-yourself path around individual library
+methods, see `scripts/guides/lens_calc.py`.
+
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -497,6 +497,36 @@ analytic light profiles to fit the galaxy light.
 There are a number of other inputs features which slightly change the behaviour of this likelihood function, which
 are described in additional notebooks found in the `guides` package:
 
- - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually 
+ - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually
  ray-traced to the source-plane and used to evaluate the light profile more accurately.
+
+__JAX__
+
+The step-by-step interferometer likelihood you've just walked through
+can be JAX-accelerated by wrapping construction in `@jax.jit`. Pattern
+mirrors the `imaging/likelihood_function.py` walkthrough:
+
+```python
+import jax
+import jax.numpy as jnp
+from autolens.jax import register_tracer_classes
+
+register_tracer_classes(tracer)  # one-time pytree setup
+
+@jax.jit
+def my_log_likelihood(instance):
+    tracer = al.Tracer(galaxies=instance.galaxies)
+    fit = al.FitInterferometer(dataset=dataset, tracer=tracer)
+    return fit.log_likelihood
+```
+
+Use `TransformerDFT` (the default) under JAX — `TransformerNUFFT` is not
+JAX-traceable. To validate the JAX log-likelihood matches the NumPy
+chi-squared you derived above, use `Fitness._vmap(jnp.array([parameters]))`
+(production validation pattern — single `jax.jit(fn)(concrete)` would
+hide un-threaded `xp` sites).
+
+For the canonical Analysis-driven path (zero JAX code on your side),
+see `start_here.py` / `modeling.py`. For JIT-ing library methods
+directly, see `scripts/guides/lens_calc.py`.
 """

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -331,4 +331,46 @@ al.output_to_json(
 
 """
 Finish.
+
+__JAX Variant__
+
+For fast repeated interferometer simulations, instantiate the simulator
+with `use_jax=True` and wrap the call in `@jax.jit`. The simulator handles
+pytree registration internally.
+
+```python
+import jax
+import jax.numpy as jnp
+
+simulator_jax = al.SimulatorInterferometer(
+    uv_wavelengths=uv_wavelengths,
+    exposure_time=300.0,
+    noise_sigma=0.1,
+    transformer_class=al.TransformerDFT,  # NUFFT (pynufft) is not JAX-traceable
+    use_jax=True,
+)
+
+@jax.jit
+def simulate(tracer):
+    image = tracer.image_2d_from(grid=real_space_grid, xp=jnp)
+    return simulator_jax.via_image_from(image=image)
+
+dataset_jax = simulate(tracer)   # Interferometer with jax.Array visibilities
+```
+
+Two notes specific to interferometer:
+
+- Use `TransformerDFT` (the default) under JAX. `TransformerNUFFT` (pynufft)
+  is faster on large UV sets but is not JAX-traceable. The `nufftax`
+  research path is tracking a JAX-native NUFFT replacement; see
+  `autolens_workspace_test/scripts/interferometer/nufft.py` for the
+  parity work.
+- Eager `simulator_jax.via_image_from(image)` already runs on JAX without
+  the `@jax.jit` wrap; the JIT only matters for repeated calls. The
+  `@jax.jit` wrap shown above is currently blocked by a pre-existing
+  `Array2D.native` autoarray limitation — eager use works today; the
+  JIT wrap works once a separate refactor lands.
+
+See `scripts/guides/lens_calc.py` for the "JIT-it-yourself" pattern
+applied to individual library methods.
 """

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -30,14 +30,18 @@ __Contents__
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoLens runs interferometer model-fits on JAX by default. If you
+installed `autolens[jax]`, `al.AnalysisInterferometer(dataset=dataset)`
+below auto-enables `use_jax=True`. Use `TransformerDFT` (the default in
+this script) under JAX — `TransformerNUFFT` (pynufft) is faster on large
+UV sets but is not JAX-traceable; the `nufftax` replacement (see the
+`__NUFFT (nufftax)__` section below) is a research path tracking that.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate interferometer datasets. This is useful for building machine
-learning training datasets, or for investigating lensing effects in a controlled way.
+For the broader JAX principles (when you write `@jax.jit` yourself, the
+return-type contract), see the top-level `autolens_workspace/start_here.py`
+`__JAX__` section. For a runnable `@jax.jit + SimulatorInterferometer(use_jax=True)`
+example, see the `__JAX Variant__` section at the end of
+`scripts/interferometer/simulator.py`.
 
 __NUFFT (nufftax)__
 
@@ -235,13 +239,12 @@ Nautilus to fit the model to the interferometer data.
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+`AnalysisInterferometer` defaults to `use_jax=True` when JAX is installed.
+The search driver wraps the likelihood in `jax.vmap(jax.jit(...))` —
+batches of parameter vectors evaluate in parallel. Force NumPy with
+`use_jax=False` (or `PYAUTO_DISABLE_JAX=1`) when debugging.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-**Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce 
+**Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce
 an error. If this occurs, see the `autolens_workspace/guides/modeling/bug_fix` example for a fix.
 """
 search = af.Nautilus(

--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -40,6 +40,22 @@ __Contents__
 - **New User Wrap Up:** The `point_source` package of the `autolens_workspace` contains numerous example scripts for.
 - **Shape Solver:** All calculations above assumed the source was a point source with no size.
 
+__JAX__
+
+This guide walks through point-source fitting at a low level (no
+non-linear search) — the `FitPointDataset` and `PointSolver` objects work
+on either NumPy or JAX. For the standard search-driven modeling path
+where `AnalysisPoint` auto-enables `use_jax=True` and the JIT happens
+inside the search driver, see `start_here.py` / `modeling.py`. For the
+explicit `@jax.jit + PointSolver(use_jax=True)` pattern (useful for fast
+forward-solving in custom code), see `simulator.py`'s `__JAX Variant__`
+section.
+
+Note: `PointSolver(use_jax=True)` works inside `@jax.jit` (unlike the
+imaging / interferometer simulators, which are currently blocked by a
+pre-existing `Array2D.native` autoarray limitation). The triangle-
+refinement loop doesn't go through `.native`.
+
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/point_source/simulator.py
+++ b/scripts/point_source/simulator.py
@@ -486,4 +486,57 @@ dataset.to_csv(
 
 """
 Finished.
+
+__JAX Variant__
+
+The expensive step in point-source simulation is the multiple-image
+solve — `PointSolver` runs an iterative triangle-refinement loop. On
+JAX-jit this is order-of-magnitude faster than NumPy.
+
+```python
+import jax
+import jax.numpy as jnp
+from autolens.jax import register_tracer_classes
+
+# One-time setup: register Tracer + Galaxy + profile classes as JAX
+# pytrees BEFORE the first @jax.jit call. (Inside @jax.jit, JAX flattens
+# function arguments at trace time — auto-registration inside solve()
+# runs too late.)
+register_tracer_classes(tracer)
+
+solver_jax = al.PointSolver.for_grid(
+    grid=al.Grid2D.uniform(shape_native=(100, 100), pixel_scales=1.0),
+    pixel_scale_precision=0.001,
+    magnification_threshold=0.1,
+    use_jax=True,
+)
+
+@jax.jit
+def solve(tracer, coord):
+    return solver_jax.solve(tracer=tracer, source_plane_coordinate=coord).array
+
+positions = solve(tracer, jnp.asarray(source_galaxy.bulge.centre))
+```
+
+When `use_jax=True`, `PointSolver.solve` defaults `remove_infinities=False`
+to honour the JAX static-shape contract — positions are padded with `inf`
+where no image was found. Strip them outside the jit:
+
+```python
+raw = np.asarray(positions)
+finite_positions = raw[~np.isinf(raw).any(axis=1)]
+```
+
+Two notes:
+
+- `register_tracer_classes(tracer)` is the one user-visible setup call.
+  After the first invocation, every later `@jax.jit` with the same class
+  set works without re-registering.
+- Unlike imaging / interferometer simulators, the `PointSolver.use_jax=True`
+  + `@jax.jit` wrap really does work inside jit (it doesn't go through the
+  pre-existing `Array2D.native` autoarray limitation that blocks the image
+  simulators).
+
+See `scripts/guides/lens_calc.py` for the broader "JIT-it-yourself"
+pattern applied to other library methods.
 """

--- a/scripts/point_source/start_here.py
+++ b/scripts/point_source/start_here.py
@@ -40,14 +40,17 @@ __Contents__
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoLens runs point-source model-fits on JAX by default. `AnalysisPoint`
+auto-enables `use_jax=True` if you installed `autolens[jax]`; the search
+driver wraps the likelihood in `jax.vmap(jax.jit(...))`.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate strong lens point sources. This is useful for building machine learning
-training datasets, or for investigating lensing effects in a controlled way.
+For the broader JAX principles see `autolens_workspace/start_here.py`
+`__JAX__`. For the most user-impactful piece — the `PointSolver(use_jax=True)`
++ `@jax.jit` pattern for fast forward solving — see the `__JAX Variant__`
+at the end of `scripts/point_source/simulator.py`. Point-source solving
+is the rare case where the `@jax.jit` wrap really pays off (the
+triangle-refinement loop dominates simulation runtime); the variant
+script shows how to do it cleanly.
 
 __Google Colab Setup__
 
@@ -245,13 +248,14 @@ the model to the point source data.
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+`AnalysisPoint` defaults to `use_jax=True` when JAX is installed.
+`AnalysisPoint._register_fit_point_pytrees()` runs on first `fit_from`
+to register `FitPositionsSource`, `FitPositionsImagePair`, and `Tracer`
+as JAX pytrees — you don't need to call `register_tracer_classes`
+yourself for the modeling path (that's only required for the explicit
+JIT-it-yourself pattern in `simulator.py`'s `__JAX Variant__`).
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-**Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce 
+**Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce
 an error. If this occurs, see the `autolens_workspace/guides/modeling/bug_fix` example for a fix.
 """
 search = af.Nautilus(


### PR DESCRIPTION
## Summary

Phase 3a + 3b + 3d of `z_features/jax_user_intro.md` bundled into one PR. Adds `__JAX__` prose and `__JAX Variant__` runnable code blocks across the three core per-dataset script sets — `imaging`, `interferometer`, `point_source` — in `scripts/{imaging,interferometer,point_source}/{start_here,simulator,fit,likelihood_function}.py`.

Per-dataset `start_here.py` scripts refresh stale `__JAX__` blocks that predated the Phase 0 contract; `simulator.py` scripts gain `__JAX Variant__` blocks using the post-Phase-2 `Simulator(use_jax=True)` / `PointSolver(use_jax=True)` APIs that landed in PyAutoArray#335, #336 and PyAutoLens#538.

## Scripts Changed
- `scripts/imaging/start_here.py` — refresh 2 stale `__JAX__` blocks
- `scripts/imaging/simulator.py` — new `__JAX Variant__` (`SimulatorImaging(use_jax=True)`)
- `scripts/imaging/fit.py` — `__JAX__` prose
- `scripts/imaging/likelihood_function.py` — `__JAX__` section with `@jax.jit` recipe + `Fitness._vmap` validation
- `scripts/interferometer/start_here.py` — refresh 2 `__JAX__` blocks + TransformerDFT/NUFFT caveat
- `scripts/interferometer/simulator.py` — new `__JAX Variant__` (`SimulatorInterferometer(use_jax=True)`)
- `scripts/interferometer/fit.py` — `__JAX__` prose
- `scripts/interferometer/likelihood_function.py` — `__JAX__` section
- `scripts/point_source/start_here.py` — refresh 2 `__JAX__` blocks + `register_tracer_classes` note
- `scripts/point_source/simulator.py` — new `__JAX Variant__` with `PointSolver(use_jax=True)` + `register_tracer_classes`
- `scripts/point_source/fit.py` — `__JAX__` section in top docstring

## Test Plan

- [x] All 11 files compile cleanly via `py_compile`
- [x] `scripts/check_sizes.sh` passes (all scripts grew, none shrank)
- [x] Simulator scripts run end-to-end with `PYAUTO_TEST_MODE=1`

## Notes

`point_source/simulator.py`'s `__JAX Variant__` is the only one whose `@jax.jit` wrap really works end-to-end — `PointSolver(use_jax=True)` doesn't go through the `Array2D.native` autoarray limitation that currently blocks image / interferometer simulators under `@jax.jit`. Eager JAX use works for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)