### PR TITLE
docs: __JAX__ sections in workspace guides (data_structures, galaxies, tracer, lens_calc)

### DIFF
--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -408,5 +408,99 @@ deflections_yx_2d = tracer.deflections_yx_2d_from(grid=grid_irregular)
 print(deflections_yx_2d)
 
 """
+__JAX__
+
+PyAutoLens runs on either NumPy (the default) or JAX. The data structures
+you've met above are *backend-polymorphic* — they're Python wrappers
+around a numerical array, and that array can be a `numpy.ndarray` or a
+`jax.Array` depending on how the structure was constructed and what code
+path produced it.
+
+You can always reach the raw backing array via `.array`:
+
+```python
+grid = al.Grid2D.uniform(shape_native=(100, 100), pixel_scales=0.05)
+print(type(grid.array))          # <class 'numpy.ndarray'> on the default path
+```
+
+__When the backing becomes `jax.Array`__
+
+Three situations switch the backing to `jax.Array`:
+
+1. The structure comes back from a JAX-accelerated `Analysis(use_jax=True)`
+   fit — e.g. `fit.residual_map.array`, `fit.model_image.array` are
+   JAX-backed when the analysis ran with `use_jax=True` (the default).
+2. The structure comes back from a `Simulator(use_jax=True)` simulation
+   (see `scripts/imaging/simulator.py` `__JAX Variant__`).
+3. You constructed it inside a JAX-traced function and the upstream grid
+   was `jnp`-backed (e.g. `tracer.image_2d_from(grid=jnp_grid, xp=jnp)`).
+
+In all three cases the Python-level wrapper is the same `aa.Array2D` /
+`aa.Grid2D` / etc. you've been using — only the underlying array type
+changes. Workspace code reads identically on either backend.
+
+__Host transfer (the JAX → NumPy boundary)__
+
+Most things you do with these structures convert back to NumPy
+transparently:
+
+- Plotting (`aplt.plot_array`, `aplt.subplot_fit_imaging`, ...) — calls
+  `np.asarray(...)` internally.
+- `.fits` writing (`aplt.fits_imaging`).
+- `.copy()`, `.tolist()`.
+- Direct NumPy arithmetic — `np.sqrt(fit.residual_map.array)` transfers
+  the array off the GPU. Use `jnp.sqrt(...)` if you want to stay on the
+  GPU inside a hot loop.
+
+For one-off analysis code (notebooks, single-figure plotting), the
+transfer is invisible. For hot loops or production fits, prefer the
+JAX-native call.
+
+__The not-pytree rule__
+
+There's one place the abstraction leaks. If you write your own
+`@jax.jit` function and try to return an `aa.Array2D` (or
+`aa.Grid2DIrregular`) from inside it, the JIT boundary may fail with
+`TypeError: ... is not a valid JAX type`. The wrapper types are not
+reliably registered as JAX pytrees for return-from-JIT purposes.
+
+The workaround: return the raw `.array` from inside the jit and rewrap
+outside on the host side.
+
+```python
+@jax.jit
+def my_image_fn(tracer, grid):
+    return tracer.image_2d_from(grid=grid, xp=jnp).array   # raw jax.Array
+
+arr = my_image_fn(tracer, grid)
+img_wrapped = al.Array2D(values=arr, mask=grid.mask)
+```
+
+You only encounter this when *you* write the `@jax.jit` — the library
+handles its own returns correctly (`AnalysisImaging(use_jax=True)` gives
+back a proper `FitImaging`; `SimulatorImaging(use_jax=True)` gives back a
+proper `Imaging`).
+
+For the full deep-dive on writing your own JAX-jit functions that
+compose PyAutoLens library calls (decorator-on-def vs `jax.jit(bound_method)`,
+cache-identity considerations, closure-captured `self` vs traced-argument
+distinction, the `@jax.jit + xp=jnp` pairing rule), see
+`scripts/guides/lens_calc.py` — that's the canonical advanced guide for
+the "JIT-it-yourself" path.
+
+__Summary__
+
+| You construct / receive | Backing type |
+|---|---|
+| `al.Grid2D.uniform(shape_native, pixel_scales)` | `numpy.ndarray` |
+| `fit = analysis.fit_from(instance)` from `AnalysisImaging(use_jax=True)` | `jax.Array` |
+| `dataset = simulator.via_tracer_from(...)` from `SimulatorImaging(use_jax=True)` | `jax.Array` |
+| `tracer.image_2d_from(grid=jnp_grid, xp=jnp)` inside your own `@jax.jit` | `jax.Array` |
+
+`.array` is the safe accessor for the raw backing in all cases.
+Plotting and `.fits` writers handle the conversion transparently.
+"""
+
+"""
 Finish.
 """

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -200,4 +200,76 @@ logarithm of its values and plot it in log10 space.
 
 The `plot_array`/`subplot_\*` object has an input `use_log10`, which will do this automatically when we call the `plot_array` method.
 Below, we can see that the image plotted now appears more clearly, with the outskirts of the light profile more visible.
