### PR TITLE
docs(guides/results): thread test_mode segment through aggregator tutorial paths

### DIFF
--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -20,7 +20,9 @@ fast enough to fit inside the per-script CI timeout.
 import sys
 from pathlib import Path
 
-results_path = Path("output") / "results_folder"
+from autoconf.test_mode import with_test_mode_segment
+
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if results_path.exists():
     sys.exit(0)
 

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -37,6 +37,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 import os
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autolens as al
 import autolens.plot as aplt
@@ -48,7 +50,7 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -56,6 +56,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 
 import numpy as np
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autolens as al
 import autolens.plot as aplt
@@ -68,7 +70,7 @@ The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tu
 in this folder) have results to work with. When that folder already exists the helper exits immediately,
 so re-running this tutorial is cheap.
 """
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -24,6 +24,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 import os
 from pathlib import Path
 
+from autoconf.test_mode import with_test_mode_segment
+
 import autofit as af
 import autolens as al
 import autolens.plot as aplt
@@ -35,7 +37,7 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -24,6 +24,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autolens as al
 
@@ -35,7 +37,7 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -44,6 +44,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autolens as al
 import autolens.plot as aplt
@@ -56,7 +58,7 @@ The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tu
 in this folder) have results to work with. When that folder already exists the helper exits immediately,
 so re-running this tutorial is cheap.
 """
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -52,6 +52,8 @@ from autoconf import jax_wrapper  # Sets JAX environment before other imports
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autolens.plot as aplt
 
@@ -91,7 +93,7 @@ First, set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys


### PR DESCRIPTION
## Summary

Workspace side of PyAutoLabs/PyAutoConf#110. Threads the new `with_test_mode_segment` helper through `_quick_fit.py` and 6 aggregator tutorial scripts so the read side agrees with the write side under `PYAUTO_TEST_MODE`.

7 files changed, each replacing the hard-coded `results_path = Path("output") / "results_folder"` with `with_test_mode_segment(Path("output")) / "results_folder"`. No other logic touched.

End-users running without env vars see the same `output/results_folder/` path as before. Smoke runs (`PYAUTO_TEST_MODE` set) now correctly land at `output/test_mode/results_folder/`, matching the search write path.

## Test plan

- [x] PyAutoConf #110 unit tests cover the helper.
- [ ] Workspace CI "Match library branches" picks up the `feature/test-mode-output-path` branch on PyAutoConf for any cross-repo CI runs.
- [ ] Local `autobuild run_all autolens --timeout-secs 300` flips `guides/results/aggregator/{data_fitting, models}.py` from FAIL to PASS once PyAutoConf #110 merges.

## Related

- PyAutoLabs/PyAutoConf#110 — adds the `with_test_mode_segment` helper.
- PyAutoLabs/autogalaxy_workspace#TBD — mirror of this PR for the autogalaxy side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)