### PR TITLE
fix: ensure aggregator helper results include datasets

### DIFF
--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -17,14 +17,23 @@ than running to convergence. This produces a shallow but valid posterior
 fast enough to fit inside the per-script CI timeout.
 """
 
-import sys
 from pathlib import Path
+import shutil
+import sys
 
 from autoconf.test_mode import with_test_mode_segment
 
+
+def has_imaging_dataset(results_path):
+    return any(results_path.glob("**/image/dataset.fits"))
+
+
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if results_path.exists():
+if has_imaging_dataset(results_path):
     sys.exit(0)
+
+if results_path.exists():
+    shutil.rmtree(results_path)
 
 import os
 

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -51,7 +51,7 @@ First, set up the aggregator as shown in `start_here.py`.
 from autofit.aggregator.aggregator import Aggregator
 
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 
@@ -61,7 +61,7 @@ if not results_path.exists():
     )
 
 agg = Aggregator.from_directory(
-    directory=Path("output") / "results_folder",
+    directory=results_path,
 )
 
 """

--- a/scripts/guides/results/aggregator/galaxies_fits.py
+++ b/scripts/guides/results/aggregator/galaxies_fits.py
@@ -71,7 +71,7 @@ in this folder) have results to work with. When that folder already exists the h
 so re-running this tutorial is cheap.
 """
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -38,7 +38,7 @@ First, set up the aggregator as shown in `start_here.py`.
 from autofit.aggregator.aggregator import Aggregator
 
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 
@@ -48,7 +48,7 @@ if not results_path.exists():
     )
 
 agg = Aggregator.from_directory(
-    directory=Path("output") / "results_folder",
+    directory=results_path,
 )
 #
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -38,7 +38,7 @@ First, set up the aggregator as shown in `start_here.py`.
 from autofit.aggregator.aggregator import Aggregator
 
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 
@@ -48,7 +48,7 @@ if not results_path.exists():
     )
 
 agg = Aggregator.from_directory(
-    directory=Path("output") / "results_folder",
+    directory=results_path,
 )
 
 """

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -59,7 +59,7 @@ in this folder) have results to work with. When that folder already exists the h
 so re-running this tutorial is cheap.
 """
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -94,7 +94,7 @@ First, set up the aggregator as shown in `start_here.py`.
 from autofit.aggregator.aggregator import Aggregator
 
 results_path = with_test_mode_segment(Path("output")) / "results_folder"
-if not results_path.exists():
+if not any(results_path.glob("**/image/dataset.fits")):
     import subprocess
     import sys
 
@@ -104,7 +104,7 @@ if not results_path.exists():
     )
 
 agg = Aggregator.from_directory(
-    directory=Path("output") / "results_folder",
+    directory=results_path,
 )
 
 """


### PR DESCRIPTION
## Summary
Fixes the results aggregator release failures by making the shared quick-fit result reusable only when it contains the `image/dataset.fits` artifact required by `ImagingAgg`. Stale or incompatible `output/results_folder` contents are regenerated, and aggregator scripts now pass the test-mode-aware `results_path` into `Aggregator.from_directory`.

## Scripts Changed
- `scripts/guides/results/_quick_fit.py` — validates reusable helper output by checking for `**/image/dataset.fits`; removes incompatible helper output before regenerating.
- `scripts/guides/results/aggregator/data_fitting.py` — checks for a valid helper dataset and scrapes `results_path`.
- `scripts/guides/results/aggregator/models.py` — checks for a valid helper dataset and scrapes `results_path`.
- `scripts/guides/results/aggregator/queries.py` — uses the same valid-helper guard and `results_path` scrape directory.
- `scripts/guides/results/aggregator/samples_via_aggregator.py` — uses the same valid-helper guard and `results_path` scrape directory.
- `scripts/guides/results/aggregator/galaxies_fits.py` — uses the valid-helper guard before resuming the helper fit.
- `scripts/guides/results/aggregator/samples.py` — uses the valid-helper guard before resuming the helper fit.

## Test Plan
- [x] `scripts/guides/results/aggregator/data_fitting.py` passes with the PyAutoBuild repro environment.
- [x] `scripts/guides/results/aggregator/models.py` passes with the PyAutoBuild repro environment.
- [x] `python ../PyAutoBuild/autobuild/run_python.py autolens scripts/guides/results/aggregator --report-dir /tmp/pyautobuild-autolens-results-aggregator` passes all aggregator scripts.