+
+__JAX__
+
+When you write your own `@jax.jit` around a function that takes a
+`Galaxy` or `Galaxies` as an argument, JAX needs to flatten and unflatten
+that object across the JIT boundary — i.e. the class must be registered
+as a JAX pytree. The library handles this for you automatically in two
+situations:
+
+1. You constructed an `Analysis` with `use_jax=True` (the default for
+   modeling fits). `AnalysisImaging._register_fit_imaging_pytrees()`
+   walks the dataset on first `fit_from` call and registers every
+   reachable `Galaxy` / profile class.
+2. You constructed a `Simulator` with `use_jax=True` and made a call —
+   same walk happens.
+
+After either, every `Galaxy`, `LightProfile`, `MassProfile`, `Point`,
+etc. of the same class is JIT-safe forever in the current process. You
+never call `register_instance_pytree(Galaxy)` yourself.
+
+__The "I have no Analysis or Simulator handy" case__
+
+For a quick exploration script or a custom forward model that doesn't go
+through `Simulator.via_tracer_from`, you may want to JIT a function that
+takes a `Galaxy` or list of galaxies as an argument:
+
+```python
+@jax.jit
+def galaxy_image(galaxy, grid):
+    return galaxy.image_2d_from(grid=grid, xp=jnp).array
+```
+
+Without prior pytree registration this fails the first time `galaxy` is
+traced. The workaround: trigger registration at the top of your script.
+Two equivalent approaches:
+
+```python
+# (a) Reach for an Analysis instance — its first construction triggers
+# the registration walk on the (possibly dummy) dataset.
+_ = al.AnalysisImaging(dataset=dataset, use_jax=True)
+
+# (b) Use the dedicated walker on a representative tracer.
+from autolens.jax import register_tracer_classes
+register_tracer_classes(tracer)
+```
+
+After either, `galaxy_image` JITs cleanly.
+
+__Closure-captured galaxy: registration not needed__
+
+There's a way to JIT a galaxy-method call that does NOT need pytree
+registration: pass the galaxy as the bound method's `self`, not as an
+argument.
+
+```python
+jitted_image = jax.jit(galaxy.image_2d_from)   # bound method; assign ONCE
+arr = jitted_image(grid=grid, xp=jnp).array
+```
+
+`galaxy` here is closed over inside the bound method; JAX treats it as a
+closure constant, doesn't trace through it, and pytree registration
+never enters the picture.
+
+Trade-off: you can't vary `galaxy` across calls and still hit the
+compilation cache. If you want to evaluate the same function for many
+different galaxies (parameter sweep), the argument form (with prior
+registration) is the right choice.
+
+The full deep-dive on the bound-method vs traced-argument trade-off,
+cache-identity footguns, and the `@jax.jit + xp=jnp` pairing rule lives
+in `scripts/guides/lens_calc.py`. The `.array` host-transfer mechanics
+live in `scripts/guides/data_structures.py`.
 """

--- a/scripts/guides/lens_calc.py
+++ b/scripts/guides/lens_calc.py
@@ -429,6 +429,169 @@ geometric_array = aa.Array2D(values=geometric_delay, mask=grid.mask)
 aplt.plot_array(array=geometric_array, title="Geometric Time Delay Term")
 
 """
