### PR TITLE
docs: remove Array2D.native jit-blocked caveats from JAX variant blocks

### DIFF
--- a/scripts/group/simulator.py
+++ b/scripts/group/simulator.py
@@ -314,8 +314,7 @@ __JAX Variant__
 Same pattern as `scripts/imaging/simulator.py` `__JAX Variant__`:
 instantiate `al.SimulatorImaging(use_jax=True)` and wrap
 `via_tracer_from` in `@jax.jit`. The simulator handles pytree
-registration internally. Eager JAX path works; `@jax.jit` is currently
-blocked by the pre-existing `Array2D.native` autoarray limitation.
+registration internally.
 
 See `scripts/imaging/simulator.py` for the runnable variant block.
 """

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -324,15 +324,9 @@ The `dataset_jax.data.array` is a `jax.Array`; `aplt.fits_imaging` and the
 plotters call `numpy.asarray()` internally, so saving / plotting works
 without manual conversion.
 
-Two notes:
-
-- Eager `simulator_jax.via_tracer_from(tracer, grid)` (no `@jax.jit`)
-  already runs on JAX and is sufficient for one-off simulations. The
-  `@jax.jit` wrap is only beneficial when you call the function many times.
-- `@jax.jit` wrap is currently blocked by a pre-existing `Array2D.native`
-  jit-incompatibility in autoarray's slim/native reshape. Eager JAX works
-  today; the `@jax.jit` shown above will work once a separate refactor
-  task lands.
+Note: eager `simulator_jax.via_tracer_from(tracer, grid)` (no `@jax.jit`)
+already runs on JAX and is sufficient for one-off simulations. The
+`@jax.jit` wrap is only beneficial when you call the function many times.
 
 See `scripts/guides/lens_calc.py` for the advanced "JIT-it-yourself"
 pattern that wraps individual library methods like `tracer.image_2d_from`

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -366,10 +366,7 @@ Two notes specific to interferometer:
   `autolens_workspace_test/scripts/interferometer/nufft.py` for the
   parity work.
 - Eager `simulator_jax.via_image_from(image)` already runs on JAX without
-  the `@jax.jit` wrap; the JIT only matters for repeated calls. The
-  `@jax.jit` wrap shown above is currently blocked by a pre-existing
-  `Array2D.native` autoarray limitation — eager use works today; the
-  JIT wrap works once a separate refactor lands.
+  the `@jax.jit` wrap; the JIT only matters for repeated calls.
 
 See `scripts/guides/lens_calc.py` for the "JIT-it-yourself" pattern
 applied to individual library methods.

--- a/scripts/point_source/fit.py
+++ b/scripts/point_source/fit.py
@@ -51,10 +51,8 @@ explicit `@jax.jit + PointSolver(use_jax=True)` pattern (useful for fast
 forward-solving in custom code), see `simulator.py`'s `__JAX Variant__`
 section.
 
-Note: `PointSolver(use_jax=True)` works inside `@jax.jit` (unlike the
-imaging / interferometer simulators, which are currently blocked by a
-pre-existing `Array2D.native` autoarray limitation). The triangle-
-refinement loop doesn't go through `.native`.
+Note: `PointSolver(use_jax=True)` works inside `@jax.jit`. The triangle-
+refinement loop operates on raw arrays and doesn't go through `.native`.
 
 """
 

--- a/scripts/point_source/simulator.py
+++ b/scripts/point_source/simulator.py
@@ -532,10 +532,9 @@ Two notes:
 - `register_tracer_classes(tracer)` is the one user-visible setup call.
   After the first invocation, every later `@jax.jit` with the same class
   set works without re-registering.
-- Unlike imaging / interferometer simulators, the `PointSolver.use_jax=True`
-  + `@jax.jit` wrap really does work inside jit (it doesn't go through the
-  pre-existing `Array2D.native` autoarray limitation that blocks the image
-  simulators).
+- Unlike imaging / interferometer simulators, `PointSolver.use_jax=True`
+  does not go through `Array2D.native` at all — the triangle-refinement
+  loop operates on raw arrays throughout.
 
 See `scripts/guides/lens_calc.py` for the broader "JIT-it-yourself"
 pattern applied to other library methods.


### PR DESCRIPTION
## Summary

The `array_2d_via_indexes_from` jit-safety fix (PyAutoArray#339) makes `Array2D.native` jit-traceable. Removed the "currently blocked by a pre-existing Array2D.native autoarray limitation" notes from all JAX variant blocks — the `@jax.jit` wrap now works.

## Scripts Changed
- `scripts/imaging/simulator.py` — removed jit-blocked caveat from JAX variant notes
- `scripts/interferometer/simulator.py` — removed jit-blocked caveat from JAX variant notes
- `scripts/group/simulator.py` — removed jit-blocked caveat from JAX variant notes
- `scripts/point_source/simulator.py` — updated note about PointSolver not using Array2D.native
- `scripts/point_source/fit.py` — simplified note about PointSolver jit compatibility

## Upstream PR
https://github.com/PyAutoLabs/PyAutoArray/pull/339

## Test Plan
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)