### PR TITLE
config: add quick_update_background + live_visual_update defaults

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -5,6 +5,8 @@
 updates:
   iterations_per_quick_update: 1e99 # Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.
   iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.
+  quick_update_background: false    # If True, perform_quick_update runs on a background daemon thread so the sampler is never blocked while visuals render. Requires the Analysis subclass to set `supports_background_update = True`.
+  live_visual_update: false         # If True, quick-update visuals are pushed to a live surface (a Jupyter cell when in a kernel, a matplotlib viewer subprocess otherwise) in addition to being written to disk.
 fits:
   flip_for_ds9: true
 psf:
@@ -22,6 +24,8 @@ hpc:
   hpc_mode: false                   # If True, use HPC mode, which disables GUI visualization, logging to screen and other settings which are not suited to running on a super computer.
   iterations_per_quick_update: 250000 #  Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.
   iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.
+  quick_update_background: false    # Keep off on HPC: background rendering pulls matplotlib into the sampler process even when no display is attached.
+  live_visual_update: false         # Keep off on HPC: nodes are headless with no GUI and no notebook kernel, so the live display surface has nothing to attach to.
 adapt:
   adapt_minimum_percent: 0.01
   adapt_noise_limit: 100000000.0


### PR DESCRIPTION
## Summary

Item 4 of `PyAutoPrompt/issued/on_the_fly_docs.md`. Mirrors the two library defaults from `PyAutoFit/autofit/config/general.yaml` into the workspace's `config/general.yaml`. Without this the workspace's `updates:` and `hpc:` sections silently shadow the library values, leaving `quick_update_background` and `live_visual_update` unresolvable when code tries to read them from the workspace context.

## Scripts Changed

- `config/general.yaml` — appends `quick_update_background: false` and `live_visual_update: false` under both `updates:` and `hpc:` with explanatory comments.

## Test Plan

- [ ] Smoke tests pass
- [ ] `python scripts/imaging/start_here.py` runs under `PYAUTO_TEST_MODE=1` with no config-key-missing errors

Refs https://github.com/PyAutoLabs/autofit_workspace/issues/66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)