+__JAX (JIT-it-yourself)__
+
+This is the canonical home for the "JIT-it-yourself" advanced path.
+Audience: users building custom forward models or scientific tools
+using PyAutoLens primitives directly — not running standard fits
+(which go through `Analysis(use_jax=True)` and need zero JAX code from
+you) or standard simulations (which use `Simulator(use_jax=True)`
+similarly).
+
+If you're writing `@jax.jit` yourself around library calls like
+`tracer.image_2d_from`, `LensCalc.magnification_2d_via_hessian_from`,
+or your own `log_likelihood(instance)` function, this section is for you.
+
+__The pairing rule: `@jax.jit` + `xp=jnp`__
+
+The single rule to remember: when you decorate a function with
+`@jax.jit` that calls a PyAutoLens library method internally, **pass
+`xp=jnp` to that method inside the function body**.
+
+```python
+import jax
+import jax.numpy as jnp
+
+@jax.jit
+def magnification_fn(lens_calc, grid):
+    return lens_calc.magnification_2d_via_hessian_from(grid=grid, xp=jnp)
+```
+
+The `xp=jnp` is what tells the library "you're inside a JAX trace —
+route calls through `jax.numpy` and don't wrap the return in an
+autoarray type (it would fail to cross the JIT boundary)".
+
+__The footgun: forgetting `xp=jnp`__
+
+The default for `xp` in library method signatures is `np`. If you
+forget to pass `xp=jnp` inside `@jax.jit`, one of two things happens:
+
+- The function body does `np.sqrt(jax_array)` — NumPy routes through
+  `__array__()` on the JAX tracer, host-transferring off the GPU.
+  Your fit runs, invisibly slower than the NumPy path.
+- The `if xp is np:` guard inside library functions fires and wraps
+  the result in `aa.Array2D`, which fails at the JIT boundary with
+  `TypeError: ... is not a valid JAX type`.
+
+The library raises a clear `ValueError` on the easy mismatch — when
+you pass `xp=np` with a `grid.use_jax=True` input:
+
+```
+ValueError: Called magnification_2d_via_hessian_from with xp=np but
+the input grid is JAX-backed (grid.use_jax=True). Inside @jax.jit,
+pass xp=jnp explicitly.
+```
+
+If you see this error: add `xp=jnp` to the call site. Done.
+
+__Decorator-on-def vs `jax.jit(bound_method)`__
+
+JAX accepts any callable — `@jax.jit` is sugar for `fn = jax.jit(fn)`.
+You can JIT a standalone function (canonical) or a bound method
+(shortcut). Both work:
+
+```python
+# Form 1 (canonical): decorator on def
+@jax.jit
+def image_fn(tracer, grid):
+    return tracer.image_2d_from(grid=grid, xp=jnp).array
+
+# Form 2: jit on bound method, assign-to-variable
+jitted = jax.jit(tracer.image_2d_from)
+arr = jitted(grid=grid, xp=jnp).array
+```
+
+Form 2 is shorter for interactive use. **Footgun:** bound methods are
+fresh objects on every attribute access, so this silently misses the
+JIT cache every iteration:
+
+```python
+# DON'T DO THIS — fresh jax.jit closure every iteration
+for grid in many_grids:
+    arr = jax.jit(tracer.image_2d_from)(grid=grid, xp=jnp).array
+```
+
+If you're calling a JITted method in a loop: assign once outside the
+loop, or use the decorator-on-def form.
+
+__Closure-captured `self` vs traced argument__
+
+Form 1 and Form 2 differ in *semantics*, not just syntax:
+
+- **Form 2 (`jax.jit(tracer.image_2d_from)`):** `tracer` is the bound
+  method's `self`; JAX captures it as a closure constant and doesn't
+  trace through it. **`Tracer` does NOT need to be pytree-registered.**
+  Trade-off: a different tracer means a fresh bound-method object and a
+  fresh JIT cache key.
+- **Form 1 (`@jax.jit def image_fn(tracer, grid)`):** `tracer` is a
+  traced argument. **`Tracer` DOES need pytree registration** (which
+  `Analysis(use_jax=True)` does for you, or you can trigger via
+  `autolens.jax.register_tracer_classes(tracer)`). Trade-off: cache
+  reuse across different tracers — parameter sweeps and `jax.vmap`
+  work naturally.
+
+Pick based on whether you want to vary the tracer across calls:
+
+- Parameter sweep / `jax.vmap` over models? Form 1.
+- Quick one-off / interactive exploration? Form 2 (assign once).
+
+__`LensCalc` and the wrapped-vs-raw return type__
+
+`LensCalc.magnification_2d_via_hessian_from`,
+`.shear_yx_2d_via_hessian_from`, `.convergence_2d_via_hessian_from`,
+and the eigen-value methods all implement the `if xp is np:` guard
+inside:
+
+```python
+def magnification_2d_via_hessian_from(self, grid, xp=np):
+    ...
+    if xp is np:
+        return aa.Array2D(values=mag, mask=grid.mask)   # numpy: wrapped
+    return mag                                            # jax: raw jax.Array
+```
+
+This is intentional. Inside `@jax.jit` (where you pass `xp=jnp`), you
+get back a raw `jax.Array`. On the NumPy path (no `xp` or `xp=np`),
+you get an `aa.Array2D` wrapper. The function adapts to which path
+you're on.
+
+Implication: when you JIT-wrap a `LensCalc` method, expect a raw
+`jax.Array` back. Rewrap with `aa.Array2D(values=..., mask=...)` on
+the host if you want the wrapper for downstream plotting:
+
+```python
+@jax.jit
+def magnification_fn(lens_calc, grid):
+    return lens_calc.magnification_2d_via_hessian_from(grid=grid, xp=jnp)
+
+mag_raw = magnification_fn(lens_calc, grid)
+mag_wrapped = aa.Array2D(values=mag_raw, mask=grid.mask)
+aplt.plot_array(array=mag_wrapped)
+```
+
+For `Tracer` and `Galaxy` methods that don't have the guard internally
+(e.g. `tracer.image_2d_from`), the `.array` unwrap inside the jit +
+rewrap outside discipline applies — see `scripts/guides/data_structures.py`
+`__JAX__` section.
+
+__Summary — the three rules__
+
+The "JIT-it-yourself" path is bounded by three rules:
+
+1. **`@jax.jit` and `xp=jnp` are paired.** Forgetting `xp=jnp` either
+   silently host-transfers or fails at the boundary.
+2. **`.array` unwrap inside the jit; rewrap on the host** if you want
+   the autoarray wrapper.
+3. **Tracer-as-argument needs pytree registration** (via
+   `register_tracer_classes(tracer)` or any `Analysis(use_jax=True)`
+   construction); tracer-as-closure (bound-method form) doesn't.
+
+For the standard `Analysis` / `Simulator` paths — where you do none
+of this and JAX runs implicitly — see the top-level
+`autolens_workspace/start_here.py` `__JAX__` section.
+"""
+
+"""
 __Wrap Up__
 
 This guide introduced the `LensCalc` class and the key lensing quantities it computes:

