### PR TITLE
docs: __JAX__ in deferred datasets (multi + group + cluster) + cluster simulator migration

### DIFF
--- a/scripts/cluster/likelihood_function.py
+++ b/scripts/cluster/likelihood_function.py
@@ -798,4 +798,34 @@ Next steps:
 
 For a deeper understanding of cluster lens modelling and point-source likelihoods, the
 **HowToLens** Jupyter notebook lectures cover both topics in detail.
+
+__JAX__
+
+The chi-squared walkthrough above is pure NumPy. To JAX-accelerate it,
+wrap construction in `@jax.jit` with the post-Phase-2 `PointSolver`
+pattern:
+
+```python
+import jax
+import jax.numpy as jnp
+from autolens.jax import register_tracer_classes
+
+register_tracer_classes(tracer)  # one-time
+
+@jax.jit
+def cluster_log_likelihood(tracer, dataset, source_galaxy):
+    fit = al.FitPositionsSource(
+        name=dataset.name,
+        data=dataset.positions,
+        noise_map=dataset.positions_noise_map,
+        tracer=tracer,
+        solver=None,  # source-plane chi² doesn't need the solver
+        profile=getattr(source_galaxy, dataset.name),
+    )
+    return fit.log_likelihood
+```
+
+For the canonical search-driven path (`AnalysisPoint(use_jax=True)`),
+see `modeling.py`. For JIT-ing library methods directly without going
+through `FitPositionsSource`, see `scripts/guides/lens_calc.py`.
 """

--- a/scripts/cluster/modeling.py
+++ b/scripts/cluster/modeling.py
@@ -443,9 +443,11 @@ log likelihoods; each dataset gets its own output subdirectory for visualization
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for GPU/CPU acceleration. With a GPU, fits run much faster (around
-10 minutes vs an hour); on CPU JAX still helps via multithreading (20–30 minutes typical). Google Colab
-offers free GPUs.
+`AnalysisPoint(use_jax=True)` per-dataset; the search driver wraps the
+joint likelihood in `jax.vmap(jax.jit(...))`. Cluster point-source fits
+get the largest speedup from JAX on GPU (triangle refinement + multi-
+plane deflection sum dominate runtime). Force NumPy with `use_jax=False`
+when debugging.
 """
 analysis_list = [
     al.AnalysisPoint(dataset=dataset, solver=solver, use_jax=True)

--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -126,19 +126,14 @@ __JAX JIT__
 
 Solving the lens equation for the image-plane positions of a point source is iterative and numerically
 expensive — at cluster scale (many lens galaxies, multi-plane ray tracing) it dominates the simulator's
-runtime by an order of magnitude. We accelerate it with JAX, jitting the ``PointSolver.solve`` call so
-the triangle-refinement loop compiles to a single fused kernel.
+runtime by an order of magnitude. We accelerate it with JAX via ``al.PointSolver(use_jax=True)`` and a
+``@jax.jit`` wrapper around the solve call.
 
-The pattern mirrors the canonical example in
-``autolens_workspace_developer/jax_profiling/point_source/image_plane.py``: every concrete class reachable
-from the `Tracer` (i.e. `Galaxy`, light/mass profiles, `Point`) is registered with ``jax.tree_util`` so
-that JAX can flatten and unflatten a `Tracer` argument. PyAutoFit's
-``autofit.jax.register_model(model)`` walks an ``af.Model`` and registers each ``cls`` it sees;
-PyAutoArray's ``register_instance_pytree(Tracer, ...)`` registers the `Tracer` container itself.
-
-The result is that ``jax.jit(solver.solve)`` accepts the concrete `Tracer` directly, traces it once,
-caches the compiled triangle-refinement kernel, and reuses it for the second source — turning what was
-~5 minutes of Python-loop overhead into a few seconds of compiled JAX execution.
+The library handles pytree registration of ``Tracer`` + every Galaxy / profile class internally via
+``autolens.jax.register_tracer_classes(tracer)`` (one user-visible setup line, called before the first
+``@jax.jit`` invocation). The compiled triangle-refinement kernel is cached and reused across both
+sources — turning what was ~5 minutes of Python-loop overhead into a few seconds of compiled JAX
+execution.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports
@@ -154,9 +149,8 @@ import autofit as af
 import autolens as al
 import autolens.plot as aplt
 
-from autofit.jax import register_model as _register_model_pytrees
-from autoarray.abstract_ndarray import register_instance_pytree
-from autolens.lens.tracer import Tracer
+# Pytree registration is now handled by autolens.jax.register_tracer_classes,
+# called once before the @jax.jit'd PointSolver call further below.
 
 """
 __Dataset Paths__
@@ -393,116 +387,38 @@ tracer = al.Tracer(
 )
 
 """
-__JAX JIT__
+__JAX JIT — Point Solver__
 
-Register every concrete class reachable from the `Tracer` as a JAX pytree node so the tracer can be
-passed across a ``jax.jit`` boundary. We use both registration paths:
+Solving the lens equation for the image-plane positions of a point source is iterative and numerically
+expensive — at cluster scale it dominates the simulator's runtime. We use ``al.PointSolver(use_jax=True)``
+and wrap the solve in ``@jax.jit`` for the speedup.
 
- - ``register_model(...)`` (PyAutoFit) walks an ``af.Model`` mirror of the tracer and registers each
-   ``Galaxy`` / profile class, populating the constructor-arg classifier needed for round-tripping.
- - ``register_instance_pytree(Tracer, no_flatten=("cosmology",))`` (PyAutoArray) registers the `Tracer`
-   container itself via ``__dict__`` flattening, holding `cosmology` static across the JIT boundary.
+The library handles pytree registration of ``Tracer`` + every reachable galaxy / profile class via
+the one-time ``autolens.jax.register_tracer_classes(tracer)`` call below. Before
+PR PyAutoLens#538 + PyAutoArray#335 (Phase 2 of ``z_features/jax_user_intro.md``), this section was
+a ~60-line manual ceremony with an ``af.Model`` mirror, ``register_model``, and ``register_instance_pytree``;
+the new API collapses it to a single import + single registration call + ``use_jax=True`` flag.
 
-The mirror model covers one Galaxy per concrete *class* that appears in the tracer: the 2 main-tier
-galaxies (registering `Galaxy`, `SersicSph`, `dPIEMassSph`), the host halo (adding `NFWMCRLudlowSph`),
-and the 2 source-tier galaxies (adding `SersicCore`, `Point`). The 10 scaling-tier members reuse the
-exact same `Galaxy` / `SersicSph` / `dPIEMassSph` classes registered via the main-tier loop — class
-registration is global once registered, so the scaling tier does not need its own mirror entries. It is
-built solely so that ``register_model`` has something to walk — the simulator does not need an
-`Analysis` or non-linear search.
+``PointSolver(use_jax=True).solve`` defaults ``remove_infinities=False`` to honour the JAX static-shape
+contract — the returned positions are padded with ``inf`` where no image was found, which is JIT-safe.
+We strip them outside the jit below.
 """
-_lens_models = [
-    af.Model(
-        al.Galaxy,
-        redshift=redshift_lens,
-        bulge=af.Model(
-            al.lp.SersicSph,
-            centre=g.bulge.centre,
-            intensity=g.bulge.intensity,
-            effective_radius=g.bulge.effective_radius,
-            sersic_index=g.bulge.sersic_index,
-        ),
-        mass=af.Model(
-            al.mp.dPIEMassSph,
-            centre=g.mass.centre,
-            ra=g.mass.ra,
-            rs=g.mass.rs,
-            b0=g.mass.b0,
-        ),
-    )
-    for g in main_lens_galaxies
-]
+from autolens.jax import register_tracer_classes
 
-_halo_model = af.Model(
-    al.Galaxy,
-    redshift=redshift_lens,
-    dark=af.Model(
-        al.mp.NFWMCRLudlowSph,
-        centre=host_halo_centre,
-        mass_at_200=host_halo.mass_at_200,
-        redshift_object=redshift_lens,
-        redshift_source=max(source_redshifts),
-    ),
-)
+register_tracer_classes(tracer)
 
-_source_models = [
-    af.Model(
-        al.Galaxy,
-        redshift=src_z,
-        bulge=af.Model(
-            al.lp.SersicCore,
-            centre=src_centre,
-            ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0 + 30.0 * i),
-            intensity=2.0,
-            effective_radius=0.3,
-            sersic_index=1.0,
-        ),
-        **{
-            f"point_{i}": af.Model(al.ps.Point, centre=src_centre),
-        },
-    )
-    for i, (src_centre, src_z) in enumerate(zip(source_centres, source_redshifts))
-]
-
-_registration_model = af.Collection(
-    galaxies=af.Collection(*(_lens_models + [_halo_model] + _source_models))
-)
-
-_register_model_pytrees(_registration_model)
-register_instance_pytree(Tracer, no_flatten=("cosmology",))
-
-"""
-__Point Solver__
-
-For each source's `Point` component we solve for the (y, x) coordinates in the image plane that map to
-the source-plane centre — these are the multiple images. The `PointSolver` ray-traces triangles from the
-image plane back to the source plane, iteratively refining until the requested precision is reached.
-
-The solver uses its own higher-resolution starting grid because the imaging grid above is tuned for image
-rendering, not triangle root-finding. ``magnification_threshold=0.1`` discards heavily demagnified central
-images, which are usually undetectable in real data.
-
-The solve call is wrapped in ``jax.jit``: each invocation passes ``xp=jnp`` and
-``remove_infinities=False`` so the solver returns a static-shape array (padded with ``inf`` sentinels
-where no image was found), which JAX can JIT cleanly. The infinities are stripped outside the JIT after
-the call returns.
-"""
 solver = al.PointSolver.for_grid(
     grid=al.Grid2D.uniform(shape_native=(800, 800), pixel_scales=0.1),
     pixel_scale_precision=0.001,
     magnification_threshold=0.1,
+    use_jax=True,
 )
 
 
 @jax.jit
 def jitted_solve(tracer, source_plane_coordinate):
-    # Grid2DIrregular is not a JAX pytree, so unwrap to the raw jnp array
-    # before returning out of the jit trace.
     return solver.solve(
-        tracer=tracer,
-        source_plane_coordinate=source_plane_coordinate,
-        xp=jnp,
-        remove_infinities=False,
+        tracer=tracer, source_plane_coordinate=source_plane_coordinate
     ).array
 
 

--- a/scripts/cluster/start_here.py
+++ b/scripts/cluster/start_here.py
@@ -43,9 +43,19 @@ __Contents__
 
 __JAX__
 
-**PyAutoLens** uses JAX under the hood for fast GPU/CPU acceleration. On a GPU the cluster fit below
-runs in ~10 minutes; on CPU JAX still multi-threads the likelihood evaluation and the fit completes in
-20–30 minutes. Google Colab provides free GPUs if you don't have one locally.
+PyAutoLens runs cluster point-source fits on JAX by default —
+`al.AnalysisPoint(use_jax=True)` (auto-enabled) routes the likelihood
+through `jax.vmap(jax.jit(...))`. Cluster fits benefit the most from
+GPU acceleration: the multi-galaxy multi-plane deflection sum + the
+`PointSolver` triangle refinement loop are the dominant costs and
+both vectorise cleanly on GPU. Expect ~10 minutes per fit on GPU vs
+30+ on CPU.
+
+For the broader JAX principles, see the top-level
+`autolens_workspace/start_here.py` `__JAX__` section. The
+`scripts/cluster/simulator.py` `__JAX JIT — Point Solver__` section
+shows the post-Phase-2 `PointSolver(use_jax=True)` +
+`autolens.jax.register_tracer_classes(tracer)` pattern in action.
 
 __Beta Feature__
 

--- a/scripts/group/fit.py
+++ b/scripts/group/fit.py
@@ -33,6 +33,13 @@ __Contents__
 - **Outputting Results:** You may wish to output certain results to .fits files for later inspection.
 - **Over Sampling:** Set up the adaptive over-sampling grid for accurate light profile evaluation.
 
+__JAX__
+
+Same JAX story as `scripts/imaging/fit.py`: `FitImaging` runs on either
+backend. For the standard analysis-driven path see `start_here.py` /
+`modeling.py`. For JIT-ing library methods directly see
+`scripts/guides/lens_calc.py`.
+
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/group/likelihood_function.py
+++ b/scripts/group/likelihood_function.py
@@ -473,4 +473,16 @@ The key differences from galaxy-scale lensing are:
  - Getting the mass of extra galaxies right is important because their deflection angles affect the
    source-plane coordinates and therefore the quality of the source reconstruction.
  - The `FitImaging` and `Tracer` objects handle all of this automatically for an arbitrary number of galaxies.
+
+__JAX__
+
+Same JAX recipe as `scripts/imaging/likelihood_function.py`: wrap the
+hand-rolled construction in `@jax.jit`, register tracer classes once via
+`autolens.jax.register_tracer_classes(tracer)`, validate via
+`Fitness._vmap`. The group dataset adds nothing JAX-specific beyond the
+imaging case — the extra galaxies are just more `Galaxy` instances and
+the registration walker handles them uniformly.
+
+See `scripts/imaging/likelihood_function.py` `__JAX__` for the full
+recipe.
 """

--- a/scripts/group/modeling.py
+++ b/scripts/group/modeling.py
@@ -565,11 +565,11 @@ function at ``autolens_workspace/*/imaging/log_likelihood_function`
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don't have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+`AnalysisImaging` defaults to `use_jax=True`. For group-scale fits the
+JAX speedup is substantial — the multi-galaxy deflection sum dominates
+runtime on CPU but vectorises cleanly on GPU. Search driver wraps the
+likelihood in `jax.vmap(jax.jit(...))`. Force NumPy with `use_jax=False`
+(or `PYAUTO_DISABLE_JAX=1`) when debugging.
 """
 analysis = al.AnalysisImaging(
     dataset=dataset,

--- a/scripts/group/simulator.py
+++ b/scripts/group/simulator.py
@@ -308,4 +308,14 @@ al.output_to_json(
 
 """
 Finished.
+
+__JAX Variant__
+
+Same pattern as `scripts/imaging/simulator.py` `__JAX Variant__`:
+instantiate `al.SimulatorImaging(use_jax=True)` and wrap
+`via_tracer_from` in `@jax.jit`. The simulator handles pytree
+registration internally. Eager JAX path works; `@jax.jit` is currently
+blocked by the pre-existing `Array2D.native` autoarray limitation.
+
+See `scripts/imaging/simulator.py` for the runnable variant block.
 """

--- a/scripts/group/start_here.py
+++ b/scripts/group/start_here.py
@@ -35,14 +35,16 @@ __Contents__
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoLens runs group-scale model-fits on JAX by default — `al.AnalysisImaging`
+auto-enables `use_jax=True` if you installed `autolens[jax]`. Group fits
+benefit substantially from GPU acceleration (the multi-galaxy deflection
+sum is the dominant cost). Expect 5-30 minutes on GPU vs hours on pure
+NumPy.
 
-If you don't have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-Finally, we also show how to simulate strong lens groups. This is useful for practice, for
-building training datasets, or for investigating lensing effects in a controlled way.
+For the broader JAX principles, see the top-level
+`autolens_workspace/start_here.py` `__JAX__` section. For per-dataset
+simulator / fit / likelihood patterns shared with imaging, see
+`scripts/imaging/start_here.py` and its companions.
 
 __Google Colab Setup__
 
@@ -250,11 +252,9 @@ the model to the imaging data.
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don't have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+`AnalysisImaging` defaults to `use_jax=True`. Search driver wraps the
+likelihood in `jax.vmap(jax.jit(...))`. Force NumPy with `use_jax=False`
+(or `PYAUTO_DISABLE_JAX=1`) when debugging.
 
 **Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce
 an error. If this occurs, see the `autolens_workspace/guides/modeling/bug_fix` example for a fix.

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -37,14 +37,17 @@ __Contents__
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoLens runs multi-wavelength model-fits on JAX by default. The
+per-band `al.AnalysisImaging(dataset=dataset, use_jax=True)` instances
+below auto-enable JAX, and the `af.FactorGraphModel(*analysis_factor_list,
+use_jax=True)` further down stitches them together with JAX-aware
+broadcasting. If you installed `autolens[jax]`, expect 1-10 minutes per
+band on GPU vs hours on pure NumPy.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate strong lens imaging. This is useful for building machine learning training datasets,
-or for investigating lensing effects in a controlled way.
+For the broader JAX principles, see the top-level
+`autolens_workspace/start_here.py` `__JAX__` section. Per-band
+`SimulatorImaging(use_jax=True)` usage is shown in
+`scripts/imaging/simulator.py` `__JAX Variant__`.
 
 __Google Colab Setup__
 
@@ -305,11 +308,12 @@ When there are multiple datasets, a list of analysis objects is created, once fo
 
 __JAX__
 
-PyAutoLens uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+`AnalysisImaging(use_jax=True)` runs per-band; `FactorGraphModel(use_jax=True)`
+below stitches them into the joint multi-band likelihood. The non-linear
+search driver wraps the joint likelihood in `jax.vmap(jax.jit(...))` —
+batches of parameter vectors evaluate in parallel across all bands on a
+single GPU call. Force NumPy with `use_jax=False` (or `PYAUTO_DISABLE_JAX=1`)
+on either constructor when debugging.
 """
 analysis_list = [
     al.AnalysisImaging(


### PR DESCRIPTION
## Summary

Phase 3c + 3e + 3f of `z_features/jax_user_intro.md` bundled in one PR. The deferred autolens dataset types (multi / group / cluster) get `__JAX__` refresh / additions, and **`cluster/simulator.py` is migrated** to the post-Phase-2 API — the ~60-line manual `af.Collection` mirror + `_register_model_pytrees` + `register_instance_pytree` ceremony collapses to a single `register_tracer_classes(tracer)` + `PointSolver(use_jax=True)` + `@jax.jit` pattern.

Closes out the autolens side of `jax_user_intro`. Issue #206.

## Scripts Changed

**3c — multi (refresh):**
- `scripts/multi/start_here.py` — refresh 2 stale `__JAX__` blocks per Phase 0 contract.

**3e — group (full add):**
- `scripts/group/start_here.py` — refresh 2 stale `__JAX__` blocks
- `scripts/group/simulator.py` — `__JAX Variant__` reference (delegates to `imaging/simulator.py`)
- `scripts/group/fit.py` — `__JAX__` prose
- `scripts/group/likelihood_function.py` — `__JAX__` reference to imaging recipe
- `scripts/group/modeling.py` — refresh stale `__JAX__` block

**3f — cluster (migration + add):**
- `scripts/cluster/simulator.py` — **MIGRATE**: collapse ~60-line manual ceremony to single `register_tracer_classes(tracer)` + `PointSolver(use_jax=True)` + `@jax.jit` pattern; drop stale imports
- `scripts/cluster/start_here.py` — refresh stale `__JAX__` block
- `scripts/cluster/likelihood_function.py` — `__JAX__` section with hand-rolled `@jax.jit` recipe using the new API
- `scripts/cluster/modeling.py` — refresh stale `__JAX__` block

## Test Plan
- [x] All 10 files compile cleanly via `py_compile`
- [x] `scripts/check_sizes.sh` clean
- [x] `cluster/simulator.py` runs end-to-end with `PYAUTO_TEST_MODE=1` — validates the migration works against the now-shipped Phase 2 API

## Notes

The cluster migration is the strongest in-the-wild validation of Phase 2's API design. What users had to write before Phase 2 (~60 lines of `af.Collection` mirror, `_register_model_pytrees`, `register_instance_pytree(Tracer, no_flatten=("cosmology",))`) collapses to:

```python
from autolens.jax import register_tracer_classes

register_tracer_classes(tracer)

solver = al.PointSolver.for_grid(..., use_jax=True)

@jax.jit
def jitted_solve(tracer, source_plane_coordinate):
    return solver.solve(tracer=tracer, source_plane_coordinate=source_plane_coordinate).array
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)