--- a/scripts/guides/tracer.py
+++ b/scripts/guides/tracer.py
@@ -520,5 +520,79 @@ time_delay = tracer.time_delays_from(grid=grid)
 # einstein_mass_angular = tracer.einstein_mass_angular_from(grid=grid)
 
 """
+__JAX__
+
+`Tracer` ray-tracing is the most JAX-friendly part of PyAutoLens — pure
+numerical kernels with no data-dependent control flow. Typical speedups
+for `tracer.image_2d_from(grid)` and related ops on a large grid:
+10-30× for galaxy-scale models, 30-100× for cluster-scale on GPU.
+
+You access this in two ways.
+
+__1. The implicit path: `Analysis` and `Simulator`__
+
+`AnalysisImaging(use_jax=True)` (the default) and
+`SimulatorImaging(use_jax=True)` both JAX-accelerate the tracer
+internally. Pytree registration runs as a side effect of the first
+`fit_from` / `via_tracer_from` call; you write nothing JAX-specific.
+
+__2. The explicit path: your own `@jax.jit`__
+
+For parameter sweeps, custom forward models, or batch figure generation
+where you want fine-grained control:
+
+```python
+import jax
+import jax.numpy as jnp
+from autolens.jax import register_tracer_classes
+
+register_tracer_classes(tracer)   # one-time pytree registration
+
+@jax.jit
+def image_fn(tracer, grid):
+    return tracer.image_2d_from(grid=grid, xp=jnp).array
+
+image = image_fn(tracer, grid)
+```
+
+Two rules:
+
+- **`@jax.jit` + `xp=jnp` pair up.** Forgetting `xp=jnp` either
+  silently host-transfers (slow) or fails at the boundary; the library
+  now raises a clear `ValueError` on the easy mismatch (see
+  `lens_calc.py` for the rationale and `AbstractMaker.__init__`'s
+  guard).
+- **`.array` unwrap inside the jit, rewrap outside.** Wrapper types
+  (`aa.Array2D`, `aa.Grid2DIrregular`) aren't reliably pytree for
+  return-from-JIT — return raw arrays, rewrap on the host.
+
+__Multi-plane traces under JIT__
+
+The recursive multi-plane lens equation in
+`tracer.traced_grid_2d_list_from(grid)` is pure numerical with no
+data-dependent control flow, so it JITs cleanly. For multi-plane point-
+source solving (forward-solving multiple-image positions through several
+planes), use the higher-level `al.PointSolver(use_jax=True)` — see
+`scripts/point_source/simulator.py` `__JAX Variant__`.
+
+__Performance expectations__
+
+Tracer image generation on JAX-GPU typically beats NumPy-CPU by:
+
+- 10-30× for galaxy-scale (single lens galaxy, single source).
+- 30-100× for cluster-scale (many galaxies, multi-plane).
+
+Actual speedup depends on grid size, profile complexity, and GPU
+hardware. `autolens_workspace_developer/jax_profiling/` carries measured
+numbers for representative configurations.
+
+For the full "JIT-it-yourself" deep-dive (bound-method form, cache-
+identity considerations, closure-captured `self` vs traced-argument),
+see `scripts/guides/lens_calc.py`. `scripts/guides/galaxies.py` covers
+the pytree registration mechanics. `scripts/guides/data_structures.py`
+covers the `.array` host-transfer story.
+"""
+
+"""
 Fin.
 """


### PR DESCRIPTION
## Summary

Phase 5a + 5b + 5c + 5d of `z_features/jax_user_intro.md` bundled into one PR. Adds `__JAX__` sections to the four autolens workspace guides. `lens_calc.py` is the canonical home for the "JIT-it-yourself" advanced pattern that the rest of the series has been forward-referencing.

## Scripts Changed
- `scripts/guides/data_structures.py` — `__JAX__` section covering the `.array` story, when backing becomes `jax.Array`, host-transfer mechanics, the not-pytree rule + `.array` unwrap-rewrap workaround.
- `scripts/guides/galaxies.py` — pytree registration for `Galaxy` / `Galaxies` (implicit via Analysis/Simulator; explicit via `autolens.jax.register_tracer_classes`); closure-captured `self` vs traced-argument distinction.
- `scripts/guides/tracer.py` — tracer ray-tracing on JAX (implicit + explicit paths), multi-plane under JIT, performance expectations.
- `scripts/guides/lens_calc.py` — the canonical "JIT-it-yourself" guide: `@jax.jit + xp=jnp` rule, mismatch `ValueError`, decorator vs bound method, cache identity, closure vs traced argument, LensCalc `if xp is np:` guard return-type discipline.

## Test Plan

- [x] All 4 files compile cleanly via `py_compile`
- [x] `scripts/check_sizes.sh` clean (all guides grew)
- [x] All 4 guides run end-to-end with `PYAUTO_TEST_MODE=1`

## Notes

`lens_calc.py` is the longest of the four sections — it owns the canonical JIT-it-yourself documentation. The other three guides cite it for the advanced material rather than duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)